### PR TITLE
Improve interrupts & limits usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ import { getQuickJS, shouldInterruptAfterDeadline } from 'quickjs-emscripten'
 getQuickJS().then(QuickJS => {
   const result = QuickJS.evalCode('1 + 1', {
     shouldInterrupt: shouldInterruptAfterDeadline(Date.now() + 1000),
+    memoryLimitBytes: 1024 * 1024,
   })
   console.log(result)
 })
@@ -64,6 +65,9 @@ getQuickJS().then(QuickJS => {
 You can use [QuickJSVm](https://github.com/justjake/quickjs-emscripten/blob/master/doc/classes/quickjsvm.md)
 to build a scripting environment by modifying globals and exposing functions
 into the QuickJS interpreter.
+
+Each `QuickJSVm` instance has its own environment, CPU limit, and memory
+limit. See the documentation for details.
 
 ```typescript
 const vm = QuickJS.createVm()

--- a/doc/README.md
+++ b/doc/README.md
@@ -58,6 +58,7 @@ import { getQuickJS, shouldInterruptAfterDeadline } from 'quickjs-emscripten'
 getQuickJS().then(QuickJS => {
   const result = QuickJS.evalCode('1 + 1', {
     shouldInterrupt: shouldInterruptAfterDeadline(Date.now() + 1000),
+    memoryLimitBytes: 1024 * 1024,
   })
   console.log(result)
 })
@@ -68,6 +69,9 @@ getQuickJS().then(QuickJS => {
 You can use [QuickJSVm](https://github.com/justjake/quickjs-emscripten/blob/master/doc/classes/quickjsvm.md)
 to build a scripting environment by modifying globals and exposing functions
 into the QuickJS interpreter.
+
+Each `QuickJSVm` instance has its own environment, CPU limit, and memory
+limit. See the documentation for details.
 
 ```typescript
 const vm = QuickJS.createVm()

--- a/doc/classes/lifetime.md
+++ b/doc/classes/lifetime.md
@@ -55,7 +55,7 @@ Typically, quickjs-emscripten uses Lifetimes to protect C memory pointers.
 
 \+ **new Lifetime**(`_value`: T, `copier?`: undefined | function, `disposer?`: undefined | function, `_owner?`: Owner): *[Lifetime](lifetime.md)*
 
-*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
+*Defined in [quickjs.ts:71](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L71)*
 
 When the Lifetime is disposed, it will call `disposer(_value)`. Use the
 disposer function to implement whatever cleanup needs to happen at the end
@@ -81,7 +81,7 @@ Name | Type |
 
 • **_alive**: *boolean* = true
 
-*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
+*Defined in [quickjs.ts:71](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L71)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **_owner**? : *Owner*
 
-*Defined in [quickjs.ts:86](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L86)*
+*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **_value**: *T*
 
-*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
+*Defined in [quickjs.ts:82](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L82)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **copier**? : *undefined | function*
 
-*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
+*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **disposer**? : *undefined | function*
 
-*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
+*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
 
 ## Accessors
 
@@ -121,7 +121,7 @@ ___
 
 • **get alive**(): *boolean*
 
-*Defined in [quickjs.ts:89](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L89)*
+*Defined in [quickjs.ts:88](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L88)*
 
 **Returns:** *boolean*
 
@@ -131,7 +131,7 @@ ___
 
 • **get dupable**(): *boolean*
 
-*Defined in [quickjs.ts:108](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L108)*
+*Defined in [quickjs.ts:107](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L107)*
 
 **Returns:** *boolean*
 
@@ -141,7 +141,7 @@ ___
 
 • **get owner**(): *undefined | Owner*
 
-*Defined in [quickjs.ts:104](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L104)*
+*Defined in [quickjs.ts:103](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L103)*
 
 **Returns:** *undefined | Owner*
 
@@ -151,7 +151,7 @@ ___
 
 • **get value**(): *T*
 
-*Defined in [quickjs.ts:99](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L99)*
+*Defined in [quickjs.ts:98](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L98)*
 
 The value this Lifetime protects. You must never retain the value - it
 may become invalid, leading to memory errors.
@@ -166,7 +166,7 @@ may become invalid, leading to memory errors.
 
 ▸ **dispose**(): *void*
 
-*Defined in [quickjs.ts:131](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L131)*
+*Defined in [quickjs.ts:130](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L130)*
 
 Dispose of [value](lifetime.md#value) and perform cleanup.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **dup**(): *[Lifetime](lifetime.md)‹TCopy, TCopy, Owner›*
 
-*Defined in [quickjs.ts:115](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L115)*
+*Defined in [quickjs.ts:114](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L114)*
 
 Create a new handle pointing to the same [value](lifetime.md#value).
 

--- a/doc/classes/lifetime.md
+++ b/doc/classes/lifetime.md
@@ -55,7 +55,7 @@ Typically, quickjs-emscripten uses Lifetimes to protect C memory pointers.
 
 \+ **new Lifetime**(`_value`: T, `copier?`: undefined | function, `disposer?`: undefined | function, `_owner?`: Owner): *[Lifetime](lifetime.md)*
 
-*Defined in [quickjs.ts:70](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L70)*
+*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
 
 When the Lifetime is disposed, it will call `disposer(_value)`. Use the
 disposer function to implement whatever cleanup needs to happen at the end
@@ -81,7 +81,7 @@ Name | Type |
 
 • **_alive**: *boolean* = true
 
-*Defined in [quickjs.ts:70](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L70)*
+*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **_owner**? : *Owner*
 
-*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
+*Defined in [quickjs.ts:86](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L86)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **_value**: *T*
 
-*Defined in [quickjs.ts:81](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L81)*
+*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **copier**? : *undefined | function*
 
-*Defined in [quickjs.ts:82](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L82)*
+*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **disposer**? : *undefined | function*
 
-*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
+*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
 
 ## Accessors
 
@@ -121,7 +121,7 @@ ___
 
 • **get alive**(): *boolean*
 
-*Defined in [quickjs.ts:87](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L87)*
+*Defined in [quickjs.ts:89](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L89)*
 
 **Returns:** *boolean*
 
@@ -131,7 +131,7 @@ ___
 
 • **get dupable**(): *boolean*
 
-*Defined in [quickjs.ts:106](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L106)*
+*Defined in [quickjs.ts:108](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L108)*
 
 **Returns:** *boolean*
 
@@ -141,7 +141,7 @@ ___
 
 • **get owner**(): *undefined | Owner*
 
-*Defined in [quickjs.ts:102](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L102)*
+*Defined in [quickjs.ts:104](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L104)*
 
 **Returns:** *undefined | Owner*
 
@@ -151,7 +151,7 @@ ___
 
 • **get value**(): *T*
 
-*Defined in [quickjs.ts:97](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L97)*
+*Defined in [quickjs.ts:99](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L99)*
 
 The value this Lifetime protects. You must never retain the value - it
 may become invalid, leading to memory errors.
@@ -166,7 +166,7 @@ may become invalid, leading to memory errors.
 
 ▸ **dispose**(): *void*
 
-*Defined in [quickjs.ts:129](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L129)*
+*Defined in [quickjs.ts:131](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L131)*
 
 Dispose of [value](lifetime.md#value) and perform cleanup.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **dup**(): *[Lifetime](lifetime.md)‹TCopy, TCopy, Owner›*
 
-*Defined in [quickjs.ts:113](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L113)*
+*Defined in [quickjs.ts:115](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L115)*
 
 Create a new handle pointing to the same [value](lifetime.md#value).
 

--- a/doc/classes/quickjs.md
+++ b/doc/classes/quickjs.md
@@ -34,7 +34,7 @@ and return the result as a native Javascript value.
 
 \+ **new QuickJS**(): *[QuickJS](quickjs.md)*
 
-*Defined in [quickjs.ts:956](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L956)*
+*Defined in [quickjs.ts:955](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L955)*
 
 **Returns:** *[QuickJS](quickjs.md)*
 
@@ -44,7 +44,7 @@ and return the result as a native Javascript value.
 
 ▸ **createVm**(): *[QuickJSVm](quickjsvm.md)*
 
-*Defined in [quickjs.ts:1003](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1003)*
+*Defined in [quickjs.ts:1002](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1002)*
 
 Create a QuickJS VM.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **evalCode**(`code`: string, `options`: [QuickJSEvalOptions](../interfaces/quickjsevaloptions.md)): *unknown*
 
-*Defined in [quickjs.ts:1044](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1044)*
+*Defined in [quickjs.ts:1043](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1043)*
 
 One-off evaluate code without needing to create a VM.
 

--- a/doc/classes/quickjs.md
+++ b/doc/classes/quickjs.md
@@ -34,7 +34,7 @@ and return the result as a native Javascript value.
 
 \+ **new QuickJS**(): *[QuickJS](quickjs.md)*
 
-*Defined in [quickjs.ts:940](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L940)*
+*Defined in [quickjs.ts:956](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L956)*
 
 **Returns:** *[QuickJS](quickjs.md)*
 
@@ -44,7 +44,7 @@ and return the result as a native Javascript value.
 
 ▸ **createVm**(): *[QuickJSVm](quickjsvm.md)*
 
-*Defined in [quickjs.ts:987](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L987)*
+*Defined in [quickjs.ts:1003](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1003)*
 
 Create a QuickJS VM.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **evalCode**(`code`: string, `options`: [QuickJSEvalOptions](../interfaces/quickjsevaloptions.md)): *unknown*
 
-*Defined in [quickjs.ts:1028](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1028)*
+*Defined in [quickjs.ts:1044](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1044)*
 
 One-off evaluate code without needing to create a VM.
 

--- a/doc/classes/quickjsvm.md
+++ b/doc/classes/quickjsvm.md
@@ -84,7 +84,7 @@ tuning.
 
 \+ **new QuickJSVm**(`args`: object): *[QuickJSVm](quickjsvm.md)*
 
-*Defined in [quickjs.ts:239](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L239)*
+*Defined in [quickjs.ts:238](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L238)*
 
 Use [QuickJS.createVm](quickjs.md#createvm) to create a QuickJSVm instance.
 
@@ -102,7 +102,7 @@ Name | Type |
 
 • **get false**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:298](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L298)*
+*Defined in [quickjs.ts:297](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L297)*
 
 [`false`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/false).
 
@@ -114,7 +114,7 @@ ___
 
 • **get global**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:313](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L313)*
+*Defined in [quickjs.ts:312](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L312)*
 
 [`global`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects).
 A handle to the global object inside the interpreter.
@@ -128,7 +128,7 @@ ___
 
 • **get null**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:272](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L272)*
+*Defined in [quickjs.ts:271](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L271)*
 
 [`null`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null).
 
@@ -140,7 +140,7 @@ ___
 
 • **get true**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:285](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L285)*
+*Defined in [quickjs.ts:284](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L284)*
 
 [`true`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/true).
 
@@ -152,7 +152,7 @@ ___
 
 • **get undefined**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:259](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L259)*
+*Defined in [quickjs.ts:258](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L258)*
 
 [`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined).
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **callFunction**(`func`: [QuickJSHandle](../globals.md#quickjshandle), `thisVal`: [QuickJSHandle](../globals.md#quickjshandle), ...`args`: [QuickJSHandle](../globals.md#quickjshandle)[]): *[VmCallResult](../globals.md#vmcallresult)‹[QuickJSHandle](../globals.md#quickjshandle)›*
 
-*Defined in [quickjs.ts:518](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L518)*
+*Defined in [quickjs.ts:517](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L517)*
 
 [`func.call(thisVal, ...args)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call).
 Call a JSValue as a function.
@@ -190,7 +190,7 @@ ___
 
 ▸ **computeMemoryUsage**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:694](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L694)*
+*Defined in [quickjs.ts:693](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L693)*
 
 Compute memory usage for this runtime. Returns the result as a handle to a
 JSValue object. Use [dump](quickjsvm.md#dump) to convert to a native object.
@@ -206,7 +206,7 @@ ___
 
 ▸ **defineProp**(`handle`: [QuickJSHandle](../globals.md#quickjshandle), `key`: [QuickJSPropertyKey](../globals.md#quickjspropertykey), `descriptor`: [VmPropertyDescriptor](../interfaces/vmpropertydescriptor.md)‹[QuickJSHandle](../globals.md#quickjshandle)›): *void*
 
-*Defined in [quickjs.ts:469](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L469)*
+*Defined in [quickjs.ts:468](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L468)*
 
 [`Object.defineProperty(handle, key, descriptor)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **dispose**(): *void*
 
-*Defined in [quickjs.ts:725](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L725)*
+*Defined in [quickjs.ts:724](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L724)*
 
 Dispose of this VM's underlying resources.
 
@@ -241,7 +241,7 @@ ___
 
 ▸ **dump**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *any*
 
-*Defined in [quickjs.ts:615](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L615)*
+*Defined in [quickjs.ts:614](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L614)*
 
 Dump a JSValue to Javascript in a best-effort fashion.
 Returns `handle.toString()` if it cannot be serialized to JSON.
@@ -260,7 +260,7 @@ ___
 
 ▸ **dumpMemoryUsage**(): *string*
 
-*Defined in [quickjs.ts:704](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L704)*
+*Defined in [quickjs.ts:703](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L703)*
 
 **Returns:** *string*
 
@@ -275,7 +275,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:561](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L561)*
+*Defined in [quickjs.ts:560](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L560)*
 
 Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
 Evauatetes the Javascript source `code` in the global scope of this VM.
@@ -307,7 +307,7 @@ ___
 
 ▸ **executePendingJobs**(`maxJobsToExecute`: number): *[ExecutePendingJobsResult](../globals.md#executependingjobsresult)*
 
-*Defined in [quickjs.ts:585](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L585)*
+*Defined in [quickjs.ts:584](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L584)*
 
 Execute pendingJobs on the VM until `maxJobsToExecute` jobs are executed
 (default all pendingJobs), the queue is exhausted, or the runtime
@@ -333,7 +333,7 @@ ___
 
 ▸ **getNumber**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *number*
 
-*Defined in [quickjs.ts:354](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L354)*
+*Defined in [quickjs.ts:353](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L353)*
 
 Converts `handle` into a Javascript number.
 
@@ -353,7 +353,7 @@ ___
 
 ▸ **getProp**(`handle`: [QuickJSHandle](../globals.md#quickjshandle), `key`: [QuickJSPropertyKey](../globals.md#quickjspropertykey)): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:430](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L430)*
+*Defined in [quickjs.ts:429](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L429)*
 
 `handle[key]`.
 Get a property from a JSValue.
@@ -373,7 +373,7 @@ ___
 
 ▸ **getString**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *string*
 
-*Defined in [quickjs.ts:369](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L369)*
+*Defined in [quickjs.ts:368](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L368)*
 
 Converts `handle` to a Javascript string.
 
@@ -391,7 +391,7 @@ ___
 
 ▸ **hasPendingJob**(): *boolean*
 
-*Defined in [quickjs.ts:605](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L605)*
+*Defined in [quickjs.ts:604](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L604)*
 
 In QuickJS, promises and async functions create pendingJobs. These do not execute
 immediately and need to be run by calling [executePendingJobs](quickjsvm.md#executependingjobs).
@@ -406,7 +406,7 @@ ___
 
 ▸ **newArray**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:394](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L394)*
+*Defined in [quickjs.ts:393](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L393)*
 
 `[]`.
 Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
@@ -421,7 +421,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:407](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L407)*
+*Defined in [quickjs.ts:406](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L406)*
 
 Convert a Javascript function into a QuickJS function value.
 See [VmFunctionImplementation](../globals.md#vmfunctionimplementation) for more details.
@@ -447,7 +447,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:346](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L346)*
+*Defined in [quickjs.ts:345](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L345)*
 
 Converts a Javascript number into a QuckJS value.
 
@@ -467,7 +467,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:380](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L380)*
+*Defined in [quickjs.ts:379](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L379)*
 
 `{}`.
 Create a new QuickJS [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer).
@@ -488,7 +488,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:362](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L362)*
+*Defined in [quickjs.ts:361](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L361)*
 
 Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) value.
 
@@ -506,7 +506,7 @@ ___
 
 ▸ **removeInterruptHandler**(): *void*
 
-*Defined in [quickjs.ts:712](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L712)*
+*Defined in [quickjs.ts:711](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L711)*
 
 Remove the interrupt handler, if any.
 See [setInterruptHandler](quickjsvm.md#setinterrupthandler).
@@ -519,7 +519,7 @@ ___
 
 ▸ **setInterruptHandler**(`cb`: [InterruptHandler](../globals.md#interrupthandler)): *void*
 
-*Defined in [quickjs.ts:667](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L667)*
+*Defined in [quickjs.ts:666](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L666)*
 
 Set a callback which is regularly called by the QuickJS engine when it is
 executing code. This callback can be used to implement an execution
@@ -541,7 +541,7 @@ ___
 
 ▸ **setMemoryLimit**(`limitBytes`: number): *void*
 
-*Defined in [quickjs.ts:679](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L679)*
+*Defined in [quickjs.ts:678](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L678)*
 
 Set the max memory this runtime can allocate.
 To remove the limit, set to `-1`.
@@ -560,7 +560,7 @@ ___
 
 ▸ **setProp**(`handle`: [QuickJSHandle](../globals.md#quickjshandle), `key`: [QuickJSPropertyKey](../globals.md#quickjspropertykey), `value`: [QuickJSHandle](../globals.md#quickjshandle)): *void*
 
-*Defined in [quickjs.ts:454](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L454)*
+*Defined in [quickjs.ts:453](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L453)*
 
 `handle[key] = value`.
 Set a property on a JSValue.
@@ -585,7 +585,7 @@ ___
 
 ▸ **typeof**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *string*
 
-*Defined in [quickjs.ts:338](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L338)*
+*Defined in [quickjs.ts:337](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L337)*
 
 `typeof` operator. **Not** [standards compliant](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof).
 
@@ -606,7 +606,7 @@ ___
 
 ▸ **unwrapResult**<**T**>(`result`: [SuccessOrFail](../globals.md#successorfail)‹T, [QuickJSHandle](../globals.md#quickjshandle)›): *T*
 
-*Defined in [quickjs.ts:640](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L640)*
+*Defined in [quickjs.ts:639](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L639)*
 
 Unwrap a SuccessOrFail result such as a [VmCallResult](../globals.md#vmcallresult) or a
 [ExecutePendingJobsResult](../globals.md#executependingjobsresult), where the fail branch contains a handle to a QuickJS error value.

--- a/doc/classes/quickjsvm.md
+++ b/doc/classes/quickjsvm.md
@@ -13,13 +13,22 @@ untrusted code from different souces for isolation.
 
 Use [QuickJS.createVm](quickjs.md#createvm) to create a new QuickJSVm.
 
-Create QuickJS values with methods like [newNumber](quickjsvm.md#newnumber), [newString](quickjsvm.md#newstring), [newArray](quickjsvm.md#newarray), [newObject](quickjsvm.md#newobject), and [newFunction](quickjsvm.md#newfunction).
+Create QuickJS values inside the interpreter with methods like
+[newNumber](quickjsvm.md#newnumber), [newString](quickjsvm.md#newstring), [newArray](quickjsvm.md#newarray), [newObject](quickjsvm.md#newobject), and
+[newFunction](quickjsvm.md#newfunction).
 
-Call [setProp](quickjsvm.md#setprop) or [defineProp](quickjsvm.md#defineprop) to customize objects. Use those methods with [global](quickjsvm.md#global) to expose the
-values you create to the interior of the interpreter, so they can be used in [evalCode](quickjsvm.md#evalcode).
+Call [setProp](quickjsvm.md#setprop) or [defineProp](quickjsvm.md#defineprop) to customize objects. Use those methods
+with [global](quickjsvm.md#global) to expose the values you create to the interior of the
+interpreter, so they can be used in [evalCode](quickjsvm.md#evalcode).
 
-Use [evalCode](quickjsvm.md#evalcode) or [callFunction](quickjsvm.md#callfunction) to execute Javascript inside the VM.
-If you're using asynchronous code inside the QuickJSVm, you may need to also call [executePendingJobs](quickjsvm.md#executependingjobs).
+Use [evalCode](quickjsvm.md#evalcode) or [callFunction](quickjsvm.md#callfunction) to execute Javascript inside the VM. If
+you're using asynchronous code inside the QuickJSVm, you may need to also
+call [executePendingJobs](quickjsvm.md#executependingjobs).
+
+Implement memory and CPU constraints with [setInterruptHandler](quickjsvm.md#setinterrupthandler)
+(called regularly while the interpreter runs) and [setMemoryLimit](quickjsvm.md#setmemorylimit).
+Use [computeMemoryUsage](quickjsvm.md#computememoryusage) or [dumpMemoryUsage](quickjsvm.md#dumpmemoryusage) to guide memory limit
+tuning.
 
 ## Hierarchy
 
@@ -62,10 +71,10 @@ If you're using asynchronous code inside the QuickJSVm, you may need to also cal
 * [newNumber](quickjsvm.md#newnumber)
 * [newObject](quickjsvm.md#newobject)
 * [newString](quickjsvm.md#newstring)
-* [removeShouldInterruptHandler](quickjsvm.md#removeshouldinterrupthandler)
+* [removeInterruptHandler](quickjsvm.md#removeinterrupthandler)
+* [setInterruptHandler](quickjsvm.md#setinterrupthandler)
 * [setMemoryLimit](quickjsvm.md#setmemorylimit)
 * [setProp](quickjsvm.md#setprop)
-* [setShouldInterruptHandler](quickjsvm.md#setshouldinterrupthandler)
 * [typeof](quickjsvm.md#typeof)
 * [unwrapResult](quickjsvm.md#unwrapresult)
 
@@ -75,7 +84,7 @@ If you're using asynchronous code inside the QuickJSVm, you may need to also cal
 
 \+ **new QuickJSVm**(`args`: object): *[QuickJSVm](quickjsvm.md)*
 
-*Defined in [quickjs.ts:228](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L228)*
+*Defined in [quickjs.ts:239](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L239)*
 
 Use [QuickJS.createVm](quickjs.md#createvm) to create a QuickJSVm instance.
 
@@ -93,7 +102,7 @@ Name | Type |
 
 • **get false**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:287](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L287)*
+*Defined in [quickjs.ts:298](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L298)*
 
 [`false`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/false).
 
@@ -105,7 +114,7 @@ ___
 
 • **get global**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:302](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L302)*
+*Defined in [quickjs.ts:313](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L313)*
 
 [`global`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects).
 A handle to the global object inside the interpreter.
@@ -119,7 +128,7 @@ ___
 
 • **get null**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:261](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L261)*
+*Defined in [quickjs.ts:272](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L272)*
 
 [`null`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null).
 
@@ -131,7 +140,7 @@ ___
 
 • **get true**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:274](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L274)*
+*Defined in [quickjs.ts:285](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L285)*
 
 [`true`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/true).
 
@@ -143,7 +152,7 @@ ___
 
 • **get undefined**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:248](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L248)*
+*Defined in [quickjs.ts:259](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L259)*
 
 [`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined).
 
@@ -155,7 +164,7 @@ ___
 
 ▸ **callFunction**(`func`: [QuickJSHandle](../globals.md#quickjshandle), `thisVal`: [QuickJSHandle](../globals.md#quickjshandle), ...`args`: [QuickJSHandle](../globals.md#quickjshandle)[]): *[VmCallResult](../globals.md#vmcallresult)‹[QuickJSHandle](../globals.md#quickjshandle)›*
 
-*Defined in [quickjs.ts:507](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L507)*
+*Defined in [quickjs.ts:518](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L518)*
 
 [`func.call(thisVal, ...args)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call).
 Call a JSValue as a function.
@@ -181,7 +190,7 @@ ___
 
 ▸ **computeMemoryUsage**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:683](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L683)*
+*Defined in [quickjs.ts:694](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L694)*
 
 Compute memory usage for this runtime. Returns the result as a handle to a
 JSValue object. Use [dump](quickjsvm.md#dump) to convert to a native object.
@@ -197,7 +206,7 @@ ___
 
 ▸ **defineProp**(`handle`: [QuickJSHandle](../globals.md#quickjshandle), `key`: [QuickJSPropertyKey](../globals.md#quickjspropertykey), `descriptor`: [VmPropertyDescriptor](../interfaces/vmpropertydescriptor.md)‹[QuickJSHandle](../globals.md#quickjshandle)›): *void*
 
-*Defined in [quickjs.ts:458](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L458)*
+*Defined in [quickjs.ts:469](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L469)*
 
 [`Object.defineProperty(handle, key, descriptor)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
 
@@ -217,7 +226,7 @@ ___
 
 ▸ **dispose**(): *void*
 
-*Defined in [quickjs.ts:714](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L714)*
+*Defined in [quickjs.ts:725](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L725)*
 
 Dispose of this VM's underlying resources.
 
@@ -232,7 +241,7 @@ ___
 
 ▸ **dump**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *any*
 
-*Defined in [quickjs.ts:604](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L604)*
+*Defined in [quickjs.ts:615](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L615)*
 
 Dump a JSValue to Javascript in a best-effort fashion.
 Returns `handle.toString()` if it cannot be serialized to JSON.
@@ -251,7 +260,7 @@ ___
 
 ▸ **dumpMemoryUsage**(): *string*
 
-*Defined in [quickjs.ts:693](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L693)*
+*Defined in [quickjs.ts:704](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L704)*
 
 **Returns:** *string*
 
@@ -266,7 +275,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:550](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L550)*
+*Defined in [quickjs.ts:561](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L561)*
 
 Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
 Evauatetes the Javascript source `code` in the global scope of this VM.
@@ -277,7 +286,7 @@ See [unwrapResult](quickjsvm.md#unwrapresult), which will throw if the function 
 return the result handle directly.
 
 *Note*: to protect against infinite loops, provide an interrupt handler to
-[setShouldInterruptHandler](quickjsvm.md#setshouldinterrupthandler). You can use [shouldInterruptAfterDeadline](../globals.md#shouldinterruptafterdeadline) to
+[setInterruptHandler](quickjsvm.md#setinterrupthandler). You can use [shouldInterruptAfterDeadline](../globals.md#shouldinterruptafterdeadline) to
 create a time-based deadline.
 
 **Parameters:**
@@ -298,7 +307,7 @@ ___
 
 ▸ **executePendingJobs**(`maxJobsToExecute`: number): *[ExecutePendingJobsResult](../globals.md#executependingjobsresult)*
 
-*Defined in [quickjs.ts:574](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L574)*
+*Defined in [quickjs.ts:585](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L585)*
 
 Execute pendingJobs on the VM until `maxJobsToExecute` jobs are executed
 (default all pendingJobs), the queue is exhausted, or the runtime
@@ -324,7 +333,7 @@ ___
 
 ▸ **getNumber**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *number*
 
-*Defined in [quickjs.ts:343](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L343)*
+*Defined in [quickjs.ts:354](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L354)*
 
 Converts `handle` into a Javascript number.
 
@@ -344,7 +353,7 @@ ___
 
 ▸ **getProp**(`handle`: [QuickJSHandle](../globals.md#quickjshandle), `key`: [QuickJSPropertyKey](../globals.md#quickjspropertykey)): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:419](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L419)*
+*Defined in [quickjs.ts:430](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L430)*
 
 `handle[key]`.
 Get a property from a JSValue.
@@ -364,7 +373,7 @@ ___
 
 ▸ **getString**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *string*
 
-*Defined in [quickjs.ts:358](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L358)*
+*Defined in [quickjs.ts:369](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L369)*
 
 Converts `handle` to a Javascript string.
 
@@ -382,7 +391,7 @@ ___
 
 ▸ **hasPendingJob**(): *boolean*
 
-*Defined in [quickjs.ts:594](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L594)*
+*Defined in [quickjs.ts:605](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L605)*
 
 In QuickJS, promises and async functions create pendingJobs. These do not execute
 immediately and need to be run by calling [executePendingJobs](quickjsvm.md#executependingjobs).
@@ -397,7 +406,7 @@ ___
 
 ▸ **newArray**(): *[QuickJSHandle](../globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:383](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L383)*
+*Defined in [quickjs.ts:394](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L394)*
 
 `[]`.
 Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
@@ -412,7 +421,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:396](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L396)*
+*Defined in [quickjs.ts:407](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L407)*
 
 Convert a Javascript function into a QuickJS function value.
 See [VmFunctionImplementation](../globals.md#vmfunctionimplementation) for more details.
@@ -438,7 +447,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:335](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L335)*
+*Defined in [quickjs.ts:346](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L346)*
 
 Converts a Javascript number into a QuckJS value.
 
@@ -458,7 +467,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:369](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L369)*
+*Defined in [quickjs.ts:380](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L380)*
 
 `{}`.
 Create a new QuickJS [object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer).
@@ -479,7 +488,7 @@ ___
 
 *Implementation of [LowLevelJavascriptVm](../interfaces/lowleveljavascriptvm.md)*
 
-*Defined in [quickjs.ts:351](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L351)*
+*Defined in [quickjs.ts:362](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L362)*
 
 Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) value.
 
@@ -493,14 +502,36 @@ Name | Type |
 
 ___
 
-###  removeShouldInterruptHandler
+###  removeInterruptHandler
 
-▸ **removeShouldInterruptHandler**(): *void*
+▸ **removeInterruptHandler**(): *void*
 
-*Defined in [quickjs.ts:701](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L701)*
+*Defined in [quickjs.ts:712](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L712)*
 
 Remove the interrupt handler, if any.
-See [setShouldInterruptHandler](quickjsvm.md#setshouldinterrupthandler).
+See [setInterruptHandler](quickjsvm.md#setinterrupthandler).
+
+**Returns:** *void*
+
+___
+
+###  setInterruptHandler
+
+▸ **setInterruptHandler**(`cb`: [InterruptHandler](../globals.md#interrupthandler)): *void*
+
+*Defined in [quickjs.ts:667](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L667)*
+
+Set a callback which is regularly called by the QuickJS engine when it is
+executing code. This callback can be used to implement an execution
+timeout.
+
+The interrupt handler can be removed with [removeInterruptHandler](quickjsvm.md#removeinterrupthandler).
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cb` | [InterruptHandler](../globals.md#interrupthandler) |
 
 **Returns:** *void*
 
@@ -510,7 +541,7 @@ ___
 
 ▸ **setMemoryLimit**(`limitBytes`: number): *void*
 
-*Defined in [quickjs.ts:668](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L668)*
+*Defined in [quickjs.ts:679](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L679)*
 
 Set the max memory this runtime can allocate.
 To remove the limit, set to `-1`.
@@ -529,7 +560,7 @@ ___
 
 ▸ **setProp**(`handle`: [QuickJSHandle](../globals.md#quickjshandle), `key`: [QuickJSPropertyKey](../globals.md#quickjspropertykey), `value`: [QuickJSHandle](../globals.md#quickjshandle)): *void*
 
-*Defined in [quickjs.ts:443](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L443)*
+*Defined in [quickjs.ts:454](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L454)*
 
 `handle[key] = value`.
 Set a property on a JSValue.
@@ -550,33 +581,11 @@ Name | Type | Description |
 
 ___
 
-###  setShouldInterruptHandler
-
-▸ **setShouldInterruptHandler**(`cb`: [ShouldInterruptHandler](../globals.md#shouldinterrupthandler)): *void*
-
-*Defined in [quickjs.ts:656](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L656)*
-
-Set a callback which is regularly called by the QuickJS engine when it is
-executing code. This callback can be used to implement an execution
-timeout.
-
-The interrupt handler can be removed with [removeShouldInterruptHandler](quickjsvm.md#removeshouldinterrupthandler).
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`cb` | [ShouldInterruptHandler](../globals.md#shouldinterrupthandler) |
-
-**Returns:** *void*
-
-___
-
 ###  typeof
 
 ▸ **typeof**(`handle`: [QuickJSHandle](../globals.md#quickjshandle)): *string*
 
-*Defined in [quickjs.ts:327](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L327)*
+*Defined in [quickjs.ts:338](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L338)*
 
 `typeof` operator. **Not** [standards compliant](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof).
 
@@ -597,7 +606,7 @@ ___
 
 ▸ **unwrapResult**<**T**>(`result`: [SuccessOrFail](../globals.md#successorfail)‹T, [QuickJSHandle](../globals.md#quickjshandle)›): *T*
 
-*Defined in [quickjs.ts:629](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L629)*
+*Defined in [quickjs.ts:640](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L640)*
 
 Unwrap a SuccessOrFail result such as a [VmCallResult](../globals.md#vmcallresult) or a
 [ExecutePendingJobsResult](../globals.md#executependingjobsresult), where the fail branch contains a handle to a QuickJS error value.

--- a/doc/classes/staticlifetime.md
+++ b/doc/classes/staticlifetime.md
@@ -50,7 +50,7 @@ A Lifetime that lives forever. Used for constants.
 
 *Overrides [Lifetime](lifetime.md).[constructor](lifetime.md#constructor)*
 
-*Defined in [quickjs.ts:149](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L149)*
+*Defined in [quickjs.ts:148](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L148)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ Name | Type |
 
 *Inherited from [Lifetime](lifetime.md).[_alive](lifetime.md#protected-_alive)*
 
-*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
+*Defined in [quickjs.ts:71](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L71)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_owner](lifetime.md#protected-optional-_owner)*
 
-*Defined in [quickjs.ts:86](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L86)*
+*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_value](lifetime.md#protected-_value)*
 
-*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
+*Defined in [quickjs.ts:82](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L82)*
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[copier](lifetime.md#protected-optional-copier)*
 
-*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
+*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[disposer](lifetime.md#protected-optional-disposer)*
 
-*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
+*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
 
 ## Accessors
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[alive](lifetime.md#alive)*
 
-*Defined in [quickjs.ts:89](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L89)*
+*Defined in [quickjs.ts:88](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L88)*
 
 **Returns:** *boolean*
 
@@ -131,7 +131,7 @@ ___
 
 *Overrides [Lifetime](lifetime.md).[dupable](lifetime.md#dupable)*
 
-*Defined in [quickjs.ts:155](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L155)*
+*Defined in [quickjs.ts:154](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L154)*
 
 **Returns:** *boolean*
 
@@ -143,7 +143,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[owner](lifetime.md#owner)*
 
-*Defined in [quickjs.ts:104](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L104)*
+*Defined in [quickjs.ts:103](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L103)*
 
 **Returns:** *undefined | Owner*
 
@@ -155,7 +155,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[value](lifetime.md#value)*
 
-*Defined in [quickjs.ts:99](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L99)*
+*Defined in [quickjs.ts:98](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L98)*
 
 The value this Lifetime protects. You must never retain the value - it
 may become invalid, leading to memory errors.
@@ -172,7 +172,7 @@ may become invalid, leading to memory errors.
 
 *Overrides [Lifetime](lifetime.md).[dispose](lifetime.md#dispose)*
 
-*Defined in [quickjs.ts:165](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L165)*
+*Defined in [quickjs.ts:164](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L164)*
 
 **Returns:** *void*
 
@@ -184,6 +184,6 @@ ___
 
 *Overrides [Lifetime](lifetime.md).[dup](lifetime.md#dup)*
 
-*Defined in [quickjs.ts:160](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L160)*
+*Defined in [quickjs.ts:159](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L159)*
 
 **Returns:** *this*

--- a/doc/classes/staticlifetime.md
+++ b/doc/classes/staticlifetime.md
@@ -50,7 +50,7 @@ A Lifetime that lives forever. Used for constants.
 
 *Overrides [Lifetime](lifetime.md).[constructor](lifetime.md#constructor)*
 
-*Defined in [quickjs.ts:147](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L147)*
+*Defined in [quickjs.ts:149](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L149)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ Name | Type |
 
 *Inherited from [Lifetime](lifetime.md).[_alive](lifetime.md#protected-_alive)*
 
-*Defined in [quickjs.ts:70](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L70)*
+*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_owner](lifetime.md#protected-optional-_owner)*
 
-*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
+*Defined in [quickjs.ts:86](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L86)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_value](lifetime.md#protected-_value)*
 
-*Defined in [quickjs.ts:81](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L81)*
+*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[copier](lifetime.md#protected-optional-copier)*
 
-*Defined in [quickjs.ts:82](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L82)*
+*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[disposer](lifetime.md#protected-optional-disposer)*
 
-*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
+*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
 
 ## Accessors
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[alive](lifetime.md#alive)*
 
-*Defined in [quickjs.ts:87](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L87)*
+*Defined in [quickjs.ts:89](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L89)*
 
 **Returns:** *boolean*
 
@@ -131,7 +131,7 @@ ___
 
 *Overrides [Lifetime](lifetime.md).[dupable](lifetime.md#dupable)*
 
-*Defined in [quickjs.ts:153](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L153)*
+*Defined in [quickjs.ts:155](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L155)*
 
 **Returns:** *boolean*
 
@@ -143,7 +143,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[owner](lifetime.md#owner)*
 
-*Defined in [quickjs.ts:102](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L102)*
+*Defined in [quickjs.ts:104](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L104)*
 
 **Returns:** *undefined | Owner*
 
@@ -155,7 +155,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[value](lifetime.md#value)*
 
-*Defined in [quickjs.ts:97](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L97)*
+*Defined in [quickjs.ts:99](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L99)*
 
 The value this Lifetime protects. You must never retain the value - it
 may become invalid, leading to memory errors.
@@ -172,7 +172,7 @@ may become invalid, leading to memory errors.
 
 *Overrides [Lifetime](lifetime.md).[dispose](lifetime.md#dispose)*
 
-*Defined in [quickjs.ts:163](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L163)*
+*Defined in [quickjs.ts:165](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L165)*
 
 **Returns:** *void*
 
@@ -184,6 +184,6 @@ ___
 
 *Overrides [Lifetime](lifetime.md).[dup](lifetime.md#dup)*
 
-*Defined in [quickjs.ts:158](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L158)*
+*Defined in [quickjs.ts:160](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L160)*
 
 **Returns:** *this*

--- a/doc/classes/weaklifetime.md
+++ b/doc/classes/weaklifetime.md
@@ -56,7 +56,7 @@ Used for function arguments.
 
 *Overrides [Lifetime](lifetime.md).[constructor](lifetime.md#constructor)*
 
-*Defined in [quickjs.ts:175](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L175)*
+*Defined in [quickjs.ts:174](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L174)*
 
 **Parameters:**
 
@@ -77,7 +77,7 @@ Name | Type |
 
 *Inherited from [Lifetime](lifetime.md).[_alive](lifetime.md#protected-_alive)*
 
-*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
+*Defined in [quickjs.ts:71](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L71)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_owner](lifetime.md#protected-optional-_owner)*
 
-*Defined in [quickjs.ts:86](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L86)*
+*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_value](lifetime.md#protected-_value)*
 
-*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
+*Defined in [quickjs.ts:82](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L82)*
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[copier](lifetime.md#protected-optional-copier)*
 
-*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
+*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[disposer](lifetime.md#protected-optional-disposer)*
 
-*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
+*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
 
 ## Accessors
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[alive](lifetime.md#alive)*
 
-*Defined in [quickjs.ts:89](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L89)*
+*Defined in [quickjs.ts:88](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L88)*
 
 **Returns:** *boolean*
 
@@ -139,7 +139,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[dupable](lifetime.md#dupable)*
 
-*Defined in [quickjs.ts:108](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L108)*
+*Defined in [quickjs.ts:107](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L107)*
 
 **Returns:** *boolean*
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[owner](lifetime.md#owner)*
 
-*Defined in [quickjs.ts:104](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L104)*
+*Defined in [quickjs.ts:103](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L103)*
 
 **Returns:** *undefined | Owner*
 
@@ -163,7 +163,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[value](lifetime.md#value)*
 
-*Defined in [quickjs.ts:99](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L99)*
+*Defined in [quickjs.ts:98](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L98)*
 
 The value this Lifetime protects. You must never retain the value - it
 may become invalid, leading to memory errors.
@@ -180,7 +180,7 @@ may become invalid, leading to memory errors.
 
 *Overrides [Lifetime](lifetime.md).[dispose](lifetime.md#dispose)*
 
-*Defined in [quickjs.ts:186](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L186)*
+*Defined in [quickjs.ts:185](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L185)*
 
 **Returns:** *void*
 
@@ -192,7 +192,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[dup](lifetime.md#dup)*
 
-*Defined in [quickjs.ts:115](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L115)*
+*Defined in [quickjs.ts:114](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L114)*
 
 Create a new handle pointing to the same [value](weaklifetime.md#value).
 

--- a/doc/classes/weaklifetime.md
+++ b/doc/classes/weaklifetime.md
@@ -56,7 +56,7 @@ Used for function arguments.
 
 *Overrides [Lifetime](lifetime.md).[constructor](lifetime.md#constructor)*
 
-*Defined in [quickjs.ts:173](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L173)*
+*Defined in [quickjs.ts:175](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L175)*
 
 **Parameters:**
 
@@ -77,7 +77,7 @@ Name | Type |
 
 *Inherited from [Lifetime](lifetime.md).[_alive](lifetime.md#protected-_alive)*
 
-*Defined in [quickjs.ts:70](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L70)*
+*Defined in [quickjs.ts:72](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L72)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_owner](lifetime.md#protected-optional-_owner)*
 
-*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
+*Defined in [quickjs.ts:86](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L86)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[_value](lifetime.md#protected-_value)*
 
-*Defined in [quickjs.ts:81](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L81)*
+*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[copier](lifetime.md#protected-optional-copier)*
 
-*Defined in [quickjs.ts:82](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L82)*
+*Defined in [quickjs.ts:84](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L84)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[disposer](lifetime.md#protected-optional-disposer)*
 
-*Defined in [quickjs.ts:83](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L83)*
+*Defined in [quickjs.ts:85](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L85)*
 
 ## Accessors
 
@@ -127,7 +127,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[alive](lifetime.md#alive)*
 
-*Defined in [quickjs.ts:87](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L87)*
+*Defined in [quickjs.ts:89](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L89)*
 
 **Returns:** *boolean*
 
@@ -139,7 +139,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[dupable](lifetime.md#dupable)*
 
-*Defined in [quickjs.ts:106](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L106)*
+*Defined in [quickjs.ts:108](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L108)*
 
 **Returns:** *boolean*
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[owner](lifetime.md#owner)*
 
-*Defined in [quickjs.ts:102](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L102)*
+*Defined in [quickjs.ts:104](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L104)*
 
 **Returns:** *undefined | Owner*
 
@@ -163,7 +163,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[value](lifetime.md#value)*
 
-*Defined in [quickjs.ts:97](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L97)*
+*Defined in [quickjs.ts:99](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L99)*
 
 The value this Lifetime protects. You must never retain the value - it
 may become invalid, leading to memory errors.
@@ -180,7 +180,7 @@ may become invalid, leading to memory errors.
 
 *Overrides [Lifetime](lifetime.md).[dispose](lifetime.md#dispose)*
 
-*Defined in [quickjs.ts:184](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L184)*
+*Defined in [quickjs.ts:186](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L186)*
 
 **Returns:** *void*
 
@@ -192,7 +192,7 @@ ___
 
 *Inherited from [Lifetime](lifetime.md).[dup](lifetime.md#dup)*
 
-*Defined in [quickjs.ts:113](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L113)*
+*Defined in [quickjs.ts:115](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L115)*
 
 Create a new handle pointing to the same [value](weaklifetime.md#value).
 

--- a/doc/globals.md
+++ b/doc/globals.md
@@ -23,6 +23,7 @@
 ### Type aliases
 
 * [ExecutePendingJobsResult](globals.md#executependingjobsresult)
+* [InterruptHandler](globals.md#interrupthandler)
 * [JSCFunctionPointer](globals.md#jscfunctionpointer)
 * [JSContextPointer](globals.md#jscontextpointer)
 * [JSRuntimePointer](globals.md#jsruntimepointer)
@@ -36,7 +37,6 @@
 * [QTS_C_To_HostInterruptFuncPointer](globals.md#qts_c_to_hostinterruptfuncpointer)
 * [QuickJSHandle](globals.md#quickjshandle)
 * [QuickJSPropertyKey](globals.md#quickjspropertykey)
-* [ShouldInterruptHandler](globals.md#shouldinterrupthandler)
 * [StaticJSValue](globals.md#staticjsvalue)
 * [SuccessOrFail](globals.md#successorfail)
 * [VmCallResult](globals.md#vmcallresult)
@@ -54,12 +54,39 @@
 
 Ƭ **ExecutePendingJobsResult**: *[SuccessOrFail](globals.md#successorfail)‹number, [QuickJSHandle](globals.md#quickjshandle)›*
 
-*Defined in [quickjs.ts:195](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L195)*
+*Defined in [quickjs.ts:197](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L197)*
 
 Used as an optional for the results of executing pendingJobs.
 On success, `value` contains the number of async jobs executed
 by the runtime.
 `{ value: number } | { error: QuickJSHandle }`.
+
+___
+
+###  InterruptHandler
+
+Ƭ **InterruptHandler**: *function*
+
+*Defined in [quickjs.ts:61](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L61)*
+
+Callback called regularly while the VM executes code.
+Determines if a VM's execution should be interrupted.
+
+**`param`** The VM instance
+
+**`returns`** `true` to interrupt JS execution inside the VM.
+
+**`returns`** `false` or `undefined` to continue JS execution inside the VM.
+
+#### Type declaration:
+
+▸ (`vm`: [QuickJSVm](classes/quickjsvm.md)): *boolean | undefined*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`vm` | [QuickJSVm](classes/quickjsvm.md) |
 
 ___
 
@@ -97,7 +124,7 @@ ___
 
 Ƭ **JSValue**: *[Lifetime](classes/lifetime.md)‹[JSValuePointer](globals.md#jsvaluepointer), [JSValuePointer](globals.md#jsvaluepointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:902](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L902)*
+*Defined in [quickjs.ts:913](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L913)*
 
 A owned QuickJSHandle that should be disposed or returned.
 
@@ -119,7 +146,7 @@ ___
 
 Ƭ **JSValueConst**: *[Lifetime](classes/lifetime.md)‹[JSValueConstPointer](globals.md#jsvalueconstpointer), [JSValuePointer](globals.md#jsvaluepointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:885](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L885)*
+*Defined in [quickjs.ts:896](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L896)*
 
 A QuickJSHandle to a borrowed value that does not need to be disposed.
 
@@ -201,7 +228,7 @@ ___
 
 Ƭ **QuickJSHandle**: *[StaticJSValue](globals.md#staticjsvalue) | [JSValue](globals.md#jsvalue) | [JSValueConst](globals.md#jsvalueconst)*
 
-*Defined in [quickjs.ts:911](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L911)*
+*Defined in [quickjs.ts:922](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L922)*
 
 Wraps a C pointer to a QuickJS JSValue, which represents a Javascript value inside
 a QuickJS virtual machine.
@@ -215,30 +242,7 @@ ___
 
 Ƭ **QuickJSPropertyKey**: *number | string | [QuickJSHandle](globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:61](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L61)*
-
-___
-
-###  ShouldInterruptHandler
-
-Ƭ **ShouldInterruptHandler**: *function*
-
-*Defined in [quickjs.ts:59](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L59)*
-
-Determines if a VM's execution should be interrupted.
-
-Return `true` to interrupt JS execution.
-Return `false` or `undefined` to continue JS execution.
-
-#### Type declaration:
-
-▸ (`vm`: [QuickJSVm](classes/quickjsvm.md)): *boolean | undefined*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`vm` | [QuickJSVm](classes/quickjsvm.md) |
+*Defined in [quickjs.ts:63](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L63)*
 
 ___
 
@@ -246,7 +250,7 @@ ___
 
 Ƭ **StaticJSValue**: *[Lifetime](classes/lifetime.md)‹[JSValueConstPointer](globals.md#jsvalueconstpointer), [JSValueConstPointer](globals.md#jsvalueconstpointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:873](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L873)*
+*Defined in [quickjs.ts:884](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L884)*
 
 A QuickJSHandle to a constant that will never change, and does not need to
 be disposed.
@@ -309,7 +313,7 @@ Name | Type |
 
 ▸ **getQuickJS**(): *Promise‹[QuickJS](classes/quickjs.md)›*
 
-*Defined in [quickjs.ts:1106](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1106)*
+*Defined in [quickjs.ts:1131](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1131)*
 
 This is the top-level entrypoint for the quickjs-emscripten library.
 Get the root QuickJS API.
@@ -322,7 +326,7 @@ ___
 
 ▸ **getQuickJSSync**(): *[QuickJS](classes/quickjs.md)*
 
-*Defined in [quickjs.ts:1119](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1119)*
+*Defined in [quickjs.ts:1144](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1144)*
 
 Provides synchronous access to the QuickJS API once [getQuickJS](globals.md#getquickjs) has resolved at
 least once.
@@ -335,9 +339,9 @@ ___
 
 ###  shouldInterruptAfterDeadline
 
-▸ **shouldInterruptAfterDeadline**(`deadline`: Date | number): *[ShouldInterruptHandler](globals.md#shouldinterrupthandler)*
+▸ **shouldInterruptAfterDeadline**(`deadline`: Date | number): *[InterruptHandler](globals.md#interrupthandler)*
 
-*Defined in [quickjs.ts:1092](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1092)*
+*Defined in [quickjs.ts:1117](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1117)*
 
 Returns an interrupt handler that interrupts Javascript execution after a deadline time.
 
@@ -347,4 +351,4 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `deadline` | Date &#124; number | Interrupt execution if it's still running after this time.   Number values are compared against `Date.now()`  |
 
-**Returns:** *[ShouldInterruptHandler](globals.md#shouldinterrupthandler)*
+**Returns:** *[InterruptHandler](globals.md#interrupthandler)*

--- a/doc/globals.md
+++ b/doc/globals.md
@@ -54,7 +54,7 @@
 
 Ƭ **ExecutePendingJobsResult**: *[SuccessOrFail](globals.md#successorfail)‹number, [QuickJSHandle](globals.md#quickjshandle)›*
 
-*Defined in [quickjs.ts:197](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L197)*
+*Defined in [quickjs.ts:196](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L196)*
 
 Used as an optional for the results of executing pendingJobs.
 On success, `value` contains the number of async jobs executed
@@ -67,12 +67,10 @@ ___
 
 Ƭ **InterruptHandler**: *function*
 
-*Defined in [quickjs.ts:61](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L61)*
+*Defined in [quickjs.ts:60](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L60)*
 
 Callback called regularly while the VM executes code.
 Determines if a VM's execution should be interrupted.
-
-**`param`** The VM instance
 
 **`returns`** `true` to interrupt JS execution inside the VM.
 
@@ -124,7 +122,7 @@ ___
 
 Ƭ **JSValue**: *[Lifetime](classes/lifetime.md)‹[JSValuePointer](globals.md#jsvaluepointer), [JSValuePointer](globals.md#jsvaluepointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:913](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L913)*
+*Defined in [quickjs.ts:912](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L912)*
 
 A owned QuickJSHandle that should be disposed or returned.
 
@@ -146,7 +144,7 @@ ___
 
 Ƭ **JSValueConst**: *[Lifetime](classes/lifetime.md)‹[JSValueConstPointer](globals.md#jsvalueconstpointer), [JSValuePointer](globals.md#jsvaluepointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:896](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L896)*
+*Defined in [quickjs.ts:895](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L895)*
 
 A QuickJSHandle to a borrowed value that does not need to be disposed.
 
@@ -228,7 +226,7 @@ ___
 
 Ƭ **QuickJSHandle**: *[StaticJSValue](globals.md#staticjsvalue) | [JSValue](globals.md#jsvalue) | [JSValueConst](globals.md#jsvalueconst)*
 
-*Defined in [quickjs.ts:922](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L922)*
+*Defined in [quickjs.ts:921](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L921)*
 
 Wraps a C pointer to a QuickJS JSValue, which represents a Javascript value inside
 a QuickJS virtual machine.
@@ -242,7 +240,7 @@ ___
 
 Ƭ **QuickJSPropertyKey**: *number | string | [QuickJSHandle](globals.md#quickjshandle)*
 
-*Defined in [quickjs.ts:63](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L63)*
+*Defined in [quickjs.ts:62](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L62)*
 
 ___
 
@@ -250,7 +248,7 @@ ___
 
 Ƭ **StaticJSValue**: *[Lifetime](classes/lifetime.md)‹[JSValueConstPointer](globals.md#jsvalueconstpointer), [JSValueConstPointer](globals.md#jsvalueconstpointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:884](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L884)*
+*Defined in [quickjs.ts:883](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L883)*
 
 A QuickJSHandle to a constant that will never change, and does not need to
 be disposed.
@@ -313,7 +311,7 @@ Name | Type |
 
 ▸ **getQuickJS**(): *Promise‹[QuickJS](classes/quickjs.md)›*
 
-*Defined in [quickjs.ts:1131](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1131)*
+*Defined in [quickjs.ts:1130](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1130)*
 
 This is the top-level entrypoint for the quickjs-emscripten library.
 Get the root QuickJS API.
@@ -326,7 +324,7 @@ ___
 
 ▸ **getQuickJSSync**(): *[QuickJS](classes/quickjs.md)*
 
-*Defined in [quickjs.ts:1144](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1144)*
+*Defined in [quickjs.ts:1143](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1143)*
 
 Provides synchronous access to the QuickJS API once [getQuickJS](globals.md#getquickjs) has resolved at
 least once.
@@ -341,7 +339,7 @@ ___
 
 ▸ **shouldInterruptAfterDeadline**(`deadline`: Date | number): *[InterruptHandler](globals.md#interrupthandler)*
 
-*Defined in [quickjs.ts:1117](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1117)*
+*Defined in [quickjs.ts:1116](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1116)*
 
 Returns an interrupt handler that interrupts Javascript execution after a deadline time.
 

--- a/doc/interfaces/quickjsevaloptions.md
+++ b/doc/interfaces/quickjsevaloptions.md
@@ -21,7 +21,7 @@ Options for [QuickJS.evalCode](../classes/quickjs.md#evalcode).
 
 • **memoryLimitBytes**? : *undefined | number*
 
-*Defined in [quickjs.ts:937](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L937)*
+*Defined in [quickjs.ts:936](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L936)*
 
 Memory limit, in bytes, of WASM heap memory used by the QuickJS VM.
 
@@ -31,7 +31,7 @@ ___
 
 • **shouldInterrupt**? : *[InterruptHandler](../globals.md#interrupthandler)*
 
-*Defined in [quickjs.ts:932](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L932)*
+*Defined in [quickjs.ts:931](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L931)*
 
 Interrupt evaluation if `shouldInterrupt` returns `true`.
 See [shouldInterruptAfterDeadline](../globals.md#shouldinterruptafterdeadline).

--- a/doc/interfaces/quickjsevaloptions.md
+++ b/doc/interfaces/quickjsevaloptions.md
@@ -12,15 +12,26 @@ Options for [QuickJS.evalCode](../classes/quickjs.md#evalcode).
 
 ### Properties
 
+* [memoryLimitBytes](quickjsevaloptions.md#optional-memorylimitbytes)
 * [shouldInterrupt](quickjsevaloptions.md#optional-shouldinterrupt)
 
 ## Properties
 
+### `Optional` memoryLimitBytes
+
+• **memoryLimitBytes**? : *undefined | number*
+
+*Defined in [quickjs.ts:937](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L937)*
+
+Memory limit, in bytes, of WASM heap memory used by the QuickJS VM.
+
+___
+
 ### `Optional` shouldInterrupt
 
-• **shouldInterrupt**? : *[ShouldInterruptHandler](../globals.md#shouldinterrupthandler)*
+• **shouldInterrupt**? : *[InterruptHandler](../globals.md#interrupthandler)*
 
-*Defined in [quickjs.ts:921](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L921)*
+*Defined in [quickjs.ts:932](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L932)*
 
 Interrupt evaluation if `shouldInterrupt` returns `true`.
 See [shouldInterruptAfterDeadline](../globals.md#shouldinterruptafterdeadline).

--- a/ts/quickjs.test.ts
+++ b/ts/quickjs.test.ts
@@ -2,7 +2,7 @@
  * These tests demonstate some common patterns for using quickjs-emscripten.
  */
 
-import { getQuickJS, QuickJSVm, QuickJSHandle, ShouldInterruptHandler } from './quickjs'
+import { getQuickJS, QuickJSVm, QuickJSHandle, InterruptHandler } from './quickjs'
 import { it, describe } from 'mocha'
 import assert from 'assert'
 import { VmCallResult } from './vm-interface'
@@ -365,12 +365,12 @@ describe('QuickJSVm', async () => {
   describe('interrupt handler', () => {
     it('is called with the expected VM', () => {
       let calls = 0
-      const interruptHandler: ShouldInterruptHandler = interruptVm => {
+      const interruptHandler: InterruptHandler = interruptVm => {
         assert.strictEqual(interruptVm, vm, 'ShouldInterruptHandler callback VM is the vm')
         calls++
         return false
       }
-      vm.setShouldInterruptHandler(interruptHandler)
+      vm.setInterruptHandler(interruptHandler)
 
       vm.unwrapResult(vm.evalCode('1 + 1')).dispose()
 
@@ -379,14 +379,14 @@ describe('QuickJSVm', async () => {
 
     it('interrupts infinite loop execution', () => {
       let calls = 0
-      const interruptHandler: ShouldInterruptHandler = interruptVm => {
+      const interruptHandler: InterruptHandler = interruptVm => {
         if (calls > 10) {
           return true
         }
         calls++
         return false
       }
-      vm.setShouldInterruptHandler(interruptHandler)
+      vm.setInterruptHandler(interruptHandler)
 
       const result = vm.evalCode('i = 0; while (1) { i++ }')
 

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -51,12 +51,14 @@ type CToHostCallbackFunctionImplementation = (
 type CToHostInterruptImplementation = (rt: JSRuntimePointer) => 0 | 1
 
 /**
+ * Callback called regularly while the VM executes code.
  * Determines if a VM's execution should be interrupted.
  *
- * Return `true` to interrupt JS execution.
- * Return `false` or `undefined` to continue JS execution.
+ * @param vm - The VM instance
+ * @returns `true` to interrupt JS execution inside the VM.
+ * @returns `false` or `undefined` to continue JS execution inside the VM.
  */
-export type ShouldInterruptHandler = (vm: QuickJSVm) => boolean | undefined
+export type InterruptHandler = (vm: QuickJSVm) => boolean | undefined
 
 export type QuickJSPropertyKey = number | string | QuickJSHandle
 
@@ -206,13 +208,22 @@ export type ExecutePendingJobsResult = SuccessOrFail<number, QuickJSHandle>
  *
  * Use [[QuickJS.createVm]] to create a new QuickJSVm.
  *
- * Create QuickJS values with methods like [[newNumber]], [[newString]], [[newArray]], [[newObject]], and [[newFunction]].
+ * Create QuickJS values inside the interpreter with methods like
+ * [[newNumber]], [[newString]], [[newArray]], [[newObject]], and
+ * [[newFunction]].
  *
- * Call [[setProp]] or [[defineProp]] to customize objects. Use those methods with [[global]] to expose the
- * values you create to the interior of the interpreter, so they can be used in [[evalCode]].
+ * Call [[setProp]] or [[defineProp]] to customize objects. Use those methods
+ * with [[global]] to expose the values you create to the interior of the
+ * interpreter, so they can be used in [[evalCode]].
  *
- * Use [[evalCode]] or [[callFunction]] to execute Javascript inside the VM.
- * If you're using asynchronous code inside the QuickJSVm, you may need to also call [[executePendingJobs]].
+ * Use [[evalCode]] or [[callFunction]] to execute Javascript inside the VM. If
+ * you're using asynchronous code inside the QuickJSVm, you may need to also
+ * call [[executePendingJobs]].
+ *
+ * Implement memory and CPU constraints with [[setInterruptHandler]]
+ * (called regularly while the interpreter runs) and [[setMemoryLimit]].
+ * Use [[computeMemoryUsage]] or [[dumpMemoryUsage]] to guide memory limit
+ * tuning.
  */
 export class QuickJSVm implements LowLevelJavascriptVm<QuickJSHandle> {
   private readonly ctx: Lifetime<JSContextPointer>
@@ -539,7 +550,7 @@ export class QuickJSVm implements LowLevelJavascriptVm<QuickJSHandle> {
    * return the result handle directly.
    *
    * *Note*: to protect against infinite loops, provide an interrupt handler to
-   * [[setShouldInterruptHandler]]. You can use [[shouldInterruptAfterDeadline]] to
+   * [[setInterruptHandler]]. You can use [[shouldInterruptAfterDeadline]] to
    * create a time-based deadline.
    *
    *
@@ -644,16 +655,16 @@ export class QuickJSVm implements LowLevelJavascriptVm<QuickJSHandle> {
     return result.value
   }
 
-  private interruptHandler: ShouldInterruptHandler | undefined
+  private interruptHandler: InterruptHandler | undefined
 
   /**
    * Set a callback which is regularly called by the QuickJS engine when it is
    * executing code. This callback can be used to implement an execution
    * timeout.
    *
-   * The interrupt handler can be removed with [[removeShouldInterruptHandler]].
+   * The interrupt handler can be removed with [[removeInterruptHandler]].
    */
-  setShouldInterruptHandler(cb: ShouldInterruptHandler) {
+  setInterruptHandler(cb: InterruptHandler) {
     const prevInterruptHandler = this.interruptHandler
     this.interruptHandler = cb
     if (!prevInterruptHandler) {
@@ -696,9 +707,9 @@ export class QuickJSVm implements LowLevelJavascriptVm<QuickJSHandle> {
 
   /**
    * Remove the interrupt handler, if any.
-   * See [[setShouldInterruptHandler]].
+   * See [[setInterruptHandler]].
    */
-  removeShouldInterruptHandler() {
+  removeInterruptHandler() {
     if (this.interruptHandler) {
       this.ffi.QTS_RuntimeDisableInterruptHandler(this.rt.value)
       this.interruptHandler = undefined
@@ -918,7 +929,7 @@ export interface QuickJSEvalOptions {
    * Interrupt evaluation if `shouldInterrupt` returns `true`.
    * See [[shouldInterruptAfterDeadline]].
    */
-  shouldInterrupt?: ShouldInterruptHandler
+  shouldInterrupt?: InterruptHandler
 }
 
 /**
@@ -1029,7 +1040,7 @@ export class QuickJS {
     const vm = this.createVm()
 
     if (options.shouldInterrupt) {
-      vm.setShouldInterruptHandler(options.shouldInterrupt)
+      vm.setInterruptHandler(options.shouldInterrupt)
     }
 
     const result = vm.evalCode(code)
@@ -1089,7 +1100,7 @@ export class QuickJS {
  * @param deadline - Interrupt execution if it's still running after this time.
  *   Number values are compared against `Date.now()`
  */
-export function shouldInterruptAfterDeadline(deadline: Date | number): ShouldInterruptHandler {
+export function shouldInterruptAfterDeadline(deadline: Date | number): InterruptHandler {
   const deadlineAsNumber = typeof deadline === 'number' ? deadline : deadline.getTime()
 
   return function() {

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -930,6 +930,11 @@ export interface QuickJSEvalOptions {
    * See [[shouldInterruptAfterDeadline]].
    */
   shouldInterrupt?: InterruptHandler
+
+  /**
+   * Memory limit, in bytes, of WASM heap memory used by the QuickJS VM.
+   */
+  memoryLimitBytes?: number
 }
 
 /**
@@ -1043,7 +1048,16 @@ export class QuickJS {
       vm.setInterruptHandler(options.shouldInterrupt)
     }
 
+    if (options.memoryLimitBytes !== undefined) {
+      vm.setMemoryLimit(options.memoryLimitBytes)
+    }
+
     const result = vm.evalCode(code)
+
+    if (options.memoryLimitBytes !== undefined) {
+      // Remove memory limit so we can dump the result without exceeding it.
+      vm.setMemoryLimit(-1)
+    }
 
     if (result.error) {
       const error = vm.dump(result.error)

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -54,7 +54,6 @@ type CToHostInterruptImplementation = (rt: JSRuntimePointer) => 0 | 1
  * Callback called regularly while the VM executes code.
  * Determines if a VM's execution should be interrupted.
  *
- * @param vm - The VM instance
  * @returns `true` to interrupt JS execution inside the VM.
  * @returns `false` or `undefined` to continue JS execution inside the VM.
  */


### PR DESCRIPTION
* Rename `ShouldInterruptHandler` to `InterruptHandler` (and related methods)
* Note usage of `setInterruptHandler` and `setMemoryLimit` in QuickjsVm docs
* Note usage of `computeMemoryUsage` and `dumpMemoryUsage` in QuickjsVM docsj