### PR TITLE
Implement vm.resolve(promiseLikeHandle)

### DIFF
--- a/doc/classes/quickjs.md
+++ b/doc/classes/quickjs.md
@@ -34,7 +34,7 @@ and return the result as a native Javascript value.
 
 \+ **new QuickJS**(): *[QuickJS](quickjs.md)*
 
-*Defined in [quickjs.ts:1005](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1005)*
+*Defined in [quickjs.ts:1060](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1060)*
 
 **Returns:** *[QuickJS](quickjs.md)*
 
@@ -44,7 +44,7 @@ and return the result as a native Javascript value.
 
 ▸ **createVm**(): *[QuickJSVm](quickjsvm.md)*
 
-*Defined in [quickjs.ts:1052](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1052)*
+*Defined in [quickjs.ts:1107](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1107)*
 
 Create a QuickJS VM.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **evalCode**(`code`: string, `options`: [QuickJSEvalOptions](../interfaces/quickjsevaloptions.md)): *unknown*
 
-*Defined in [quickjs.ts:1093](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1093)*
+*Defined in [quickjs.ts:1148](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1148)*
 
 One-off evaluate code without needing to create a VM.
 

--- a/doc/classes/quickjsdeferredpromise.md
+++ b/doc/classes/quickjsdeferredpromise.md
@@ -10,7 +10,7 @@ Managing the lifetime of promises is tricky. There are three
 [QuickJSHandle](../globals.md#quickjshandle)s inside of each deferred promise object: (1) the promise
 itself, (2) the `resolve` callback, and (3) the `reject` callback.
 
-- If the promise will be fufilled before the end of it's [owner](quickjsdeferredpromise.md#owner)'s lifetime,
+- If the promise will be fulfilled before the end of it's [owner](quickjsdeferredpromise.md#owner)'s lifetime,
   the only cleanup necessary is `deferred.handle.dispose()`, because
   calling [resolve](quickjsdeferredpromise.md#resolve) or [reject](quickjsdeferredpromise.md#reject) will dispose of both callbacks automatically.
 

--- a/doc/globals.md
+++ b/doc/globals.md
@@ -138,7 +138,7 @@ ___
 
 Ƭ **JSValue**: *[Lifetime](classes/lifetime.md)‹[JSValuePointer](globals.md#jsvaluepointer), [JSValuePointer](globals.md#jsvaluepointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:962](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L962)*
+*Defined in [quickjs.ts:1017](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1017)*
 
 A owned QuickJSHandle that should be disposed or returned.
 
@@ -160,7 +160,7 @@ ___
 
 Ƭ **JSValueConst**: *[Lifetime](classes/lifetime.md)‹[JSValueConstPointer](globals.md#jsvalueconstpointer), [JSValuePointer](globals.md#jsvaluepointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:945](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L945)*
+*Defined in [quickjs.ts:1000](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1000)*
 
 A QuickJSHandle to a borrowed value that does not need to be disposed.
 
@@ -252,7 +252,7 @@ ___
 
 Ƭ **QuickJSHandle**: *[StaticJSValue](globals.md#staticjsvalue) | [JSValue](globals.md#jsvalue) | [JSValueConst](globals.md#jsvalueconst)*
 
-*Defined in [quickjs.ts:971](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L971)*
+*Defined in [quickjs.ts:1026](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1026)*
 
 Wraps a C pointer to a QuickJS JSValue, which represents a Javascript value inside
 a QuickJS virtual machine.
@@ -274,7 +274,7 @@ ___
 
 Ƭ **StaticJSValue**: *[Lifetime](classes/lifetime.md)‹[JSValueConstPointer](globals.md#jsvalueconstpointer), [JSValueConstPointer](globals.md#jsvalueconstpointer), [QuickJSVm](classes/quickjsvm.md)›*
 
-*Defined in [quickjs.ts:933](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L933)*
+*Defined in [quickjs.ts:988](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L988)*
 
 A QuickJSHandle to a constant that will never change, and does not need to
 be disposed.
@@ -337,7 +337,7 @@ Name | Type |
 
 ▸ **getQuickJS**(): *Promise‹[QuickJS](classes/quickjs.md)›*
 
-*Defined in [quickjs.ts:1177](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1177)*
+*Defined in [quickjs.ts:1232](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1232)*
 
 This is the top-level entrypoint for the quickjs-emscripten library.
 Get the root QuickJS API.
@@ -350,7 +350,7 @@ ___
 
 ▸ **getQuickJSSync**(): *[QuickJS](classes/quickjs.md)*
 
-*Defined in [quickjs.ts:1190](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1190)*
+*Defined in [quickjs.ts:1245](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1245)*
 
 Provides synchronous access to the QuickJS API once [getQuickJS](globals.md#getquickjs) has resolved at
 least once.
@@ -365,7 +365,7 @@ ___
 
 ▸ **shouldInterruptAfterDeadline**(`deadline`: Date | number): *[InterruptHandler](globals.md#interrupthandler)*
 
-*Defined in [quickjs.ts:1163](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1163)*
+*Defined in [quickjs.ts:1218](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1218)*
 
 Returns an interrupt handler that interrupts Javascript execution after a deadline time.
 

--- a/doc/interfaces/quickjsevaloptions.md
+++ b/doc/interfaces/quickjsevaloptions.md
@@ -21,7 +21,7 @@ Options for [QuickJS.evalCode](../classes/quickjs.md#evalcode).
 
 • **memoryLimitBytes**? : *undefined | number*
 
-*Defined in [quickjs.ts:986](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L986)*
+*Defined in [quickjs.ts:1041](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1041)*
 
 Memory limit, in bytes, of WASM heap memory used by the QuickJS VM.
 
@@ -31,7 +31,7 @@ ___
 
 • **shouldInterrupt**? : *[InterruptHandler](../globals.md#interrupthandler)*
 
-*Defined in [quickjs.ts:981](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L981)*
+*Defined in [quickjs.ts:1036](https://github.com/justjake/quickjs-emscripten/blob/master/ts/quickjs.ts#L1036)*
 
 Interrupt evaluation if `shouldInterrupt` returns `true`.
 See [shouldInterruptAfterDeadline](../globals.md#shouldinterruptafterdeadline).

--- a/ts/quickjs.test.ts
+++ b/ts/quickjs.test.ts
@@ -503,7 +503,7 @@ describe('QuickJSVm', async () => {
       let deferred: QuickJSDeferredPromise = undefined as any
 
       function timeout(ms: number) {
-        return new Promise(resolve => {
+        return new Promise<void>(resolve => {
           setTimeout(() => resolve(), ms)
         })
       }

--- a/ts/quickjs.test.ts
+++ b/ts/quickjs.test.ts
@@ -549,7 +549,7 @@ describe('QuickJSVm', async () => {
 
       assert.equal(vm.typeof(result), 'object', 'Async function returns an object (promise)')
 
-      const promise = result.consume(result => vm.resolve(result))
+      const promise = result.consume(result => vm.resolvePromise(result))
       vm.executePendingJobs()
       const asyncResult = vm.unwrapResult(await promise)
 
@@ -571,7 +571,7 @@ describe('QuickJSVm', async () => {
 
       assert.equal(vm.typeof(result), 'object', 'Async function returns an object (promise)')
 
-      const promise = result.consume(result => vm.resolve(result))
+      const promise = result.consume(result => vm.resolvePromise(result))
       vm.executePendingJobs()
       const asyncResult = await promise
 

--- a/ts/quickjs.test.ts
+++ b/ts/quickjs.test.ts
@@ -535,7 +535,7 @@ describe('QuickJSVm', async () => {
     })
   })
 
-  describe('.resolve()', () => {
+  describe('.resolvePromise()', () => {
     it('retrieves async function return value as a successful VM result', async () => {
       const result = vm.unwrapResult(
         vm.evalCode(`
@@ -583,6 +583,20 @@ describe('QuickJSVm', async () => {
 
       assert.equal(error.name, 'Error')
       assert.equal(error.message, 'oops')
+    })
+
+    it('converts non-promise handles into a promise, too', async () => {
+      const stringHandle = vm.newString('foo')
+      const promise = vm.resolvePromise(stringHandle)
+      stringHandle.dispose()
+
+      vm.executePendingJobs()
+
+      const final = await promise.then(result => {
+        const stringHandle2 = vm.unwrapResult(result)
+        return `unwrapped: ${stringHandle2.consume(stringHandle2 => vm.dump(stringHandle2))}`
+      })
+      assert.equal(final, `unwrapped: foo`)
     })
   })
 

--- a/ts/quickjs.test.ts
+++ b/ts/quickjs.test.ts
@@ -1,5 +1,5 @@
 /**
- * These tests demonstate some common patterns for using quickjs-emscripten.
+ * These tests demonstrate some common patterns for using quickjs-emscripten.
  */
 
 import {

--- a/ts/quickjs.ts
+++ b/ts/quickjs.ts
@@ -872,7 +872,7 @@ export class QuickJSVm implements LowLevelJavascriptVm<QuickJSHandle>, Disposabl
           ownedResultPtr = this.ffi.QTS_DupValuePointer(this.ctx.value, handle.value)
         }
       } catch (error) {
-        ownedResultPtr = this.errorToHandle(error).consume(errorHandle =>
+        ownedResultPtr = this.errorToHandle(error as Error).consume(errorHandle =>
           this.ffi.QTS_Throw(this.ctx.value, errorHandle.value)
         )
       }


### PR DESCRIPTION
fixes https://github.com/justjake/quickjs-emscripten/issues/46 by making it much easier to work with async functions inside the VM.