### PR TITLE
Separate distribution for target web and node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ npm-error.log
 
 /build
 /dist
+/dist-*
 quickjs/test_fib.c
 quickjs/examples/test_fib

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ else
 	CFLAGS_EMCC+=--closure 1
 endif
 
+ifdef ENVIRONMENT
+	CFLAGS_EMCC+=-s ENVIRONMENT=$(ENVIRONMENT)
+endif
+
 wasm: $(BUILD_DIR) ts/quickjs-emscripten-module.js  ts/ffi.ts
 native: $(BUILD_WRAPPER)/native/test.exe
 all: wasm native

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "update-quickjs": "git subtree pull --prefix=quickjs --squash git@github.com:ldarren/QuickJS.git mod",
     "make-debug": "make DEBUG=1 -j 8",
     "make-release": "which emcc && make clean && make -j 8",
+    "build-web": "yarn make-release ENVIRONMENT=web && yarn build && cp -r dist/ dist-web",
+    "build-node": "yarn make-release ENVIRONMENT=node && yarn build && cp -r dist/ dist-node",
     "clean": "make clean",
     "build": "tsc",
     "doc": "typedoc --plugin typedoc-plugin-markdown ts",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "quickjs-emscripten",
   "version": "0.3.1",
   "main": "dist/quickjs.js",
+  "browser": "dist-web/quickjs.js",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I started on the idea to create separate targets for web and node, mentioned in feature idea #9.

From npm script, it passes the `ENVIRONMENT` option via make to `emcc`. I learned that its value can be one of `web, webview, worker, node, shell`. I wonder what `worker` does.

- For `web` target, the generated code does not contain any reference to `require`.
- For `node` target, the generated code does not contain any reference to `window`.

I'm not sure if creating separate directories for `dist-web` and `dist-node` is the best way, but both of them are different from the original `dist`, which has the logic to handle window and require in `quickjs-emscripten-module.js`.