### PR TITLE
pass context through on interrupt handlers

### DIFF
--- a/c/interface.c
+++ b/c/interface.c
@@ -597,20 +597,20 @@ JSValueConst *QTS_ArgvGetJSValueConstPointer(JSValueConst *argv, int index) {
 // --------------------
 // interrupt: C -> Host
 #ifdef __EMSCRIPTEN__
-EM_JS(int, qts_host_interrupt_handler, (JSRuntime * rt), {
+EM_JS(int, qts_host_interrupt_handler, (JSRuntime * rt, JSContext *ctx), {
   // Async not supported here.
   // #ifdef QTS_ASYNCIFY
   //   const asyncify = Asyncify;
   // #else
   const asyncify = undefined;
   // #endif
-  return Module['callbacks']['shouldInterrupt'](asyncify, rt);
+  return Module['callbacks']['shouldInterrupt'](asyncify, rt, ctx);
 });
 #endif
 
 // interrupt: QuickJS -> C
-int qts_interrupt_handler(JSRuntime *rt, void *_unused) {
-  return qts_host_interrupt_handler(rt);
+int qts_interrupt_handler(JSRuntime *rt, JSContext *ctx, void *_unused) {
+  return qts_host_interrupt_handler(rt, ctx);
 }
 
 // interrupt: Host -> QuickJS

--- a/quickjs/quickjs-libc.c
+++ b/quickjs/quickjs-libc.c
@@ -721,7 +721,7 @@ static JSValue js_std_gc(JSContext *ctx, JSValueConst this_val,
     return JS_UNDEFINED;
 }
 
-static int interrupt_handler(JSRuntime *rt, void *opaque)
+static int interrupt_handler(JSRuntime *rt, JSContext *ctx, void *opaque)
 {
     return (os_pending_signals >> SIGINT) & 1;
 }

--- a/quickjs/quickjs.c
+++ b/quickjs/quickjs.c
@@ -6775,7 +6775,7 @@ static no_inline __exception int __js_poll_interrupts(JSContext *ctx)
     JSRuntime *rt = ctx->rt;
     ctx->interrupt_counter = JS_INTERRUPT_COUNTER_INIT;
     if (rt->interrupt_handler) {
-        if (rt->interrupt_handler(rt, rt->interrupt_opaque)) {
+        if (rt->interrupt_handler(rt, ctx, rt->interrupt_opaque)) {
             /* XXX: should set a specific flag to avoid catching */
             JS_ThrowInternalError(ctx, "interrupted");
             JS_SetUncatchableError(ctx, ctx->rt->current_exception, TRUE);

--- a/quickjs/quickjs.h
+++ b/quickjs/quickjs.h
@@ -840,7 +840,7 @@ typedef void JSHostPromiseRejectionTracker(JSContext *ctx, JSValueConst promise,
 void JS_SetHostPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRejectionTracker *cb, void *opaque);
 
 /* return != 0 if the JS code needs to be interrupted */
-typedef int JSInterruptHandler(JSRuntime *rt, void *opaque);
+typedef int JSInterruptHandler(JSRuntime *rt, JSContext *ctx, void *opaque);
 void JS_SetInterruptHandler(JSRuntime *rt, JSInterruptHandler *cb, void *opaque);
 /* if can_block is TRUE, Atomics.wait() can be used */
 void JS_SetCanBlock(JSRuntime *rt, JS_BOOL can_block);

--- a/ts/emscripten-types.ts
+++ b/ts/emscripten-types.ts
@@ -147,7 +147,8 @@ export interface EmscriptenModuleCallbacks {
 
   shouldInterrupt: (
     asyncify: Asyncify | undefined,
-    rt: JSRuntimePointer
+    rt: JSRuntimePointer,
+    ctx: JSContextPointer,
   ) => 0 | 1 | AsyncifySleepResult<0 | 1>
 }
 


### PR DESCRIPTION
Following the instructions @justjake laid out in #84 to add context as an arg to runtime interrupt handlers. This is definitely a useful addition, but not quite to the context-level interrupts I want. Gonna play with this codepath some more to see if I can actually achieve separate interrupts per context. The biggest blocker I know of right now is that interrupt handlers only exist at the runtime level. This means I will need to do something like `this.runtime.setInterruptHander((runtime, context) => context === this ? cb(runtime, context) : this.runtime.interruptHandler?.(runtime, context) ?? false)` . This leads to a sort of russian nesting doll situation. I would much rather be able to set interrupts per context natively, or have multiple interrupts registered on a runtime
