### PR TITLE
Implements getQuickJSImmediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The root entrypoint of this library is the `getQuickJS` function, which returns
 a promise that resolves to a [QuickJS singleton](doc/classes/quickjs.md) when
 the Emscripten WASM module is ready.
 
+Once `getQuickJS` has been awaited at least once, you also can use the `getQuickJSImmediate`
+function to directly access the singleton engine in your synchronous code.
+
 ### Safely evaluate Javascript code
 
 See [QuickJS.evalCode](https://github.com/justjake/quickjs-emscripten/blob/master/doc/classes/quickjs.md#evalcode)

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -957,3 +957,16 @@ export async function getQuickJS(): Promise<QuickJS> {
   }
   return singleton
 }
+
+/**
+ * This is the top-level entrypoint for the quickjs-emscripten library.
+ * Get the root QuickJS API.
+ */
+export async function getQuickJSImmediate(): QuickJS {
+  if (!singleton) {
+    throw new Error(
+      'QuickJS not initialized. Either wait for `ready` or use getQuickJS()'
+    )
+  }
+  return singleton
+}

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -962,7 +962,7 @@ export async function getQuickJS(): Promise<QuickJS> {
  * This is the top-level entrypoint for the quickjs-emscripten library.
  * Get the root QuickJS API.
  */
-export async function getQuickJSImmediate(): QuickJS {
+export function getQuickJSImmediate(): QuickJS {
   if (!singleton) {
     throw new Error(
       'QuickJS not initialized. Either wait for `ready` or use getQuickJS()'

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -964,9 +964,7 @@ export async function getQuickJS(): Promise<QuickJS> {
  */
 export function getQuickJSImmediate(): QuickJS {
   if (!singleton) {
-    throw new Error(
-      'QuickJS not initialized. Either wait for `ready` or use getQuickJS()'
-    )
+    throw new Error('QuickJS not initialized. Either wait for `ready` or use getQuickJS()')
   }
   return singleton
 }


### PR DESCRIPTION
I'd like to use QuickJS without turning my whole application asynchronous. To this end, I plan to call `getQuickJS` during the initialization, and `getQuickJSImmediate` afterwards.