### PR TITLE
Allow disabling intrinsic language features (like #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.26.0
+
+- [#136](https://github.com/justjake/quickjs-emscripten/pull/136), [#116](https://github.com/justjake/quickjs-emscripten/pull/116) (thanks to @GrantMatejka) Expose ability to configure Context's intrinsic objects.
+- [#135](https://github.com/justjake/quickjs-emscripten/pull/135) (thanks to @saghul) Add `quickjs-ng` variants. quickjs-ng is a fork of quickjs under active development. It implements more EcmaScript standards and removes some of quickjs's custom language features like BigFloat.
+- [#134](https://github.com/justjake/quickjs-emscripten/pull/134) Support using statement for Disposable. If you `using value = vm.unwrapResult(vm.evalCode("1+1"))`, the value will be automatically disposed when the scope exits.
+- [#133](https://github.com/justjake/quickjs-emscripten/pull/133) WebAssembly loading options & Cloudflare Worker support. Added an example of using quickjs-emscripten in a Cloudflare Worker.
+
 ## v0.25.1
 
 - [#130](https://github.com/justjake/quickjs-emscripten/pull/129) Fix some README and docs quibbles.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ main()
     - [Packaging](#packaging)
       - [Reducing package size](#reducing-package-size)
       - [WebAssembly loading](#webassembly-loading)
+      - [quickjs-ng](#quickjs-ng)
       - [Using in the browser without a build step](#using-in-the-browser-without-a-build-step)
     - [Debugging](#debugging)
     - [Supported Platforms](#supported-platforms)
@@ -642,6 +643,12 @@ const cloudflareVariant = newVariant(baseVariant, {
 ```
 
 [newVariant]: https://github.com/justjake/quickjs-emscripten/blob/main/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+
+#### quickjs-ng
+
+[quickjs-ng/quickjs](https://github.com/quickjs-ng/quickjs) (aka quickjs-ng) is a fork of the original [bellard/quickjs](https://github.com/quickjs-ng/quickjs) under active development. It implements more EcmaScript standards and removes some of quickjs's custom language features like BigFloat.
+
+There are several variants of quickjs-ng available, and quickjs-emscripten may switch to using quickjs-ng by default in the future. See [the list of variants][core].
 
 #### Using in the browser without a build step
 

--- a/c/interface.c
+++ b/c/interface.c
@@ -90,6 +90,7 @@
 #define JSVoid void
 
 #define EvalFlags int
+#define IntrinsicsFlags enum QTS_Intrinsic
 #define EvalDetectModule int
 
 void qts_log(char *msg) {
@@ -294,7 +295,7 @@ enum QTS_Intrinsic {
   QTS_Intrinsic_BignumExt = 1 << 15,
 };
 
-JSContext *QTS_NewContext(JSRuntime *rt, enum QTS_Intrinsic intrinsics) {
+JSContext *QTS_NewContext(JSRuntime *rt, IntrinsicsFlags intrinsics) {
   if (intrinsics == 0) {
     return JS_NewContext(rt);
   }

--- a/c/interface.c
+++ b/c/interface.c
@@ -275,8 +275,85 @@ void QTS_FreeRuntime(JSRuntime *rt) {
   JS_FreeRuntime(rt);
 }
 
-JSContext *QTS_NewContext(JSRuntime *rt) {
-  return JS_NewContext(rt);
+enum QTS_Intrinsic {
+  QTS_Intrinsic_BaseObjects = 1 << 0,
+  QTS_Intrinsic_Date = 1 << 1,
+  QTS_Intrinsic_Eval = 1 << 2,
+  QTS_Intrinsic_StringNormalize = 1 << 3,
+  QTS_Intrinsic_RegExp = 1 << 4,
+  QTS_Intrinsic_RegExpCompiler = 1 << 5,
+  QTS_Intrinsic_JSON = 1 << 6,
+  QTS_Intrinsic_Proxy = 1 << 7,
+  QTS_Intrinsic_MapSet = 1 << 8,
+  QTS_Intrinsic_TypedArrays = 1 << 9,
+  QTS_Intrinsic_Promise = 1 << 10,
+  QTS_Intrinsic_BigInt = 1 << 11,
+  QTS_Intrinsic_BigFloat = 1 << 12,
+  QTS_Intrinsic_BigDecimal = 1 << 13,
+  QTS_Intrinsic_OperatorOverloading = 1 << 14,
+  QTS_Intrinsic_BignumExt = 1 << 15,
+};
+
+JSContext *QTS_NewContext(JSRuntime *rt, enum QTS_Intrinsic intrinsics) {
+  if (intrinsics == 0) {
+    return JS_NewContext(rt);
+  }
+
+  JSContext *ctx = JS_NewContextRaw(rt);
+  if (ctx == NULL) {
+    return NULL;
+  }
+
+  if (intrinsics & QTS_Intrinsic_BaseObjects) {
+    JS_AddIntrinsicDate(ctx);
+  }
+  if (intrinsics & QTS_Intrinsic_Date) {
+    JS_AddIntrinsicDate(ctx);
+  }
+  if (intrinsics & QTS_Intrinsic_Eval) {
+    JS_AddIntrinsicEval(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_StringNormalize) {
+    JS_AddIntrinsicStringNormalize(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_RegExp) {
+    JS_AddIntrinsicRegExp(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_RegExpCompiler) {
+    JS_AddIntrinsicRegExpCompiler(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_JSON) {
+    JS_AddIntrinsicJSON(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_Proxy) {
+    JS_AddIntrinsicProxy(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_MapSet) {
+    JS_AddIntrinsicMapSet(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_TypedArrays) {
+    JS_AddIntrinsicTypedArrays(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_Promise) {
+    JS_AddIntrinsicPromise(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_BigInt) {
+    JS_AddIntrinsicBigInt(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_BigFloat) {
+    JS_AddIntrinsicBigFloat(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_BigDecimal) {
+    JS_AddIntrinsicBigDecimal(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_BignumExt) {
+    JS_EnableBignumExt(ctx)
+  }
+  if (intrinsics & QTS_Intrinsic_OperatorOverloading) {
+    JS_AddIntrinsicOperators(ctx)
+  }
+
+  return ctx;
 }
 
 void QTS_FreeContext(JSContext *ctx) {

--- a/c/interface.c
+++ b/c/interface.c
@@ -311,47 +311,51 @@ JSContext *QTS_NewContext(JSRuntime *rt, enum QTS_Intrinsic intrinsics) {
     JS_AddIntrinsicDate(ctx);
   }
   if (intrinsics & QTS_Intrinsic_Eval) {
-    JS_AddIntrinsicEval(ctx)
+    JS_AddIntrinsicEval(ctx);
   }
+#ifndef QTS_USE_QUICKJS_NG
   if (intrinsics & QTS_Intrinsic_StringNormalize) {
-    JS_AddIntrinsicStringNormalize(ctx)
+    JS_AddIntrinsicStringNormalize(ctx);
   }
+#endif
   if (intrinsics & QTS_Intrinsic_RegExp) {
-    JS_AddIntrinsicRegExp(ctx)
+    JS_AddIntrinsicRegExp(ctx);
   }
   if (intrinsics & QTS_Intrinsic_RegExpCompiler) {
-    JS_AddIntrinsicRegExpCompiler(ctx)
+    JS_AddIntrinsicRegExpCompiler(ctx);
   }
   if (intrinsics & QTS_Intrinsic_JSON) {
-    JS_AddIntrinsicJSON(ctx)
+    JS_AddIntrinsicJSON(ctx);
   }
   if (intrinsics & QTS_Intrinsic_Proxy) {
-    JS_AddIntrinsicProxy(ctx)
+    JS_AddIntrinsicProxy(ctx);
   }
   if (intrinsics & QTS_Intrinsic_MapSet) {
-    JS_AddIntrinsicMapSet(ctx)
+    JS_AddIntrinsicMapSet(ctx);
   }
   if (intrinsics & QTS_Intrinsic_TypedArrays) {
-    JS_AddIntrinsicTypedArrays(ctx)
+    JS_AddIntrinsicTypedArrays(ctx);
   }
   if (intrinsics & QTS_Intrinsic_Promise) {
-    JS_AddIntrinsicPromise(ctx)
+    JS_AddIntrinsicPromise(ctx);
   }
   if (intrinsics & QTS_Intrinsic_BigInt) {
-    JS_AddIntrinsicBigInt(ctx)
+    JS_AddIntrinsicBigInt(ctx);
   }
+#ifdef CONFIG_BIGNUM
   if (intrinsics & QTS_Intrinsic_BigFloat) {
-    JS_AddIntrinsicBigFloat(ctx)
+    JS_AddIntrinsicBigFloat(ctx);
   }
   if (intrinsics & QTS_Intrinsic_BigDecimal) {
-    JS_AddIntrinsicBigDecimal(ctx)
+    JS_AddIntrinsicBigDecimal(ctx);
   }
   if (intrinsics & QTS_Intrinsic_BignumExt) {
-    JS_EnableBignumExt(ctx)
+    JS_EnableBignumExt(ctx, TRUE);
   }
   if (intrinsics & QTS_Intrinsic_OperatorOverloading) {
-    JS_AddIntrinsicOperators(ctx)
+    JS_AddIntrinsicOperators(ctx);
   }
+#endif
 
   return ctx;
 }

--- a/c/interface.c
+++ b/c/interface.c
@@ -306,7 +306,7 @@ JSContext *QTS_NewContext(JSRuntime *rt, IntrinsicsFlags intrinsics) {
   }
 
   if (intrinsics & QTS_Intrinsic_BaseObjects) {
-    JS_AddIntrinsicDate(ctx);
+    JS_AddIntrinsicBaseObjects(ctx);
   }
   if (intrinsics & QTS_Intrinsic_Date) {
     JS_AddIntrinsicDate(ctx);

--- a/doc/@jitl/quickjs-ffi-types/exports.md
+++ b/doc/@jitl/quickjs-ffi-types/exports.md
@@ -30,6 +30,7 @@
   - [QuickJSVariant](exports.md#quickjsvariant)
 - [Variables](exports.md#variables)
   - [EvalFlags](exports.md#evalflags)
+  - [IntrinsicsFlags](exports.md#intrinsicsflags)
 - [Functions](exports.md#functions)
   - [assertSync()](exports.md#assertsync)
 
@@ -273,13 +274,13 @@ Bitfield options for JS_Eval() C function.
 
 ##### JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER
 
-> **JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER**: `number`
 
 don't include the stack frames before this eval in the Error() backtraces
 
 ##### JS\_EVAL\_FLAG\_COMPILE\_ONLY
 
-> **JS\_EVAL\_FLAG\_COMPILE\_ONLY**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_COMPILE\_ONLY**: `number`
 
 compile but do not run. The result is an object with a
 JS_TAG_FUNCTION_BYTECODE or JS_TAG_MODULE tag. It can be executed
@@ -287,47 +288,125 @@ with JS_EvalFunction().
 
 ##### JS\_EVAL\_FLAG\_STRICT
 
-> **JS\_EVAL\_FLAG\_STRICT**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_STRICT**: `number`
 
 force 'strict' mode
 
 ##### JS\_EVAL\_FLAG\_STRIP
 
-> **JS\_EVAL\_FLAG\_STRIP**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_STRIP**: `number`
 
 force 'strip' mode
 
 ##### JS\_EVAL\_TYPE\_DIRECT
 
-> **JS\_EVAL\_TYPE\_DIRECT**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_DIRECT**: `number`
 
 direct call (internal use)
 
 ##### JS\_EVAL\_TYPE\_GLOBAL
 
-> **JS\_EVAL\_TYPE\_GLOBAL**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_GLOBAL**: `number`
 
 global code (default)
 
 ##### JS\_EVAL\_TYPE\_INDIRECT
 
-> **JS\_EVAL\_TYPE\_INDIRECT**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_INDIRECT**: `number`
 
 indirect call (internal use)
 
 ##### JS\_EVAL\_TYPE\_MASK
 
-> **JS\_EVAL\_TYPE\_MASK**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_MASK**: `number`
 
 ##### JS\_EVAL\_TYPE\_MODULE
 
-> **JS\_EVAL\_TYPE\_MODULE**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_MODULE**: `number`
 
 module code
 
 #### Source
 
 [packages/quickjs-ffi-types/src/ffi-types.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L99)
+
+***
+
+### IntrinsicsFlags
+
+> **IntrinsicsFlags**: `Object`
+
+Bitfield options for QTS_NewContext intrinsices
+
+#### Type declaration
+
+##### BaseObjects
+
+> **`readonly`** **BaseObjects**: `number`
+
+##### BigDecimal
+
+> **`readonly`** **BigDecimal**: `number`
+
+##### BigFloat
+
+> **`readonly`** **BigFloat**: `number`
+
+##### BigInt
+
+> **`readonly`** **BigInt**: `number`
+
+##### BignumExt
+
+> **`readonly`** **BignumExt**: `number`
+
+##### Date
+
+> **`readonly`** **Date**: `number`
+
+##### Eval
+
+> **`readonly`** **Eval**: `number`
+
+##### JSON
+
+> **`readonly`** **JSON**: `number`
+
+##### MapSet
+
+> **`readonly`** **MapSet**: `number`
+
+##### OperatorOverloading
+
+> **`readonly`** **OperatorOverloading**: `number`
+
+##### Promise
+
+> **`readonly`** **Promise**: `number`
+
+##### Proxy
+
+> **`readonly`** **Proxy**: `number`
+
+##### RegExp
+
+> **`readonly`** **RegExp**: `number`
+
+##### RegExpCompiler
+
+> **`readonly`** **RegExpCompiler**: `number`
+
+##### StringNormalize
+
+> **`readonly`** **StringNormalize**: `number`
+
+##### TypedArrays
+
+> **`readonly`** **TypedArrays**: `number`
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi-types.ts:104](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L104)
 
 ## Functions
 
@@ -360,7 +439,7 @@ module code
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-types.ts:106](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L106)
+[packages/quickjs-ffi-types/src/ffi-types.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L111)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncFFI.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncFFI.md
@@ -94,7 +94,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:33](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L33)
+[packages/quickjs-ffi-types/src/ffi-async.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L34)
 
 ***
 
@@ -114,7 +114,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:193](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L193)
+[packages/quickjs-ffi-types/src/ffi-async.ts:194](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L194)
 
 ***
 
@@ -128,7 +128,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L191)
+[packages/quickjs-ffi-types/src/ffi-async.ts:192](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L192)
 
 ***
 
@@ -142,7 +142,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:190](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L190)
+[packages/quickjs-ffi-types/src/ffi-async.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L191)
 
 ***
 
@@ -156,7 +156,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L41)
+[packages/quickjs-ffi-types/src/ffi-async.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L42)
 
 ***
 
@@ -182,7 +182,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:143](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L143)
+[packages/quickjs-ffi-types/src/ffi-async.ts:144](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L144)
 
 ***
 
@@ -208,7 +208,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:150](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L150)
+[packages/quickjs-ffi-types/src/ffi-async.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L151)
 
 ***
 
@@ -242,7 +242,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L132)
+[packages/quickjs-ffi-types/src/ffi-async.ts:133](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L133)
 
 ***
 
@@ -262,7 +262,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L158)
+[packages/quickjs-ffi-types/src/ffi-async.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L159)
 
 ***
 
@@ -282,7 +282,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L162)
+[packages/quickjs-ffi-types/src/ffi-async.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L163)
 
 ***
 
@@ -302,7 +302,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L55)
+[packages/quickjs-ffi-types/src/ffi-async.ts:56](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L56)
 
 ***
 
@@ -328,7 +328,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:166](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L166)
+[packages/quickjs-ffi-types/src/ffi-async.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L167)
 
 ***
 
@@ -354,7 +354,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:173](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L173)
+[packages/quickjs-ffi-types/src/ffi-async.ts:174](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L174)
 
 ***
 
@@ -376,7 +376,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:100](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L100)
+[packages/quickjs-ffi-types/src/ffi-async.ts:101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L101)
 
 ***
 
@@ -398,7 +398,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:105](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L105)
+[packages/quickjs-ffi-types/src/ffi-async.ts:106](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L106)
 
 ***
 
@@ -418,7 +418,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L54)
+[packages/quickjs-ffi-types/src/ffi-async.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L55)
 
 ***
 
@@ -436,7 +436,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L50)
+[packages/quickjs-ffi-types/src/ffi-async.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L51)
 
 ***
 
@@ -454,7 +454,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L48)
+[packages/quickjs-ffi-types/src/ffi-async.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L49)
 
 ***
 
@@ -474,7 +474,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L51)
+[packages/quickjs-ffi-types/src/ffi-async.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L52)
 
 ***
 
@@ -494,7 +494,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L52)
+[packages/quickjs-ffi-types/src/ffi-async.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L53)
 
 ***
 
@@ -514,7 +514,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L53)
+[packages/quickjs-ffi-types/src/ffi-async.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L54)
 
 ***
 
@@ -534,7 +534,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:77](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L77)
+[packages/quickjs-ffi-types/src/ffi-async.ts:78](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L78)
 
 ***
 
@@ -554,7 +554,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:81](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L81)
+[packages/quickjs-ffi-types/src/ffi-async.ts:82](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L82)
 
 ***
 
@@ -568,7 +568,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L45)
+[packages/quickjs-ffi-types/src/ffi-async.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L46)
 
 ***
 
@@ -588,7 +588,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L71)
+[packages/quickjs-ffi-types/src/ffi-async.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L72)
 
 ***
 
@@ -606,7 +606,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:184](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L184)
+[packages/quickjs-ffi-types/src/ffi-async.ts:185](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L185)
 
 ***
 
@@ -620,7 +620,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L44)
+[packages/quickjs-ffi-types/src/ffi-async.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L45)
 
 ***
 
@@ -642,7 +642,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:110](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L110)
+[packages/quickjs-ffi-types/src/ffi-async.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L111)
 
 ***
 
@@ -664,7 +664,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L115)
+[packages/quickjs-ffi-types/src/ffi-async.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L116)
 
 ***
 
@@ -684,7 +684,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L73)
+[packages/quickjs-ffi-types/src/ffi-async.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L74)
 
 ***
 
@@ -704,7 +704,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:90](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L90)
+[packages/quickjs-ffi-types/src/ffi-async.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L91)
 
 ***
 
@@ -724,7 +724,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:94](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L94)
+[packages/quickjs-ffi-types/src/ffi-async.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L95)
 
 ***
 
@@ -738,7 +738,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L46)
+[packages/quickjs-ffi-types/src/ffi-async.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L47)
 
 ***
 
@@ -752,7 +752,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L43)
+[packages/quickjs-ffi-types/src/ffi-async.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L44)
 
 ***
 
@@ -772,7 +772,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:98](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L98)
+[packages/quickjs-ffi-types/src/ffi-async.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L99)
 
 ***
 
@@ -790,7 +790,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L99)
+[packages/quickjs-ffi-types/src/ffi-async.ts:100](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L100)
 
 ***
 
@@ -808,7 +808,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:64](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L64)
+[packages/quickjs-ffi-types/src/ffi-async.ts:65](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L65)
 
 ***
 
@@ -830,17 +830,19 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:65](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L65)
+[packages/quickjs-ffi-types/src/ffi-async.ts:66](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L66)
 
 ***
 
 ### QTS\_NewContext
 
-> **QTS\_NewContext**: (`rt`) => [`JSContextPointer`](../exports.md#jscontextpointer)
+> **QTS\_NewContext**: (`rt`, `intrinsics`) => [`JSContextPointer`](../exports.md#jscontextpointer)
 
 #### Parameters
 
 • **rt**: [`JSRuntimePointer`](../exports.md#jsruntimepointer)
+
+• **intrinsics**: [`IntrinsicsFlags`](../exports.md#intrinsicsflags)
 
 #### Returns
 
@@ -848,7 +850,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L49)
+[packages/quickjs-ffi-types/src/ffi-async.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L50)
 
 ***
 
@@ -866,7 +868,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L36)
+[packages/quickjs-ffi-types/src/ffi-async.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L37)
 
 ***
 
@@ -886,7 +888,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:70](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L70)
+[packages/quickjs-ffi-types/src/ffi-async.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L71)
 
 ***
 
@@ -908,7 +910,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:192](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L192)
+[packages/quickjs-ffi-types/src/ffi-async.ts:193](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L193)
 
 ***
 
@@ -926,7 +928,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:59](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L59)
+[packages/quickjs-ffi-types/src/ffi-async.ts:60](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L60)
 
 ***
 
@@ -946,7 +948,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:60](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L60)
+[packages/quickjs-ffi-types/src/ffi-async.ts:61](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L61)
 
 ***
 
@@ -966,7 +968,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:185](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L185)
+[packages/quickjs-ffi-types/src/ffi-async.ts:186](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L186)
 
 ***
 
@@ -980,7 +982,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L47)
+[packages/quickjs-ffi-types/src/ffi-async.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L48)
 
 ***
 
@@ -1000,7 +1002,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L72)
+[packages/quickjs-ffi-types/src/ffi-async.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L73)
 
 ***
 
@@ -1022,7 +1024,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L85)
+[packages/quickjs-ffi-types/src/ffi-async.ts:86](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L86)
 
 ***
 
@@ -1036,7 +1038,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L40)
+[packages/quickjs-ffi-types/src/ffi-async.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L41)
 
 ***
 
@@ -1056,7 +1058,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L157)
+[packages/quickjs-ffi-types/src/ffi-async.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L158)
 
 ***
 
@@ -1076,7 +1078,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L38)
+[packages/quickjs-ffi-types/src/ffi-async.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L39)
 
 ***
 
@@ -1094,7 +1096,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:198](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L198)
+[packages/quickjs-ffi-types/src/ffi-async.ts:199](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L199)
 
 ***
 
@@ -1112,7 +1114,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:200](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L200)
+[packages/quickjs-ffi-types/src/ffi-async.ts:201](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L201)
 
 ***
 
@@ -1130,7 +1132,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L39)
+[packages/quickjs-ffi-types/src/ffi-async.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L40)
 
 ***
 
@@ -1148,7 +1150,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:197](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L197)
+[packages/quickjs-ffi-types/src/ffi-async.ts:198](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L198)
 
 ***
 
@@ -1168,7 +1170,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:199](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L199)
+[packages/quickjs-ffi-types/src/ffi-async.ts:200](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L200)
 
 ***
 
@@ -1188,7 +1190,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L42)
+[packages/quickjs-ffi-types/src/ffi-async.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L43)
 
 ***
 
@@ -1208,7 +1210,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L37)
+[packages/quickjs-ffi-types/src/ffi-async.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L38)
 
 ***
 
@@ -1232,7 +1234,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:120](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L120)
+[packages/quickjs-ffi-types/src/ffi-async.ts:121](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L121)
 
 ***
 
@@ -1256,7 +1258,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L126)
+[packages/quickjs-ffi-types/src/ffi-async.ts:127](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L127)
 
 ***
 
@@ -1274,7 +1276,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:189](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L189)
+[packages/quickjs-ffi-types/src/ffi-async.ts:190](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L190)
 
 ***
 
@@ -1294,7 +1296,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L35)
+[packages/quickjs-ffi-types/src/ffi-async.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L36)
 
 ***
 
@@ -1314,7 +1316,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:180](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L180)
+[packages/quickjs-ffi-types/src/ffi-async.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L181)
 
 ***
 
@@ -1334,7 +1336,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:205](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L205)
+[packages/quickjs-ffi-types/src/ffi-async.ts:206](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L206)
 
 ***
 
@@ -1354,7 +1356,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:201](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L201)
+[packages/quickjs-ffi-types/src/ffi-async.ts:202](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L202)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSFFI.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSFFI.md
@@ -87,7 +87,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:32](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L32)
+[packages/quickjs-ffi-types/src/ffi.ts:33](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L33)
 
 ***
 
@@ -107,7 +107,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:154](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L154)
+[packages/quickjs-ffi-types/src/ffi.ts:155](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L155)
 
 ***
 
@@ -121,7 +121,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L152)
+[packages/quickjs-ffi-types/src/ffi.ts:153](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L153)
 
 ***
 
@@ -135,7 +135,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L151)
+[packages/quickjs-ffi-types/src/ffi.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L152)
 
 ***
 
@@ -149,7 +149,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L40)
+[packages/quickjs-ffi-types/src/ffi.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L41)
 
 ***
 
@@ -175,7 +175,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:122](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L122)
+[packages/quickjs-ffi-types/src/ffi.ts:123](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L123)
 
 ***
 
@@ -209,7 +209,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L111)
+[packages/quickjs-ffi-types/src/ffi.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L112)
 
 ***
 
@@ -229,7 +229,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:130](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L130)
+[packages/quickjs-ffi-types/src/ffi.ts:131](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L131)
 
 ***
 
@@ -249,7 +249,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L54)
+[packages/quickjs-ffi-types/src/ffi.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L55)
 
 ***
 
@@ -275,7 +275,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:134](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L134)
+[packages/quickjs-ffi-types/src/ffi.ts:135](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L135)
 
 ***
 
@@ -297,7 +297,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L95)
+[packages/quickjs-ffi-types/src/ffi.ts:96](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L96)
 
 ***
 
@@ -317,7 +317,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L53)
+[packages/quickjs-ffi-types/src/ffi.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L54)
 
 ***
 
@@ -335,7 +335,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L49)
+[packages/quickjs-ffi-types/src/ffi.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L50)
 
 ***
 
@@ -353,7 +353,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L47)
+[packages/quickjs-ffi-types/src/ffi.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L48)
 
 ***
 
@@ -373,7 +373,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L50)
+[packages/quickjs-ffi-types/src/ffi.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L51)
 
 ***
 
@@ -393,7 +393,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L51)
+[packages/quickjs-ffi-types/src/ffi.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L52)
 
 ***
 
@@ -413,7 +413,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L52)
+[packages/quickjs-ffi-types/src/ffi.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L53)
 
 ***
 
@@ -433,7 +433,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:76](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L76)
+[packages/quickjs-ffi-types/src/ffi.ts:77](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L77)
 
 ***
 
@@ -453,7 +453,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:80](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L80)
+[packages/quickjs-ffi-types/src/ffi.ts:81](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L81)
 
 ***
 
@@ -467,7 +467,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L44)
+[packages/quickjs-ffi-types/src/ffi.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L45)
 
 ***
 
@@ -487,7 +487,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:70](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L70)
+[packages/quickjs-ffi-types/src/ffi.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L71)
 
 ***
 
@@ -505,7 +505,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L145)
+[packages/quickjs-ffi-types/src/ffi.ts:146](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L146)
 
 ***
 
@@ -519,7 +519,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L43)
+[packages/quickjs-ffi-types/src/ffi.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L44)
 
 ***
 
@@ -541,7 +541,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:100](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L100)
+[packages/quickjs-ffi-types/src/ffi.ts:101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L101)
 
 ***
 
@@ -561,7 +561,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L72)
+[packages/quickjs-ffi-types/src/ffi.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L73)
 
 ***
 
@@ -581,7 +581,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:89](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L89)
+[packages/quickjs-ffi-types/src/ffi.ts:90](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L90)
 
 ***
 
@@ -595,7 +595,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L45)
+[packages/quickjs-ffi-types/src/ffi.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L46)
 
 ***
 
@@ -609,7 +609,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L42)
+[packages/quickjs-ffi-types/src/ffi.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L43)
 
 ***
 
@@ -629,7 +629,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:93](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L93)
+[packages/quickjs-ffi-types/src/ffi.ts:94](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L94)
 
 ***
 
@@ -647,7 +647,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:94](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L94)
+[packages/quickjs-ffi-types/src/ffi.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L95)
 
 ***
 
@@ -665,7 +665,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:63](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L63)
+[packages/quickjs-ffi-types/src/ffi.ts:64](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L64)
 
 ***
 
@@ -687,17 +687,19 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:64](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L64)
+[packages/quickjs-ffi-types/src/ffi.ts:65](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L65)
 
 ***
 
 ### QTS\_NewContext
 
-> **QTS\_NewContext**: (`rt`) => [`JSContextPointer`](../exports.md#jscontextpointer)
+> **QTS\_NewContext**: (`rt`, `intrinsics`) => [`JSContextPointer`](../exports.md#jscontextpointer)
 
 #### Parameters
 
 • **rt**: [`JSRuntimePointer`](../exports.md#jsruntimepointer)
+
+• **intrinsics**: [`IntrinsicsFlags`](../exports.md#intrinsicsflags)
 
 #### Returns
 
@@ -705,7 +707,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L48)
+[packages/quickjs-ffi-types/src/ffi.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L49)
 
 ***
 
@@ -723,7 +725,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L35)
+[packages/quickjs-ffi-types/src/ffi.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L36)
 
 ***
 
@@ -743,7 +745,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:69](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L69)
+[packages/quickjs-ffi-types/src/ffi.ts:70](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L70)
 
 ***
 
@@ -765,7 +767,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:153](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L153)
+[packages/quickjs-ffi-types/src/ffi.ts:154](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L154)
 
 ***
 
@@ -783,7 +785,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:58](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L58)
+[packages/quickjs-ffi-types/src/ffi.ts:59](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L59)
 
 ***
 
@@ -803,7 +805,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:59](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L59)
+[packages/quickjs-ffi-types/src/ffi.ts:60](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L60)
 
 ***
 
@@ -823,7 +825,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:146](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L146)
+[packages/quickjs-ffi-types/src/ffi.ts:147](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L147)
 
 ***
 
@@ -837,7 +839,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L46)
+[packages/quickjs-ffi-types/src/ffi.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L47)
 
 ***
 
@@ -857,7 +859,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L71)
+[packages/quickjs-ffi-types/src/ffi.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L72)
 
 ***
 
@@ -879,7 +881,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:84](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L84)
+[packages/quickjs-ffi-types/src/ffi.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L85)
 
 ***
 
@@ -893,7 +895,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L39)
+[packages/quickjs-ffi-types/src/ffi.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L40)
 
 ***
 
@@ -913,7 +915,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:129](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L129)
+[packages/quickjs-ffi-types/src/ffi.ts:130](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L130)
 
 ***
 
@@ -933,7 +935,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L37)
+[packages/quickjs-ffi-types/src/ffi.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L38)
 
 ***
 
@@ -951,7 +953,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L159)
+[packages/quickjs-ffi-types/src/ffi.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L160)
 
 ***
 
@@ -969,7 +971,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L161)
+[packages/quickjs-ffi-types/src/ffi.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L162)
 
 ***
 
@@ -987,7 +989,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L38)
+[packages/quickjs-ffi-types/src/ffi.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L39)
 
 ***
 
@@ -1005,7 +1007,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L158)
+[packages/quickjs-ffi-types/src/ffi.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L159)
 
 ***
 
@@ -1025,7 +1027,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L160)
+[packages/quickjs-ffi-types/src/ffi.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L161)
 
 ***
 
@@ -1045,7 +1047,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L41)
+[packages/quickjs-ffi-types/src/ffi.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L42)
 
 ***
 
@@ -1065,7 +1067,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L36)
+[packages/quickjs-ffi-types/src/ffi.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L37)
 
 ***
 
@@ -1089,7 +1091,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:105](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L105)
+[packages/quickjs-ffi-types/src/ffi.ts:106](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L106)
 
 ***
 
@@ -1107,7 +1109,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:150](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L150)
+[packages/quickjs-ffi-types/src/ffi.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L151)
 
 ***
 
@@ -1127,7 +1129,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L34)
+[packages/quickjs-ffi-types/src/ffi.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L35)
 
 ***
 
@@ -1147,7 +1149,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:141](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L141)
+[packages/quickjs-ffi-types/src/ffi.ts:142](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L142)
 
 ***
 
@@ -1167,7 +1169,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:166](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L166)
+[packages/quickjs-ffi-types/src/ffi.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L167)
 
 ***
 
@@ -1187,7 +1189,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L162)
+[packages/quickjs-ffi-types/src/ffi.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L163)
 
 ***
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -66,6 +66,7 @@ main()
     - [Packaging](#packaging)
       - [Reducing package size](#reducing-package-size)
       - [WebAssembly loading](#webassembly-loading)
+      - [quickjs-ng](#quickjs-ng)
       - [Using in the browser without a build step](#using-in-the-browser-without-a-build-step)
     - [Debugging](#debugging)
     - [Supported Platforms](#supported-platforms)
@@ -646,6 +647,12 @@ const cloudflareVariant = newVariant(baseVariant, {
 ```
 
 [newVariant]: https://github.com/justjake/quickjs-emscripten/blob/main/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+
+#### quickjs-ng
+
+[quickjs-ng/quickjs](https://github.com/quickjs-ng/quickjs) (aka quickjs-ng) is a fork of the original [bellard/quickjs](https://github.com/quickjs-ng/quickjs) under active development. It implements more EcmaScript standards and removes some of quickjs's custom language features like BigFloat.
+
+There are several variants of quickjs-ng available, and quickjs-emscripten may switch to using quickjs-ng by default in the future. See [the list of variants][core].
 
 #### Using in the browser without a build step
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSAsyncRuntime.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSAsyncRuntime.md
@@ -141,7 +141,7 @@ QuickJSWrongOwner if owned by a different runtime.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:328](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L328)
+[packages/quickjs-emscripten-core/src/runtime.ts:325](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L325)
 
 ***
 
@@ -165,7 +165,7 @@ For a human-digestible representation, see [dumpMemoryUsage](QuickJSAsyncRuntime
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:297](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L297)
+[packages/quickjs-emscripten-core/src/runtime.ts:294](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L294)
 
 ***
 
@@ -206,7 +206,7 @@ For programmatic access to this information, see [computeMemoryUsage](QuickJSAsy
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:308](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L308)
+[packages/quickjs-emscripten-core/src/runtime.ts:305](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L305)
 
 ***
 
@@ -244,7 +244,7 @@ functions or rejected promises. Those errors are available by calling
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:243](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L243)
+[packages/quickjs-emscripten-core/src/runtime.ts:240](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L240)
 
 ***
 
@@ -267,7 +267,7 @@ true if there is at least one pendingJob queued up.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:194](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L194)
+[packages/quickjs-emscripten-core/src/runtime.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L191)
 
 ***
 
@@ -316,7 +316,7 @@ See [setInterruptHandler](QuickJSAsyncRuntime.md#setinterrupthandler).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:219](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L219)
+[packages/quickjs-emscripten-core/src/runtime.ts:216](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L216)
 
 ***
 
@@ -336,7 +336,7 @@ Remove the the loader set by [setModuleLoader](QuickJSAsyncRuntime.md#setmodulel
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L181)
+[packages/quickjs-emscripten-core/src/runtime.ts:178](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L178)
 
 ***
 
@@ -364,7 +364,7 @@ The interrupt handler can be removed with [removeInterruptHandler](QuickJSAsyncR
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:207](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L207)
+[packages/quickjs-emscripten-core/src/runtime.ts:204](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L204)
 
 ***
 
@@ -392,7 +392,7 @@ See the [pull request](https://github.com/justjake/quickjs-emscripten/pull/114) 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime-asyncify.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime-asyncify.ts#L91)
+[packages/quickjs-emscripten-core/src/runtime-asyncify.ts:92](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime-asyncify.ts#L92)
 
 ***
 
@@ -417,7 +417,7 @@ To remove the limit, set to `-1`.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:282](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L282)
+[packages/quickjs-emscripten-core/src/runtime.ts:279](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L279)
 
 ***
 
@@ -446,7 +446,7 @@ The loader can be removed with [removeModuleLoader](QuickJSAsyncRuntime.md#remov
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime-asyncify.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime-asyncify.ts#L74)
+[packages/quickjs-emscripten-core/src/runtime-asyncify.ts:75](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime-asyncify.ts#L75)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSRuntime.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSRuntime.md
@@ -142,7 +142,7 @@ QuickJSWrongOwner if owned by a different runtime.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:328](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L328)
+[packages/quickjs-emscripten-core/src/runtime.ts:325](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L325)
 
 ***
 
@@ -162,7 +162,7 @@ For a human-digestible representation, see [dumpMemoryUsage](QuickJSRuntime.md#d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:297](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L297)
+[packages/quickjs-emscripten-core/src/runtime.ts:294](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L294)
 
 ***
 
@@ -203,7 +203,7 @@ For programmatic access to this information, see [computeMemoryUsage](QuickJSRun
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:308](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L308)
+[packages/quickjs-emscripten-core/src/runtime.ts:305](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L305)
 
 ***
 
@@ -237,7 +237,7 @@ functions or rejected promises. Those errors are available by calling
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:243](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L243)
+[packages/quickjs-emscripten-core/src/runtime.ts:240](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L240)
 
 ***
 
@@ -256,7 +256,7 @@ true if there is at least one pendingJob queued up.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:194](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L194)
+[packages/quickjs-emscripten-core/src/runtime.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L191)
 
 ***
 
@@ -297,7 +297,7 @@ See [setInterruptHandler](QuickJSRuntime.md#setinterrupthandler).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:219](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L219)
+[packages/quickjs-emscripten-core/src/runtime.ts:216](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L216)
 
 ***
 
@@ -313,7 +313,7 @@ Remove the the loader set by [setModuleLoader](QuickJSRuntime.md#setmoduleloader
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L181)
+[packages/quickjs-emscripten-core/src/runtime.ts:178](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L178)
 
 ***
 
@@ -337,7 +337,7 @@ The interrupt handler can be removed with [removeInterruptHandler](QuickJSRuntim
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:207](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L207)
+[packages/quickjs-emscripten-core/src/runtime.ts:204](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L204)
 
 ***
 
@@ -358,7 +358,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:316](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L316)
+[packages/quickjs-emscripten-core/src/runtime.ts:313](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L313)
 
 ***
 
@@ -379,7 +379,7 @@ To remove the limit, set to `-1`.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:282](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L282)
+[packages/quickjs-emscripten-core/src/runtime.ts:279](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L279)
 
 ***
 
@@ -404,7 +404,7 @@ The loader can be removed with [removeModuleLoader](QuickJSRuntime.md#removemodu
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/runtime.ts:172](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L172)
+[packages/quickjs-emscripten-core/src/runtime.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L169)
 
 ***
 

--- a/doc/quickjs-emscripten-core/exports.md
+++ b/doc/quickjs-emscripten-core/exports.md
@@ -18,6 +18,7 @@
   - [EitherModule](exports.md#eithermodule)
   - [ExecutePendingJobsResult](exports.md#executependingjobsresult)
   - [InterruptHandler](exports.md#interrupthandler)
+  - [Intrinsics](exports.md#intrinsics)
   - [JSBorrowedCharPointer](exports.md#jsborrowedcharpointer)
   - [JSContextPointer](exports.md#jscontextpointer)
   - [JSContextPointerPointer](exports.md#jscontextpointerpointer)
@@ -51,7 +52,9 @@
   - [VmCallResult\<VmHandle\>](exports.md#vmcallresultvmhandle)
   - [VmFunctionImplementation\<VmHandle\>](exports.md#vmfunctionimplementationvmhandle)
 - [Variables](exports.md#variables)
+  - [DefaultIntrinsics](exports.md#defaultintrinsics)
   - [EvalFlags](exports.md#evalflags)
+  - [IntrinsicsFlags](exports.md#intrinsicsflags)
 - [Functions](exports.md#functions)
   - [assertSync()](exports.md#assertsync)
   - [isFail()](exports.md#isfail)
@@ -150,7 +153,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:66
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:455
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 
@@ -160,7 +163,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:455
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:269
+packages/quickjs-ffi-types/dist/index.d.ts:292
 
 ***
 
@@ -202,6 +205,88 @@ Determines if a VM's execution should be interrupted.
 #### Source
 
 [packages/quickjs-emscripten-core/src/runtime.ts:28](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/runtime.ts#L28)
+
+***
+
+### Intrinsics
+
+> **Intrinsics**: `Object`
+
+Language features that can be enabled or disabled in a QuickJSContext.
+
+#### See
+
+[ContextOptions](interfaces/ContextOptions.md)
+
+#### Type declaration
+
+##### BaseObjects?
+
+> **BaseObjects**?: `boolean`
+
+##### BigDecimal?
+
+> **BigDecimal**?: `boolean`
+
+##### BigFloat?
+
+> **BigFloat**?: `boolean`
+
+##### BigInt?
+
+> **BigInt**?: `boolean`
+
+##### BignumExt?
+
+> **BignumExt**?: `boolean`
+
+##### Date?
+
+> **Date**?: `boolean`
+
+##### Eval?
+
+> **Eval**?: `boolean`
+
+##### JSON?
+
+> **JSON**?: `boolean`
+
+##### MapSet?
+
+> **MapSet**?: `boolean`
+
+##### OperatorOverloading?
+
+> **OperatorOverloading**?: `boolean`
+
+##### Promise?
+
+> **Promise**?: `boolean`
+
+##### Proxy?
+
+> **Proxy**?: `boolean`
+
+##### RegExp?
+
+> **RegExp**?: `boolean`
+
+##### RegExpCompiler?
+
+> **RegExpCompiler**?: `boolean`
+
+##### StringNormalize?
+
+> **StringNormalize**?: `boolean`
+
+##### TypedArrays?
+
+> **TypedArrays**?: `boolean`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/types.ts:145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L145)
 
 ***
 
@@ -260,7 +345,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:67](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L67)
+[packages/quickjs-emscripten-core/src/types.ts:68](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L68)
 
 ***
 
@@ -270,7 +355,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:68](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L68)
+[packages/quickjs-emscripten-core/src/types.ts:69](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L69)
 
 ***
 
@@ -280,7 +365,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:66](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L66)
+[packages/quickjs-emscripten-core/src/types.ts:67](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L67)
 
 ***
 
@@ -290,7 +375,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L85)
+[packages/quickjs-emscripten-core/src/types.ts:86](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L86)
 
 ***
 
@@ -300,7 +385,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:86](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L86)
+[packages/quickjs-emscripten-core/src/types.ts:87](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L87)
 
 ***
 
@@ -310,7 +395,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:84](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L84)
+[packages/quickjs-emscripten-core/src/types.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L85)
 
 ***
 
@@ -346,7 +431,7 @@ You can do so from Javascript by calling the .dispose() method.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L42)
+[packages/quickjs-emscripten-core/src/types.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L43)
 
 ***
 
@@ -365,7 +450,7 @@ quickjs-emscripten takes care of disposing JSValueConst references.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:25](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L25)
+[packages/quickjs-emscripten-core/src/types.ts:26](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L26)
 
 ***
 
@@ -480,7 +565,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:71
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:238](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L238)
+[packages/quickjs-emscripten-core/src/types.ts:281](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L281)
 
 ***
 
@@ -546,7 +631,7 @@ You must dispose of any handles you create by calling the `.dispose()` method.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L51)
+[packages/quickjs-emscripten-core/src/types.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L52)
 
 ***
 
@@ -569,7 +654,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:454
+packages/quickjs-ffi-types/dist/index.d.ts:477
 
 ***
 
@@ -582,7 +667,7 @@ be disposed.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:13](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L13)
+[packages/quickjs-emscripten-core/src/types.ts:14](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L14)
 
 ***
 
@@ -657,6 +742,64 @@ It should not retain a reference to its return value or thrown error.
 
 ## Variables
 
+### DefaultIntrinsics
+
+> **`const`** **DefaultIntrinsics**: `Readonly`\<`Object`\>
+
+The default [Intrinsics](exports.md#intrinsics) language features enabled in a QuickJSContext.
+
+#### See
+
+[ContextOptions](interfaces/ContextOptions.md)
+
+#### Type declaration
+
+##### BaseObjects
+
+> **`readonly`** **BaseObjects**: `true` = `true`
+
+##### Date
+
+> **`readonly`** **Date**: `true` = `true`
+
+##### Eval
+
+> **`readonly`** **Eval**: `true` = `true`
+
+##### JSON
+
+> **`readonly`** **JSON**: `true` = `true`
+
+##### MapSet
+
+> **`readonly`** **MapSet**: `true` = `true`
+
+##### Promise
+
+> **`readonly`** **Promise**: `true` = `true`
+
+##### Proxy
+
+> **`readonly`** **Proxy**: `true` = `true`
+
+##### RegExp
+
+> **`readonly`** **RegExp**: `true` = `true`
+
+##### StringNormalize
+
+> **`readonly`** **StringNormalize**: `true` = `true`
+
+##### TypedArrays
+
+> **`readonly`** **TypedArrays**: `true` = `true`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/types.ts:172](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L172)
+
+***
+
 ### EvalFlags
 
 > **EvalFlags**: `Object`
@@ -667,13 +810,13 @@ Bitfield options for JS_Eval() C function.
 
 ##### JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER
 
-> **JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER**: `number`
 
 don't include the stack frames before this eval in the Error() backtraces
 
 ##### JS\_EVAL\_FLAG\_COMPILE\_ONLY
 
-> **JS\_EVAL\_FLAG\_COMPILE\_ONLY**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_COMPILE\_ONLY**: `number`
 
 compile but do not run. The result is an object with a
 JS_TAG_FUNCTION_BYTECODE or JS_TAG_MODULE tag. It can be executed
@@ -681,47 +824,125 @@ with JS_EvalFunction().
 
 ##### JS\_EVAL\_FLAG\_STRICT
 
-> **JS\_EVAL\_FLAG\_STRICT**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_STRICT**: `number`
 
 force 'strict' mode
 
 ##### JS\_EVAL\_FLAG\_STRIP
 
-> **JS\_EVAL\_FLAG\_STRIP**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_STRIP**: `number`
 
 force 'strip' mode
 
 ##### JS\_EVAL\_TYPE\_DIRECT
 
-> **JS\_EVAL\_TYPE\_DIRECT**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_DIRECT**: `number`
 
 direct call (internal use)
 
 ##### JS\_EVAL\_TYPE\_GLOBAL
 
-> **JS\_EVAL\_TYPE\_GLOBAL**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_GLOBAL**: `number`
 
 global code (default)
 
 ##### JS\_EVAL\_TYPE\_INDIRECT
 
-> **JS\_EVAL\_TYPE\_INDIRECT**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_INDIRECT**: `number`
 
 indirect call (internal use)
 
 ##### JS\_EVAL\_TYPE\_MASK
 
-> **JS\_EVAL\_TYPE\_MASK**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_MASK**: `number`
 
 ##### JS\_EVAL\_TYPE\_MODULE
 
-> **JS\_EVAL\_TYPE\_MODULE**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_MODULE**: `number`
 
 module code
 
 #### Source
 
 packages/quickjs-ffi-types/dist/index.d.ts:89
+
+***
+
+### IntrinsicsFlags
+
+> **IntrinsicsFlags**: `Object`
+
+Bitfield options for QTS_NewContext intrinsices
+
+#### Type declaration
+
+##### BaseObjects
+
+> **`readonly`** **BaseObjects**: `number`
+
+##### BigDecimal
+
+> **`readonly`** **BigDecimal**: `number`
+
+##### BigFloat
+
+> **`readonly`** **BigFloat**: `number`
+
+##### BigInt
+
+> **`readonly`** **BigInt**: `number`
+
+##### BignumExt
+
+> **`readonly`** **BignumExt**: `number`
+
+##### Date
+
+> **`readonly`** **Date**: `number`
+
+##### Eval
+
+> **`readonly`** **Eval**: `number`
+
+##### JSON
+
+> **`readonly`** **JSON**: `number`
+
+##### MapSet
+
+> **`readonly`** **MapSet**: `number`
+
+##### OperatorOverloading
+
+> **`readonly`** **OperatorOverloading**: `number`
+
+##### Promise
+
+> **`readonly`** **Promise**: `number`
+
+##### Proxy
+
+> **`readonly`** **Proxy**: `number`
+
+##### RegExp
+
+> **`readonly`** **RegExp**: `number`
+
+##### RegExpCompiler
+
+> **`readonly`** **RegExpCompiler**: `number`
+
+##### StringNormalize
+
+> **`readonly`** **StringNormalize**: `number`
+
+##### TypedArrays
+
+> **`readonly`** **TypedArrays**: `number`
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:117
 
 ## Functions
 

--- a/doc/quickjs-emscripten-core/interfaces/AsyncRuntimeOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/AsyncRuntimeOptions.md
@@ -35,7 +35,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L117)
+[packages/quickjs-emscripten-core/src/types.ts:118](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L118)
 
 ***
 
@@ -49,7 +49,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L111)
+[packages/quickjs-emscripten-core/src/types.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L112)
 
 ***
 
@@ -63,7 +63,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L112)
+[packages/quickjs-emscripten-core/src/types.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L113)
 
 ***
 
@@ -77,7 +77,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L113)
+[packages/quickjs-emscripten-core/src/types.ts:114](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L114)
 
 ***
 
@@ -87,7 +87,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:135](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L135)
+[packages/quickjs-emscripten-core/src/types.ts:136](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L136)
 
 ***
 
@@ -101,7 +101,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L115)
+[packages/quickjs-emscripten-core/src/types.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L116)
 
 ***
 
@@ -115,7 +115,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L116)
+[packages/quickjs-emscripten-core/src/types.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L117)
 
 ***
 
@@ -129,7 +129,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:118](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L118)
+[packages/quickjs-emscripten-core/src/types.ts:119](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L119)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/ContextEvalOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/ContextEvalOptions.md
@@ -25,7 +25,7 @@ don't include the stack frames before this eval in the Error() backtraces
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:214](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L214)
+[packages/quickjs-emscripten-core/src/types.ts:257](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L257)
 
 ***
 
@@ -39,7 +39,7 @@ with JS_EvalFunction().
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:212](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L212)
+[packages/quickjs-emscripten-core/src/types.ts:255](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L255)
 
 ***
 
@@ -51,7 +51,7 @@ Force "strict" mode
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:204](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L204)
+[packages/quickjs-emscripten-core/src/types.ts:247](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L247)
 
 ***
 
@@ -63,7 +63,7 @@ Force "strip" mode
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:206](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L206)
+[packages/quickjs-emscripten-core/src/types.ts:249](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L249)
 
 ***
 
@@ -75,7 +75,7 @@ Global code (default)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:202](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L202)
+[packages/quickjs-emscripten-core/src/types.ts:245](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L245)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/ContextOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/ContextOptions.md
@@ -6,6 +6,9 @@
 
 # Interface: ContextOptions
 
+Options for creating a [QuickJSContext](../classes/QuickJSContext.md) or [QuickJSAsyncContext](../classes/QuickJSAsyncContext.md)
+Pass to [QuickJSRuntime#newContext](../classes/QuickJSRuntime.md#newcontext).
+
 ## Contents
 
 - [Properties](ContextOptions.md#properties)
@@ -15,15 +18,26 @@
 
 ### intrinsics?
 
-> **intrinsics**?: *typeof* `DefaultIntrinsics`
+> **intrinsics**?: [`Intrinsics`](../exports.md#intrinsics)
 
 What built-in objects and language features to enable?
 If unset, the default intrinsics will be used.
 To omit all intrinsics, pass an empty array.
 
+To remove a specific intrinsic, but retain the other defaults,
+override it from [DefaultIntrinsics](../exports.md#defaultintrinsics)
+```ts
+const contextWithoutDateOrEval = runtime.newContext({
+  intrinsics: {
+    ...DefaultIntrinsics,
+    Date: false,
+  }
+})
+```
+
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:185](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L185)
+[packages/quickjs-emscripten-core/src/types.ts:228](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L228)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModule.md
@@ -48,7 +48,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:226
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -58,7 +58,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:226
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:217
+packages/quickjs-ffi-types/dist/index.d.ts:240
 
 ***
 
@@ -68,7 +68,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:217
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:218
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 
@@ -78,7 +78,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:218
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:216
+packages/quickjs-ffi-types/dist/index.d.ts:239
 
 ***
 
@@ -88,7 +88,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:216
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:222
+packages/quickjs-ffi-types/dist/index.d.ts:245
 
 ***
 
@@ -98,7 +98,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:222
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:223
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -108,7 +108,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:223
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:220
+packages/quickjs-ffi-types/dist/index.d.ts:243
 
 ***
 
@@ -118,7 +118,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:220
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:221
+packages/quickjs-ffi-types/dist/index.d.ts:244
 
 ***
 
@@ -128,7 +128,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:221
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:219
+packages/quickjs-ffi-types/dist/index.d.ts:242
 
 ***
 
@@ -138,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:219
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:225
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -148,7 +148,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:225
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:224
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -164,7 +164,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -187,7 +187,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:234
 
 ***
 
@@ -205,7 +205,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:211
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:214
+packages/quickjs-ffi-types/dist/index.d.ts:237
 
 ***
 
@@ -223,7 +223,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:214
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:236
 
 ***
 
@@ -256,7 +256,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:238
 
 ***
 
@@ -282,7 +282,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -300,7 +300,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:187
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:212
+packages/quickjs-ffi-types/dist/index.d.ts:235
 
 ***
 
@@ -344,7 +344,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -368,7 +368,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 
@@ -393,7 +393,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:206
+packages/quickjs-ffi-types/dist/index.d.ts:229
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoader.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:271
+packages/quickjs-ffi-types/dist/index.d.ts:294
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoaderOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoaderOptions.md
@@ -34,7 +34,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -56,7 +56,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -96,7 +96,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -116,7 +116,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/JSModuleLoader.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSModuleLoader.md
@@ -22,7 +22,7 @@ Load module (sync)
 
 ## Source
 
-[packages/quickjs-emscripten-core/src/types.ts:81](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L81)
+[packages/quickjs-emscripten-core/src/types.ts:82](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L82)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/JSModuleLoaderAsync.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSModuleLoaderAsync.md
@@ -22,7 +22,7 @@ Load module (async)
 
 ## Source
 
-[packages/quickjs-emscripten-core/src/types.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L74)
+[packages/quickjs-emscripten-core/src/types.ts:75](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L75)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/JSModuleNormalizer.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSModuleNormalizer.md
@@ -26,7 +26,7 @@
 
 ## Source
 
-[packages/quickjs-emscripten-core/src/types.ts:98](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L98)
+[packages/quickjs-emscripten-core/src/types.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L99)
 
 > **JSModuleNormalizer**(`baseModuleName`, `requestedName`, `vm`): [`JSModuleNormalizeResult`](../exports.md#jsmodulenormalizeresult) \| `Promise`\<[`JSModuleNormalizeResult`](../exports.md#jsmodulenormalizeresult)\>
 
@@ -44,7 +44,7 @@
 
 ## Source
 
-[packages/quickjs-emscripten-core/src/types.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L91)
+[packages/quickjs-emscripten-core/src/types.ts:92](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L92)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/JSModuleNormalizerAsync.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSModuleNormalizerAsync.md
@@ -26,7 +26,7 @@
 
 ## Source
 
-[packages/quickjs-emscripten-core/src/types.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L91)
+[packages/quickjs-emscripten-core/src/types.ts:92](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L92)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -54,7 +54,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:226
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -68,7 +68,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:226
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:217
+packages/quickjs-ffi-types/dist/index.d.ts:240
 
 ***
 
@@ -82,7 +82,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:217
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:218
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 
@@ -96,7 +96,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:218
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:216
+packages/quickjs-ffi-types/dist/index.d.ts:239
 
 ***
 
@@ -110,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:216
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:222
+packages/quickjs-ffi-types/dist/index.d.ts:245
 
 ***
 
@@ -124,7 +124,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:222
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:223
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -138,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:223
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:220
+packages/quickjs-ffi-types/dist/index.d.ts:243
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:220
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:221
+packages/quickjs-ffi-types/dist/index.d.ts:244
 
 ***
 
@@ -166,7 +166,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:221
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:219
+packages/quickjs-ffi-types/dist/index.d.ts:242
 
 ***
 
@@ -180,7 +180,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:219
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:225
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -194,7 +194,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:225
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:224
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -204,7 +204,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:224
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:267
+packages/quickjs-ffi-types/dist/index.d.ts:290
 
 ***
 
@@ -218,7 +218,7 @@ Implement this field
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:266
+packages/quickjs-ffi-types/dist/index.d.ts:289
 
 ***
 
@@ -234,7 +234,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -261,7 +261,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:234
 
 ***
 
@@ -283,7 +283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:211
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:214
+packages/quickjs-ffi-types/dist/index.d.ts:237
 
 ***
 
@@ -305,7 +305,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:214
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:236
 
 ***
 
@@ -342,7 +342,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:238
 
 ***
 
@@ -368,7 +368,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -390,7 +390,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:187
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:212
+packages/quickjs-ffi-types/dist/index.d.ts:235
 
 ***
 
@@ -434,7 +434,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -458,7 +458,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 
@@ -487,7 +487,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:206
+packages/quickjs-ffi-types/dist/index.d.ts:229
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncFFI.md
@@ -94,7 +94,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:352
+packages/quickjs-ffi-types/dist/index.d.ts:375
 
 ***
 
@@ -114,7 +114,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:352
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -128,7 +128,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -142,7 +142,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:430
 
 ***
 
@@ -156,7 +156,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:382
 
 ***
 
@@ -182,7 +182,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:359
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:419
 
 ***
 
@@ -208,7 +208,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:420
 
 ***
 
@@ -242,7 +242,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:418
 
 ***
 
@@ -262,7 +262,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:422
 
 ***
 
@@ -282,7 +282,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:423
 
 ***
 
@@ -302,7 +302,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:373
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -328,7 +328,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:373
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -354,7 +354,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -376,7 +376,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -398,7 +398,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:413
 
 ***
 
@@ -418,7 +418,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:372
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -436,7 +436,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:372
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:368
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -454,7 +454,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:368
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:389
 
 ***
 
@@ -474,7 +474,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:366
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:369
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -494,7 +494,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:369
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:370
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -514,7 +514,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:370
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:371
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -534,7 +534,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:371
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -554,7 +554,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -568,7 +568,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:386
 
 ***
 
@@ -588,7 +588,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:363
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -606,7 +606,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -620,7 +620,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:385
 
 ***
 
@@ -642,7 +642,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:414
 
 ***
 
@@ -664,7 +664,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:415
 
 ***
 
@@ -684,7 +684,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -704,7 +704,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -724,7 +724,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -738,7 +738,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:387
 
 ***
 
@@ -752,7 +752,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:364
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:384
 
 ***
 
@@ -772,7 +772,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -790,7 +790,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 
@@ -808,7 +808,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:376
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -830,17 +830,19 @@ packages/quickjs-ffi-types/dist/index.d.ts:376
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:377
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
 ### QTS\_NewContext
 
-> **QTS\_NewContext**: (`rt`) => [`JSContextPointer`](../exports.md#jscontextpointer)
+> **QTS\_NewContext**: (`rt`, `intrinsics`) => [`JSContextPointer`](../exports.md#jscontextpointer)
 
 #### Parameters
 
 • **rt**: [`JSRuntimePointer`](../exports.md#jsruntimepointer)
+
+• **intrinsics**: [`IntrinsicsFlags`](../exports.md#intrinsicsflags)
 
 #### Returns
 
@@ -848,7 +850,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:377
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:367
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -866,7 +868,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:367
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:377
 
 ***
 
@@ -886,7 +888,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:354
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:378
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -908,7 +910,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:378
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:432
 
 ***
 
@@ -926,7 +928,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:374
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -946,7 +948,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:374
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:375
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -966,7 +968,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:375
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
@@ -980,7 +982,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:388
 
 ***
 
@@ -1000,7 +1002,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:365
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -1022,7 +1024,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -1036,7 +1038,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:381
 
 ***
 
@@ -1056,7 +1058,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:421
 
 ***
 
@@ -1076,7 +1078,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:379
 
 ***
 
@@ -1094,7 +1096,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:356
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -1112,7 +1114,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -1130,7 +1132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:380
 
 ***
 
@@ -1148,7 +1150,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:357
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -1168,7 +1170,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -1188,7 +1190,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:383
 
 ***
 
@@ -1208,7 +1210,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:378
 
 ***
 
@@ -1232,7 +1234,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:355
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:416
 
 ***
 
@@ -1256,7 +1258,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:417
 
 ***
 
@@ -1274,7 +1276,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -1294,7 +1296,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:376
 
 ***
 
@@ -1314,7 +1316,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -1334,7 +1336,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -1354,7 +1356,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to newQuickJSWASMModule or newQuickJSAsyncWASMModule.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:451
+packages/quickjs-ffi-types/dist/index.d.ts:474
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:451
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:452
+packages/quickjs-ffi-types/dist/index.d.ts:475
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:452
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:450
+packages/quickjs-ffi-types/dist/index.d.ts:473
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSEmscriptenModule.md
@@ -54,7 +54,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:226
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -68,7 +68,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:226
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:217
+packages/quickjs-ffi-types/dist/index.d.ts:240
 
 ***
 
@@ -82,7 +82,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:217
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:218
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 
@@ -96,7 +96,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:218
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:216
+packages/quickjs-ffi-types/dist/index.d.ts:239
 
 ***
 
@@ -110,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:216
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:222
+packages/quickjs-ffi-types/dist/index.d.ts:245
 
 ***
 
@@ -124,7 +124,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:222
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:223
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -138,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:223
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:220
+packages/quickjs-ffi-types/dist/index.d.ts:243
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:220
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:221
+packages/quickjs-ffi-types/dist/index.d.ts:244
 
 ***
 
@@ -166,7 +166,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:221
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:219
+packages/quickjs-ffi-types/dist/index.d.ts:242
 
 ***
 
@@ -180,7 +180,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:219
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:225
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -194,7 +194,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:225
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:224
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -204,7 +204,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:224
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:262
+packages/quickjs-ffi-types/dist/index.d.ts:285
 
 ***
 
@@ -214,7 +214,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:262
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:261
+packages/quickjs-ffi-types/dist/index.d.ts:284
 
 ***
 
@@ -230,7 +230,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -257,7 +257,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:234
 
 ***
 
@@ -279,7 +279,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:211
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:214
+packages/quickjs-ffi-types/dist/index.d.ts:237
 
 ***
 
@@ -301,7 +301,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:214
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:236
 
 ***
 
@@ -338,7 +338,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:238
 
 ***
 
@@ -364,7 +364,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -386,7 +386,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:187
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:212
+packages/quickjs-ffi-types/dist/index.d.ts:235
 
 ***
 
@@ -430,7 +430,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -454,7 +454,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 
@@ -483,7 +483,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:206
+packages/quickjs-ffi-types/dist/index.d.ts:229
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSFFI.md
@@ -87,7 +87,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:283
+packages/quickjs-ffi-types/dist/index.d.ts:306
 
 ***
 
@@ -107,7 +107,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:283
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:334
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -121,7 +121,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:334
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:332
+packages/quickjs-ffi-types/dist/index.d.ts:355
 
 ***
 
@@ -135,7 +135,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:332
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:331
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -149,7 +149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:331
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:290
+packages/quickjs-ffi-types/dist/index.d.ts:313
 
 ***
 
@@ -175,7 +175,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:290
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:323
+packages/quickjs-ffi-types/dist/index.d.ts:346
 
 ***
 
@@ -209,7 +209,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:323
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:322
+packages/quickjs-ffi-types/dist/index.d.ts:345
 
 ***
 
@@ -229,7 +229,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:322
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:325
+packages/quickjs-ffi-types/dist/index.d.ts:348
 
 ***
 
@@ -249,7 +249,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:325
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:304
+packages/quickjs-ffi-types/dist/index.d.ts:327
 
 ***
 
@@ -275,7 +275,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:304
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:326
+packages/quickjs-ffi-types/dist/index.d.ts:349
 
 ***
 
@@ -297,7 +297,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:326
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:319
+packages/quickjs-ffi-types/dist/index.d.ts:342
 
 ***
 
@@ -317,7 +317,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:319
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:303
+packages/quickjs-ffi-types/dist/index.d.ts:326
 
 ***
 
@@ -335,7 +335,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:303
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:299
+packages/quickjs-ffi-types/dist/index.d.ts:322
 
 ***
 
@@ -353,7 +353,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:299
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:297
+packages/quickjs-ffi-types/dist/index.d.ts:320
 
 ***
 
@@ -373,7 +373,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:297
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:300
+packages/quickjs-ffi-types/dist/index.d.ts:323
 
 ***
 
@@ -393,7 +393,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:300
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:301
+packages/quickjs-ffi-types/dist/index.d.ts:324
 
 ***
 
@@ -413,7 +413,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:301
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:302
+packages/quickjs-ffi-types/dist/index.d.ts:325
 
 ***
 
@@ -433,7 +433,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:302
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:313
+packages/quickjs-ffi-types/dist/index.d.ts:336
 
 ***
 
@@ -453,7 +453,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:313
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:314
+packages/quickjs-ffi-types/dist/index.d.ts:337
 
 ***
 
@@ -467,7 +467,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:314
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:294
+packages/quickjs-ffi-types/dist/index.d.ts:317
 
 ***
 
@@ -487,7 +487,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:294
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:310
+packages/quickjs-ffi-types/dist/index.d.ts:333
 
 ***
 
@@ -505,7 +505,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:310
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:328
+packages/quickjs-ffi-types/dist/index.d.ts:351
 
 ***
 
@@ -519,7 +519,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:328
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
+packages/quickjs-ffi-types/dist/index.d.ts:316
 
 ***
 
@@ -541,7 +541,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:293
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:320
+packages/quickjs-ffi-types/dist/index.d.ts:343
 
 ***
 
@@ -561,7 +561,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:320
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:312
+packages/quickjs-ffi-types/dist/index.d.ts:335
 
 ***
 
@@ -581,7 +581,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:312
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:316
+packages/quickjs-ffi-types/dist/index.d.ts:339
 
 ***
 
@@ -595,7 +595,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:316
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:295
+packages/quickjs-ffi-types/dist/index.d.ts:318
 
 ***
 
@@ -609,7 +609,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:295
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:315
 
 ***
 
@@ -629,7 +629,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:292
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:317
+packages/quickjs-ffi-types/dist/index.d.ts:340
 
 ***
 
@@ -647,7 +647,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:317
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:318
+packages/quickjs-ffi-types/dist/index.d.ts:341
 
 ***
 
@@ -665,7 +665,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:318
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:307
+packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ***
 
@@ -687,17 +687,19 @@ packages/quickjs-ffi-types/dist/index.d.ts:307
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:308
+packages/quickjs-ffi-types/dist/index.d.ts:331
 
 ***
 
 ### QTS\_NewContext
 
-> **QTS\_NewContext**: (`rt`) => [`JSContextPointer`](../exports.md#jscontextpointer)
+> **QTS\_NewContext**: (`rt`, `intrinsics`) => [`JSContextPointer`](../exports.md#jscontextpointer)
 
 #### Parameters
 
 • **rt**: [`JSRuntimePointer`](../exports.md#jsruntimepointer)
+
+• **intrinsics**: [`IntrinsicsFlags`](../exports.md#intrinsicsflags)
 
 #### Returns
 
@@ -705,7 +707,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:308
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:298
+packages/quickjs-ffi-types/dist/index.d.ts:321
 
 ***
 
@@ -723,7 +725,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:298
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:285
+packages/quickjs-ffi-types/dist/index.d.ts:308
 
 ***
 
@@ -743,7 +745,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:285
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:309
+packages/quickjs-ffi-types/dist/index.d.ts:332
 
 ***
 
@@ -765,7 +767,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:309
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:333
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -783,7 +785,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:333
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:305
+packages/quickjs-ffi-types/dist/index.d.ts:328
 
 ***
 
@@ -803,7 +805,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:305
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:306
+packages/quickjs-ffi-types/dist/index.d.ts:329
 
 ***
 
@@ -823,7 +825,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:306
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:329
+packages/quickjs-ffi-types/dist/index.d.ts:352
 
 ***
 
@@ -837,7 +839,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:329
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:296
+packages/quickjs-ffi-types/dist/index.d.ts:319
 
 ***
 
@@ -857,7 +859,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:296
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:311
+packages/quickjs-ffi-types/dist/index.d.ts:334
 
 ***
 
@@ -879,7 +881,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:311
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:315
+packages/quickjs-ffi-types/dist/index.d.ts:338
 
 ***
 
@@ -893,7 +895,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:315
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:289
+packages/quickjs-ffi-types/dist/index.d.ts:312
 
 ***
 
@@ -913,7 +915,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:289
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:324
+packages/quickjs-ffi-types/dist/index.d.ts:347
 
 ***
 
@@ -933,7 +935,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:324
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:287
+packages/quickjs-ffi-types/dist/index.d.ts:310
 
 ***
 
@@ -951,7 +953,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:287
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:336
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -969,7 +971,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:336
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:338
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -987,7 +989,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:338
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:311
 
 ***
 
@@ -1005,7 +1007,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:335
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -1025,7 +1027,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:335
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:337
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -1045,7 +1047,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:337
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:291
+packages/quickjs-ffi-types/dist/index.d.ts:314
 
 ***
 
@@ -1065,7 +1067,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:291
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:286
+packages/quickjs-ffi-types/dist/index.d.ts:309
 
 ***
 
@@ -1089,7 +1091,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:286
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:321
+packages/quickjs-ffi-types/dist/index.d.ts:344
 
 ***
 
@@ -1107,7 +1109,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:321
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:330
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -1127,7 +1129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:284
+packages/quickjs-ffi-types/dist/index.d.ts:307
 
 ***
 
@@ -1147,7 +1149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:284
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:327
+packages/quickjs-ffi-types/dist/index.d.ts:350
 
 ***
 
@@ -1167,7 +1169,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:327
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:340
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -1187,7 +1189,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:340
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:339
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to newQuickJSWASMModule or newQuickJSAsyncWASMModule.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:460
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:461
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:459
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/RuntimeOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/RuntimeOptions.md
@@ -35,7 +35,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L117)
+[packages/quickjs-emscripten-core/src/types.ts:118](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L118)
 
 ***
 
@@ -49,7 +49,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L111)
+[packages/quickjs-emscripten-core/src/types.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L112)
 
 ***
 
@@ -63,7 +63,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L112)
+[packages/quickjs-emscripten-core/src/types.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L113)
 
 ***
 
@@ -77,7 +77,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L113)
+[packages/quickjs-emscripten-core/src/types.ts:114](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L114)
 
 ***
 
@@ -87,7 +87,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:131](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L131)
+[packages/quickjs-emscripten-core/src/types.ts:132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L132)
 
 ***
 
@@ -101,7 +101,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L115)
+[packages/quickjs-emscripten-core/src/types.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L116)
 
 ***
 
@@ -115,7 +115,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L116)
+[packages/quickjs-emscripten-core/src/types.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L117)
 
 ***
 
@@ -129,7 +129,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:118](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L118)
+[packages/quickjs-emscripten-core/src/types.ts:119](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L119)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/RuntimeOptionsBase.md
+++ b/doc/quickjs-emscripten-core/interfaces/RuntimeOptionsBase.md
@@ -31,7 +31,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L117)
+[packages/quickjs-emscripten-core/src/types.ts:118](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L118)
 
 ***
 
@@ -41,7 +41,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L111)
+[packages/quickjs-emscripten-core/src/types.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L112)
 
 ***
 
@@ -51,7 +51,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L112)
+[packages/quickjs-emscripten-core/src/types.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L113)
 
 ***
 
@@ -61,7 +61,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L113)
+[packages/quickjs-emscripten-core/src/types.ts:114](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L114)
 
 ***
 
@@ -71,7 +71,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L115)
+[packages/quickjs-emscripten-core/src/types.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L116)
 
 ***
 
@@ -81,7 +81,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L116)
+[packages/quickjs-emscripten-core/src/types.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L117)
 
 ***
 
@@ -91,7 +91,7 @@
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:118](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L118)
+[packages/quickjs-emscripten-core/src/types.ts:119](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L119)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/SourceMapData.md
+++ b/doc/quickjs-emscripten-core/interfaces/SourceMapData.md
@@ -22,7 +22,7 @@
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:145
+packages/quickjs-ffi-types/dist/index.d.ts:168
 
 ***
 
@@ -32,7 +32,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:145
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:144
+packages/quickjs-ffi-types/dist/index.d.ts:167
 
 ***
 
@@ -42,7 +42,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:144
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:143
+packages/quickjs-ffi-types/dist/index.d.ts:166
 
 ***
 
@@ -52,7 +52,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:143
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:142
+packages/quickjs-ffi-types/dist/index.d.ts:165
 
 ***
 

--- a/doc/quickjs-emscripten-core/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten-core/namespaces/errors/README.md
@@ -17,6 +17,7 @@ Collects the informative errors this library may throw.
 - [QuickJSEmscriptenModuleError](classes/QuickJSEmscriptenModuleError.md)
 - [QuickJSMemoryLeakDetected](classes/QuickJSMemoryLeakDetected.md)
 - [QuickJSNotImplemented](classes/QuickJSNotImplemented.md)
+- [QuickJSUnknownIntrinsic](classes/QuickJSUnknownIntrinsic.md)
 - [QuickJSUnwrapError](classes/QuickJSUnwrapError.md)
 - [QuickJSUseAfterFree](classes/QuickJSUseAfterFree.md)
 - [QuickJSWrongOwner](classes/QuickJSWrongOwner.md)

--- a/doc/quickjs-emscripten-core/namespaces/errors/classes/QuickJSUnknownIntrinsic.md
+++ b/doc/quickjs-emscripten-core/namespaces/errors/classes/QuickJSUnknownIntrinsic.md
@@ -1,0 +1,80 @@
+[quickjs-emscripten](../../../../packages.md) • **quickjs-emscripten-core** • [Readme](../../../README.md) \| [Exports](../../../exports.md)
+
+***
+
+[quickjs-emscripten](../../../../packages.md) / [quickjs-emscripten-core](../../../exports.md) / [errors](../README.md) / QuickJSUnknownIntrinsic
+
+# Class: QuickJSUnknownIntrinsic
+
+## Contents
+
+- [Extends](QuickJSUnknownIntrinsic.md#extends)
+- [Constructors](QuickJSUnknownIntrinsic.md#constructors)
+  - [new QuickJSUnknownIntrinsic(message)](QuickJSUnknownIntrinsic.md#new-quickjsunknownintrinsicmessage)
+  - [new QuickJSUnknownIntrinsic(message)](QuickJSUnknownIntrinsic.md#new-quickjsunknownintrinsicmessage-1)
+- [Properties](QuickJSUnknownIntrinsic.md#properties)
+  - [name](QuickJSUnknownIntrinsic.md#name)
+
+## Extends
+
+- `TypeError`
+
+## Constructors
+
+### new QuickJSUnknownIntrinsic(message)
+
+> **new QuickJSUnknownIntrinsic**(`message`?): [`QuickJSUnknownIntrinsic`](QuickJSUnknownIntrinsic.md)
+
+#### Parameters
+
+• **message?**: `string`
+
+#### Returns
+
+[`QuickJSUnknownIntrinsic`](QuickJSUnknownIntrinsic.md)
+
+#### Inherited from
+
+`TypeError.constructor`
+
+#### Source
+
+node\_modules/typescript/lib/lib.es5.d.ts:1136
+
+### new QuickJSUnknownIntrinsic(message)
+
+> **new QuickJSUnknownIntrinsic**(`message`?): [`QuickJSUnknownIntrinsic`](QuickJSUnknownIntrinsic.md)
+
+#### Parameters
+
+• **message?**: `string`
+
+#### Returns
+
+[`QuickJSUnknownIntrinsic`](QuickJSUnknownIntrinsic.md)
+
+#### Inherited from
+
+`TypeError.constructor`
+
+#### Source
+
+node\_modules/typescript/lib/lib.es5.d.ts:1081
+
+## Properties
+
+### name
+
+> **name**: `string` = `"QuickJSUnknownIntrinsic"`
+
+#### Overrides
+
+`TypeError.name`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/errors.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/errors.ts#L45)
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten/README.md
+++ b/doc/quickjs-emscripten/README.md
@@ -66,6 +66,7 @@ main()
     - [Packaging](#packaging)
       - [Reducing package size](#reducing-package-size)
       - [WebAssembly loading](#webassembly-loading)
+      - [quickjs-ng](#quickjs-ng)
       - [Using in the browser without a build step](#using-in-the-browser-without-a-build-step)
     - [Debugging](#debugging)
     - [Supported Platforms](#supported-platforms)
@@ -666,6 +667,12 @@ const cloudflareVariant = newVariant(baseVariant, {
 ```
 
 [newVariant]: https://github.com/justjake/quickjs-emscripten/blob/main/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+
+#### quickjs-ng
+
+[quickjs-ng/quickjs](https://github.com/quickjs-ng/quickjs) (aka quickjs-ng) is a fork of the original [bellard/quickjs](https://github.com/quickjs-ng/quickjs) under active development. It implements more EcmaScript standards and removes some of quickjs's custom language features like BigFloat.
+
+There are several variants of quickjs-ng available, and quickjs-emscripten may switch to using quickjs-ng by default in the future. See [the list of variants][core].
 
 #### Using in the browser without a build step
 

--- a/doc/quickjs-emscripten/classes/Lifetime.md
+++ b/doc/quickjs-emscripten/classes/Lifetime.md
@@ -85,7 +85,7 @@ the creator.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:543
+packages/quickjs-emscripten-core/dist/index.d.ts:584
 
 ## Properties
 
@@ -95,7 +95,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:543
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:533
+packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 ***
 
@@ -105,7 +105,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:533
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:534
+packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 ***
 
@@ -115,7 +115,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:534
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:532
+packages/quickjs-emscripten-core/dist/index.d.ts:573
 
 ***
 
@@ -125,7 +125,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:532
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:529
+packages/quickjs-emscripten-core/dist/index.d.ts:570
 
 ***
 
@@ -143,7 +143,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:529
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:530
+packages/quickjs-emscripten-core/dist/index.d.ts:571
 
 ***
 
@@ -161,7 +161,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:530
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:531
+packages/quickjs-emscripten-core/dist/index.d.ts:572
 
 ## Accessors
 
@@ -179,7 +179,7 @@ false after the object has been [dispose](Lifetime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:544
+packages/quickjs-emscripten-core/dist/index.d.ts:585
 
 ***
 
@@ -193,7 +193,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:544
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:553
+packages/quickjs-emscripten-core/dist/index.d.ts:594
 
 ***
 
@@ -207,7 +207,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:553
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:552
+packages/quickjs-emscripten-core/dist/index.d.ts:593
 
 ***
 
@@ -228,7 +228,7 @@ If the lifetime has been [dispose](Lifetime.md#dispose-1)d already.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:551
+packages/quickjs-emscripten-core/dist/index.d.ts:592
 
 ## Methods
 
@@ -252,7 +252,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -280,7 +280,7 @@ the result of `map(this)`.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:562
+packages/quickjs-emscripten-core/dist/index.d.ts:603
 
 #### consume(map)
 
@@ -300,7 +300,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:562
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:563
+packages/quickjs-emscripten-core/dist/index.d.ts:604
 
 ***
 
@@ -324,7 +324,7 @@ Dispose of [value](Lifetime.md#value-1) and perform cleanup.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:567
+packages/quickjs-emscripten-core/dist/index.d.ts:608
 
 ***
 
@@ -340,7 +340,7 @@ Create a new handle pointing to the same [value](Lifetime.md#value-1).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:557
+packages/quickjs-emscripten-core/dist/index.d.ts:598
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
@@ -101,7 +101,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:789
+packages/quickjs-emscripten-core/dist/index.d.ts:830
 
 ## Properties
 
@@ -135,7 +135,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:798
+packages/quickjs-emscripten-core/dist/index.d.ts:839
 
 ***
 
@@ -151,7 +151,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:798
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:821
+packages/quickjs-emscripten-core/dist/index.d.ts:862
 
 ***
 
@@ -169,7 +169,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:827
+packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:827
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:813
+packages/quickjs-emscripten-core/dist/index.d.ts:854
 
 ***
 
@@ -201,7 +201,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:813
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:817
+packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 ***
 
@@ -217,7 +217,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:817
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:809
+packages/quickjs-emscripten-core/dist/index.d.ts:850
 
 ## Methods
 
@@ -237,7 +237,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -275,7 +275,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:993
+packages/quickjs-emscripten-core/dist/index.d.ts:1034
 
 ***
 
@@ -308,7 +308,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1086
+packages/quickjs-emscripten-core/dist/index.d.ts:1127
 
 ***
 
@@ -339,7 +339,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:979
+packages/quickjs-emscripten-core/dist/index.d.ts:1020
 
 ***
 
@@ -364,7 +364,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:805
+packages/quickjs-emscripten-core/dist/index.d.ts:846
 
 ***
 
@@ -389,7 +389,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1039
+packages/quickjs-emscripten-core/dist/index.d.ts:1080
 
 ***
 
@@ -423,7 +423,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1073
+packages/quickjs-emscripten-core/dist/index.d.ts:1114
 
 ***
 
@@ -473,7 +473,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1014
+packages/quickjs-emscripten-core/dist/index.d.ts:1055
 
 ***
 
@@ -523,7 +523,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:941
+packages/quickjs-emscripten-core/dist/index.d.ts:982
 
 ***
 
@@ -547,7 +547,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:937
+packages/quickjs-emscripten-core/dist/index.d.ts:978
 
 ***
 
@@ -573,7 +573,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:924
+packages/quickjs-emscripten-core/dist/index.d.ts:965
 
 ***
 
@@ -603,7 +603,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:960
+packages/quickjs-emscripten-core/dist/index.d.ts:1001
 
 ***
 
@@ -627,7 +627,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:928
+packages/quickjs-emscripten-core/dist/index.d.ts:969
 
 ***
 
@@ -652,7 +652,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:933
+packages/quickjs-emscripten-core/dist/index.d.ts:974
 
 ***
 
@@ -673,7 +673,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:861
+packages/quickjs-emscripten-core/dist/index.d.ts:902
 
 ***
 
@@ -697,7 +697,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:865
+packages/quickjs-emscripten-core/dist/index.d.ts:906
 
 ***
 
@@ -753,7 +753,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:849
+packages/quickjs-emscripten-core/dist/index.d.ts:890
 
 ***
 
@@ -781,7 +781,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:849
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:907
+packages/quickjs-emscripten-core/dist/index.d.ts:948
 
 #### newError(message)
 
@@ -801,7 +801,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:907
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:911
+packages/quickjs-emscripten-core/dist/index.d.ts:952
 
 #### newError(undefined)
 
@@ -817,7 +817,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:911
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:912
+packages/quickjs-emscripten-core/dist/index.d.ts:953
 
 ***
 
@@ -858,7 +858,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:906
+packages/quickjs-emscripten-core/dist/index.d.ts:947
 
 ***
 
@@ -882,7 +882,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:831
+packages/quickjs-emscripten-core/dist/index.d.ts:872
 
 ***
 
@@ -909,7 +909,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:856
+packages/quickjs-emscripten-core/dist/index.d.ts:897
 
 ***
 
@@ -934,7 +934,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:872
+packages/quickjs-emscripten-core/dist/index.d.ts:913
 
 #### newPromise(promise)
 
@@ -960,7 +960,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:880
+packages/quickjs-emscripten-core/dist/index.d.ts:921
 
 #### newPromise(newPromiseFn)
 
@@ -985,7 +985,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:887
+packages/quickjs-emscripten-core/dist/index.d.ts:928
 
 ***
 
@@ -1009,7 +1009,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:835
+packages/quickjs-emscripten-core/dist/index.d.ts:876
 
 ***
 
@@ -1034,7 +1034,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:845
+packages/quickjs-emscripten-core/dist/index.d.ts:886
 
 ***
 
@@ -1059,7 +1059,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:840
+packages/quickjs-emscripten-core/dist/index.d.ts:881
 
 ***
 
@@ -1091,7 +1091,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:952
+packages/quickjs-emscripten-core/dist/index.d.ts:993
 
 ***
 
@@ -1128,7 +1128,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:972
+packages/quickjs-emscripten-core/dist/index.d.ts:1013
 
 ***
 
@@ -1152,7 +1152,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1026
+packages/quickjs-emscripten-core/dist/index.d.ts:1067
 
 ***
 
@@ -1180,7 +1180,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:919
+packages/quickjs-emscripten-core/dist/index.d.ts:960
 
 ***
 
@@ -1211,7 +1211,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1046
+packages/quickjs-emscripten-core/dist/index.d.ts:1087
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncRuntime.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncRuntime.md
@@ -113,7 +113,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
@@ -49,7 +49,7 @@ Synchronous evalCode is not supported.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1259
+packages/quickjs-emscripten-core/dist/index.d.ts:1300
 
 ***
 
@@ -79,7 +79,7 @@ See the documentation for [QuickJSWASMModule#evalCode](QuickJSWASMModule.md#eval
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1271
+packages/quickjs-emscripten-core/dist/index.d.ts:1312
 
 ***
 
@@ -105,7 +105,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1257
+packages/quickjs-emscripten-core/dist/index.d.ts:1298
 
 ***
 
@@ -131,7 +131,7 @@ concurrent async actions, create multiple WebAssembly modules.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1251
+packages/quickjs-emscripten-core/dist/index.d.ts:1292
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSContext.md
@@ -129,7 +129,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:789
+packages/quickjs-emscripten-core/dist/index.d.ts:830
 
 ## Properties
 
@@ -141,7 +141,7 @@ The runtime that created this context.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:762
+packages/quickjs-emscripten-core/dist/index.d.ts:803
 
 ## Accessors
 
@@ -159,7 +159,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:798
+packages/quickjs-emscripten-core/dist/index.d.ts:839
 
 ***
 
@@ -175,7 +175,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:798
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:821
+packages/quickjs-emscripten-core/dist/index.d.ts:862
 
 ***
 
@@ -193,7 +193,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:827
+packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 ***
 
@@ -209,7 +209,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:827
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:813
+packages/quickjs-emscripten-core/dist/index.d.ts:854
 
 ***
 
@@ -225,7 +225,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:813
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:817
+packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 ***
 
@@ -241,7 +241,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:817
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:809
+packages/quickjs-emscripten-core/dist/index.d.ts:850
 
 ## Methods
 
@@ -265,7 +265,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -303,7 +303,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:993
+packages/quickjs-emscripten-core/dist/index.d.ts:1034
 
 ***
 
@@ -332,7 +332,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1086
+packages/quickjs-emscripten-core/dist/index.d.ts:1127
 
 ***
 
@@ -363,7 +363,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:979
+packages/quickjs-emscripten-core/dist/index.d.ts:1020
 
 ***
 
@@ -392,7 +392,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:805
+packages/quickjs-emscripten-core/dist/index.d.ts:846
 
 ***
 
@@ -413,7 +413,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1039
+packages/quickjs-emscripten-core/dist/index.d.ts:1080
 
 ***
 
@@ -443,7 +443,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1073
+packages/quickjs-emscripten-core/dist/index.d.ts:1114
 
 ***
 
@@ -493,7 +493,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1014
+packages/quickjs-emscripten-core/dist/index.d.ts:1055
 
 ***
 
@@ -513,7 +513,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:941
+packages/quickjs-emscripten-core/dist/index.d.ts:982
 
 ***
 
@@ -533,7 +533,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:937
+packages/quickjs-emscripten-core/dist/index.d.ts:978
 
 ***
 
@@ -559,7 +559,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:924
+packages/quickjs-emscripten-core/dist/index.d.ts:965
 
 ***
 
@@ -589,7 +589,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:960
+packages/quickjs-emscripten-core/dist/index.d.ts:1001
 
 ***
 
@@ -613,7 +613,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:928
+packages/quickjs-emscripten-core/dist/index.d.ts:969
 
 ***
 
@@ -634,7 +634,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:933
+packages/quickjs-emscripten-core/dist/index.d.ts:974
 
 ***
 
@@ -651,7 +651,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:861
+packages/quickjs-emscripten-core/dist/index.d.ts:902
 
 ***
 
@@ -671,7 +671,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:865
+packages/quickjs-emscripten-core/dist/index.d.ts:906
 
 ***
 
@@ -691,7 +691,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:849
+packages/quickjs-emscripten-core/dist/index.d.ts:890
 
 ***
 
@@ -715,7 +715,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:849
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:907
+packages/quickjs-emscripten-core/dist/index.d.ts:948
 
 #### newError(message)
 
@@ -731,7 +731,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:907
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:911
+packages/quickjs-emscripten-core/dist/index.d.ts:952
 
 #### newError(undefined)
 
@@ -743,7 +743,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:911
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:912
+packages/quickjs-emscripten-core/dist/index.d.ts:953
 
 ***
 
@@ -784,7 +784,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:906
+packages/quickjs-emscripten-core/dist/index.d.ts:947
 
 ***
 
@@ -808,7 +808,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:831
+packages/quickjs-emscripten-core/dist/index.d.ts:872
 
 ***
 
@@ -835,7 +835,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:856
+packages/quickjs-emscripten-core/dist/index.d.ts:897
 
 ***
 
@@ -856,7 +856,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:872
+packages/quickjs-emscripten-core/dist/index.d.ts:913
 
 #### newPromise(promise)
 
@@ -878,7 +878,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:880
+packages/quickjs-emscripten-core/dist/index.d.ts:921
 
 #### newPromise(newPromiseFn)
 
@@ -899,7 +899,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:887
+packages/quickjs-emscripten-core/dist/index.d.ts:928
 
 ***
 
@@ -923,7 +923,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:835
+packages/quickjs-emscripten-core/dist/index.d.ts:876
 
 ***
 
@@ -944,7 +944,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:845
+packages/quickjs-emscripten-core/dist/index.d.ts:886
 
 ***
 
@@ -965,7 +965,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:840
+packages/quickjs-emscripten-core/dist/index.d.ts:881
 
 ***
 
@@ -993,7 +993,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:952
+packages/quickjs-emscripten-core/dist/index.d.ts:993
 
 ***
 
@@ -1030,7 +1030,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:972
+packages/quickjs-emscripten-core/dist/index.d.ts:1013
 
 ***
 
@@ -1050,7 +1050,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1026
+packages/quickjs-emscripten-core/dist/index.d.ts:1067
 
 ***
 
@@ -1078,7 +1078,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:919
+packages/quickjs-emscripten-core/dist/index.d.ts:960
 
 ***
 
@@ -1105,7 +1105,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1046
+packages/quickjs-emscripten-core/dist/index.d.ts:1087
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:661
+packages/quickjs-emscripten-core/dist/index.d.ts:702
 
 ## Properties
 
@@ -94,7 +94,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:661
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:643
+packages/quickjs-emscripten-core/dist/index.d.ts:684
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:643
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:686
+packages/quickjs-emscripten-core/dist/index.d.ts:727
 
 ***
 
@@ -130,7 +130,7 @@ are finished with it.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:649
+packages/quickjs-emscripten-core/dist/index.d.ts:690
 
 ***
 
@@ -140,7 +140,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:649
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:642
+packages/quickjs-emscripten-core/dist/index.d.ts:683
 
 ***
 
@@ -165,7 +165,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:684
+packages/quickjs-emscripten-core/dist/index.d.ts:725
 
 ***
 
@@ -190,7 +190,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:675
+packages/quickjs-emscripten-core/dist/index.d.ts:716
 
 ***
 
@@ -202,7 +202,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:653
+packages/quickjs-emscripten-core/dist/index.d.ts:694
 
 ## Accessors
 
@@ -220,7 +220,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:685
+packages/quickjs-emscripten-core/dist/index.d.ts:726
 
 ## Methods
 
@@ -244,7 +244,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSRuntime.md
+++ b/doc/quickjs-emscripten/classes/QuickJSRuntime.md
@@ -118,7 +118,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
@@ -80,7 +80,7 @@ with name `"InternalError"` and  message `"interrupted"`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1215
+packages/quickjs-emscripten-core/dist/index.d.ts:1256
 
 ***
 
@@ -102,7 +102,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1189
+packages/quickjs-emscripten-core/dist/index.d.ts:1230
 
 ***
 
@@ -124,7 +124,7 @@ loading for one or more [QuickJSContext](QuickJSContext.md)s inside the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1183
+packages/quickjs-emscripten-core/dist/index.d.ts:1224
 
 ***
 

--- a/doc/quickjs-emscripten/classes/Scope.md
+++ b/doc/quickjs-emscripten/classes/Scope.md
@@ -63,7 +63,7 @@ false after the object has been [dispose](Scope.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:616
+packages/quickjs-emscripten-core/dist/index.d.ts:657
 
 ## Methods
 
@@ -87,7 +87,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -111,7 +111,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:617
+packages/quickjs-emscripten-core/dist/index.d.ts:658
 
 ***
 
@@ -135,7 +135,7 @@ Track `lifetime` so that it is disposed when this scope is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:615
+packages/quickjs-emscripten-core/dist/index.d.ts:656
 
 ***
 
@@ -165,7 +165,7 @@ Do not use with async functions. Instead, use [withScopeAsync](Scope.md#withscop
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:602
+packages/quickjs-emscripten-core/dist/index.d.ts:643
 
 ***
 
@@ -192,7 +192,7 @@ block returns.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:610
+packages/quickjs-emscripten-core/dist/index.d.ts:651
 
 ***
 
@@ -220,7 +220,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:610
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:603
+packages/quickjs-emscripten-core/dist/index.d.ts:644
 
 ***
 

--- a/doc/quickjs-emscripten/classes/StaticLifetime.md
+++ b/doc/quickjs-emscripten/classes/StaticLifetime.md
@@ -64,7 +64,7 @@ A Lifetime that lives forever. Used for constants.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:574
+packages/quickjs-emscripten-core/dist/index.d.ts:615
 
 ## Properties
 
@@ -78,7 +78,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:533
+packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 ***
 
@@ -92,7 +92,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:533
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:534
+packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 ***
 
@@ -106,7 +106,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:534
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:532
+packages/quickjs-emscripten-core/dist/index.d.ts:573
 
 ***
 
@@ -120,7 +120,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:532
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:529
+packages/quickjs-emscripten-core/dist/index.d.ts:570
 
 ***
 
@@ -142,7 +142,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:529
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:530
+packages/quickjs-emscripten-core/dist/index.d.ts:571
 
 ***
 
@@ -164,7 +164,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:530
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:531
+packages/quickjs-emscripten-core/dist/index.d.ts:572
 
 ## Accessors
 
@@ -182,7 +182,7 @@ false after the object has been [dispose](StaticLifetime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:544
+packages/quickjs-emscripten-core/dist/index.d.ts:585
 
 ***
 
@@ -196,7 +196,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:544
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:575
+packages/quickjs-emscripten-core/dist/index.d.ts:616
 
 ***
 
@@ -210,7 +210,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:552
+packages/quickjs-emscripten-core/dist/index.d.ts:593
 
 ***
 
@@ -231,7 +231,7 @@ If the lifetime has been [dispose](StaticLifetime.md#dispose-1)d already.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:551
+packages/quickjs-emscripten-core/dist/index.d.ts:592
 
 ## Methods
 
@@ -251,7 +251,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -283,7 +283,7 @@ the result of `map(this)`.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:562
+packages/quickjs-emscripten-core/dist/index.d.ts:603
 
 #### consume(map)
 
@@ -307,7 +307,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:562
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:563
+packages/quickjs-emscripten-core/dist/index.d.ts:604
 
 ***
 
@@ -327,7 +327,7 @@ Dispose of [value](StaticLifetime.md#value-1) and perform cleanup.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:577
+packages/quickjs-emscripten-core/dist/index.d.ts:618
 
 ***
 
@@ -347,7 +347,7 @@ Create a new handle pointing to the same [value](StaticLifetime.md#value-1).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:576
+packages/quickjs-emscripten-core/dist/index.d.ts:617
 
 ***
 

--- a/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
@@ -50,7 +50,7 @@ freed all the memory you've ever allocated.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1449
+packages/quickjs-emscripten-core/dist/index.d.ts:1495
 
 ## Properties
 
@@ -60,7 +60,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1449
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1447
+packages/quickjs-emscripten-core/dist/index.d.ts:1493
 
 ***
 
@@ -70,7 +70,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1447
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1448
+packages/quickjs-emscripten-core/dist/index.d.ts:1494
 
 ## Methods
 
@@ -84,7 +84,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1448
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1454
+packages/quickjs-emscripten-core/dist/index.d.ts:1500
 
 ***
 
@@ -98,7 +98,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1454
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1453
+packages/quickjs-emscripten-core/dist/index.d.ts:1499
 
 ***
 
@@ -122,7 +122,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1453
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1452
+packages/quickjs-emscripten-core/dist/index.d.ts:1498
 
 ***
 
@@ -144,7 +144,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1452
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1451
+packages/quickjs-emscripten-core/dist/index.d.ts:1497
 
 ***
 
@@ -166,7 +166,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1451
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1450
+packages/quickjs-emscripten-core/dist/index.d.ts:1496
 
 ***
 

--- a/doc/quickjs-emscripten/classes/UsingDisposable.md
+++ b/doc/quickjs-emscripten/classes/UsingDisposable.md
@@ -54,7 +54,7 @@ Base abstract class that helps implement [Disposable](../interfaces/Disposable.m
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:512
+packages/quickjs-emscripten-core/dist/index.d.ts:553
 
 ## Methods
 
@@ -74,7 +74,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -94,7 +94,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:516
+packages/quickjs-emscripten-core/dist/index.d.ts:557
 
 ***
 

--- a/doc/quickjs-emscripten/classes/WeakLifetime.md
+++ b/doc/quickjs-emscripten/classes/WeakLifetime.md
@@ -74,7 +74,7 @@ Used for function arguments.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:587
+packages/quickjs-emscripten-core/dist/index.d.ts:628
 
 ## Properties
 
@@ -88,7 +88,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:587
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:533
+packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 ***
 
@@ -102,7 +102,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:533
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:534
+packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:534
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:532
+packages/quickjs-emscripten-core/dist/index.d.ts:573
 
 ***
 
@@ -130,7 +130,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:532
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:529
+packages/quickjs-emscripten-core/dist/index.d.ts:570
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:529
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:530
+packages/quickjs-emscripten-core/dist/index.d.ts:571
 
 ***
 
@@ -174,7 +174,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:530
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:531
+packages/quickjs-emscripten-core/dist/index.d.ts:572
 
 ## Accessors
 
@@ -192,7 +192,7 @@ false after the object has been [dispose](WeakLifetime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:544
+packages/quickjs-emscripten-core/dist/index.d.ts:585
 
 ***
 
@@ -206,7 +206,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:544
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:553
+packages/quickjs-emscripten-core/dist/index.d.ts:594
 
 ***
 
@@ -220,7 +220,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:553
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:552
+packages/quickjs-emscripten-core/dist/index.d.ts:593
 
 ***
 
@@ -241,7 +241,7 @@ If the lifetime has been [dispose](WeakLifetime.md#dispose-1)d already.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:551
+packages/quickjs-emscripten-core/dist/index.d.ts:592
 
 ## Methods
 
@@ -261,7 +261,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:520
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ***
 
@@ -293,7 +293,7 @@ the result of `map(this)`.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:562
+packages/quickjs-emscripten-core/dist/index.d.ts:603
 
 #### consume(map)
 
@@ -317,7 +317,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:562
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:563
+packages/quickjs-emscripten-core/dist/index.d.ts:604
 
 ***
 
@@ -337,7 +337,7 @@ Dispose of [value](WeakLifetime.md#value-1) and perform cleanup.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:588
+packages/quickjs-emscripten-core/dist/index.d.ts:629
 
 ***
 
@@ -357,7 +357,7 @@ Create a new handle pointing to the same [value](WeakLifetime.md#value-1).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:557
+packages/quickjs-emscripten-core/dist/index.d.ts:598
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -18,6 +18,7 @@
   - [EitherModule](exports.md#eithermodule)
   - [ExecutePendingJobsResult](exports.md#executependingjobsresult)
   - [InterruptHandler](exports.md#interrupthandler)
+  - [Intrinsics](exports.md#intrinsics)
   - [JSBorrowedCharPointer](exports.md#jsborrowedcharpointer)
   - [JSContextPointer](exports.md#jscontextpointer)
   - [JSContextPointerPointer](exports.md#jscontextpointerpointer)
@@ -55,7 +56,9 @@
   - [@jitl/quickjs-wasmfile-debug-asyncify](exports.md#jitlquickjs-wasmfile-debug-asyncify)
   - [DEBUG\_SYNC](exports.md#debug-sync)
   - [@jitl/quickjs-wasmfile-debug-sync](exports.md#jitlquickjs-wasmfile-debug-sync)
+  - [DefaultIntrinsics](exports.md#defaultintrinsics)
   - [EvalFlags](exports.md#evalflags)
+  - [IntrinsicsFlags](exports.md#intrinsicsflags)
   - [RELEASE\_ASYNC](exports.md#release-async)
   - [@jitl/quickjs-wasmfile-release-asyncify](exports.md#jitlquickjs-wasmfile-release-asyncify)
   - [RELEASE\_SYNC](exports.md#release-sync)
@@ -164,7 +167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:66
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:455
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 
@@ -174,7 +177,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:455
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:269
+packages/quickjs-ffi-types/dist/index.d.ts:292
 
 ***
 
@@ -216,6 +219,88 @@ Determines if a VM's execution should be interrupted.
 #### Source
 
 packages/quickjs-emscripten-core/dist/index.d.ts:112
+
+***
+
+### Intrinsics
+
+> **Intrinsics**: `Object`
+
+Language features that can be enabled or disabled in a QuickJSContext.
+
+#### See
+
+[ContextOptions](interfaces/ContextOptions.md)
+
+#### Type declaration
+
+##### BaseObjects?
+
+> **BaseObjects**?: `boolean`
+
+##### BigDecimal?
+
+> **BigDecimal**?: `boolean`
+
+##### BigFloat?
+
+> **BigFloat**?: `boolean`
+
+##### BigInt?
+
+> **BigInt**?: `boolean`
+
+##### BignumExt?
+
+> **BignumExt**?: `boolean`
+
+##### Date?
+
+> **Date**?: `boolean`
+
+##### Eval?
+
+> **Eval**?: `boolean`
+
+##### JSON?
+
+> **JSON**?: `boolean`
+
+##### MapSet?
+
+> **MapSet**?: `boolean`
+
+##### OperatorOverloading?
+
+> **OperatorOverloading**?: `boolean`
+
+##### Promise?
+
+> **Promise**?: `boolean`
+
+##### Proxy?
+
+> **Proxy**?: `boolean`
+
+##### RegExp?
+
+> **RegExp**?: `boolean`
+
+##### RegExpCompiler?
+
+> **RegExpCompiler**?: `boolean`
+
+##### StringNormalize?
+
+> **StringNormalize**?: `boolean`
+
+##### TypedArrays?
+
+> **TypedArrays**?: `boolean`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:440
 
 ***
 
@@ -455,7 +540,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:80
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1333
+packages/quickjs-emscripten-core/dist/index.d.ts:1374
 
 ***
 
@@ -494,7 +579,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:71
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:482
+packages/quickjs-emscripten-core/dist/index.d.ts:523
 
 ***
 
@@ -508,7 +593,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:482
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1274
+packages/quickjs-emscripten-core/dist/index.d.ts:1315
 
 ***
 
@@ -573,7 +658,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:694
+packages/quickjs-emscripten-core/dist/index.d.ts:735
 
 ***
 
@@ -583,7 +668,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:694
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:454
+packages/quickjs-ffi-types/dist/index.d.ts:477
 
 ***
 
@@ -715,6 +800,64 @@ packages/variant-quickjs-wasmfile-debug-sync/dist/index.d.ts:17
 
 ***
 
+### DefaultIntrinsics
+
+> **`const`** **DefaultIntrinsics**: `Readonly`\<`Object`\>
+
+The default [Intrinsics](exports.md#intrinsics) language features enabled in a QuickJSContext.
+
+#### See
+
+[ContextOptions](interfaces/ContextOptions.md)
+
+#### Type declaration
+
+##### BaseObjects
+
+> **`readonly`** **BaseObjects**: `true`
+
+##### Date
+
+> **`readonly`** **Date**: `true`
+
+##### Eval
+
+> **`readonly`** **Eval**: `true`
+
+##### JSON
+
+> **`readonly`** **JSON**: `true`
+
+##### MapSet
+
+> **`readonly`** **MapSet**: `true`
+
+##### Promise
+
+> **`readonly`** **Promise**: `true`
+
+##### Proxy
+
+> **`readonly`** **Proxy**: `true`
+
+##### RegExp
+
+> **`readonly`** **RegExp**: `true`
+
+##### StringNormalize
+
+> **`readonly`** **StringNormalize**: `true`
+
+##### TypedArrays
+
+> **`readonly`** **TypedArrays**: `true`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:462
+
+***
+
 ### EvalFlags
 
 > **EvalFlags**: `Object`
@@ -725,13 +868,13 @@ Bitfield options for JS_Eval() C function.
 
 ##### JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER
 
-> **JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_BACKTRACE\_BARRIER**: `number`
 
 don't include the stack frames before this eval in the Error() backtraces
 
 ##### JS\_EVAL\_FLAG\_COMPILE\_ONLY
 
-> **JS\_EVAL\_FLAG\_COMPILE\_ONLY**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_COMPILE\_ONLY**: `number`
 
 compile but do not run. The result is an object with a
 JS_TAG_FUNCTION_BYTECODE or JS_TAG_MODULE tag. It can be executed
@@ -739,47 +882,125 @@ with JS_EvalFunction().
 
 ##### JS\_EVAL\_FLAG\_STRICT
 
-> **JS\_EVAL\_FLAG\_STRICT**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_STRICT**: `number`
 
 force 'strict' mode
 
 ##### JS\_EVAL\_FLAG\_STRIP
 
-> **JS\_EVAL\_FLAG\_STRIP**: `number`
+> **`readonly`** **JS\_EVAL\_FLAG\_STRIP**: `number`
 
 force 'strip' mode
 
 ##### JS\_EVAL\_TYPE\_DIRECT
 
-> **JS\_EVAL\_TYPE\_DIRECT**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_DIRECT**: `number`
 
 direct call (internal use)
 
 ##### JS\_EVAL\_TYPE\_GLOBAL
 
-> **JS\_EVAL\_TYPE\_GLOBAL**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_GLOBAL**: `number`
 
 global code (default)
 
 ##### JS\_EVAL\_TYPE\_INDIRECT
 
-> **JS\_EVAL\_TYPE\_INDIRECT**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_INDIRECT**: `number`
 
 indirect call (internal use)
 
 ##### JS\_EVAL\_TYPE\_MASK
 
-> **JS\_EVAL\_TYPE\_MASK**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_MASK**: `number`
 
 ##### JS\_EVAL\_TYPE\_MODULE
 
-> **JS\_EVAL\_TYPE\_MODULE**: `number`
+> **`readonly`** **JS\_EVAL\_TYPE\_MODULE**: `number`
 
 module code
 
 #### Source
 
 packages/quickjs-ffi-types/dist/index.d.ts:89
+
+***
+
+### IntrinsicsFlags
+
+> **IntrinsicsFlags**: `Object`
+
+Bitfield options for QTS_NewContext intrinsices
+
+#### Type declaration
+
+##### BaseObjects
+
+> **`readonly`** **BaseObjects**: `number`
+
+##### BigDecimal
+
+> **`readonly`** **BigDecimal**: `number`
+
+##### BigFloat
+
+> **`readonly`** **BigFloat**: `number`
+
+##### BigInt
+
+> **`readonly`** **BigInt**: `number`
+
+##### BignumExt
+
+> **`readonly`** **BignumExt**: `number`
+
+##### Date
+
+> **`readonly`** **Date**: `number`
+
+##### Eval
+
+> **`readonly`** **Eval**: `number`
+
+##### JSON
+
+> **`readonly`** **JSON**: `number`
+
+##### MapSet
+
+> **`readonly`** **MapSet**: `number`
+
+##### OperatorOverloading
+
+> **`readonly`** **OperatorOverloading**: `number`
+
+##### Promise
+
+> **`readonly`** **Promise**: `number`
+
+##### Proxy
+
+> **`readonly`** **Proxy**: `number`
+
+##### RegExp
+
+> **`readonly`** **RegExp**: `number`
+
+##### RegExpCompiler
+
+> **`readonly`** **RegExpCompiler**: `number`
+
+##### StringNormalize
+
+> **`readonly`** **StringNormalize**: `number`
+
+##### TypedArrays
+
+> **`readonly`** **TypedArrays**: `number`
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:117
 
 ***
 
@@ -985,7 +1206,7 @@ const getDebugModule = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SY
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1332
+packages/quickjs-emscripten-core/dist/index.d.ts:1373
 
 ***
 
@@ -1114,7 +1335,7 @@ const quickjs = new newQuickJSAsyncWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1321
+packages/quickjs-emscripten-core/dist/index.d.ts:1362
 
 ***
 
@@ -1176,7 +1397,7 @@ const quickjs = new newQuickJSWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1296
+packages/quickjs-emscripten-core/dist/index.d.ts:1337
 
 ***
 
@@ -1203,7 +1424,7 @@ This may be necessary in Cloudflare Workers, which can't compile WebAssembly mod
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1374
+packages/quickjs-emscripten-core/dist/index.d.ts:1415
 
 ***
 
@@ -1226,7 +1447,7 @@ Interrupt execution if it's still running after this time.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1382
+packages/quickjs-emscripten-core/dist/index.d.ts:1423
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/AsyncRuntimeOptions.md
+++ b/doc/quickjs-emscripten/interfaces/AsyncRuntimeOptions.md
@@ -35,7 +35,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:421
+packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 ***
 
@@ -49,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:416
+packages/quickjs-emscripten-core/dist/index.d.ts:412
 
 ***
 
@@ -63,7 +63,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:417
+packages/quickjs-emscripten-core/dist/index.d.ts:413
 
 ***
 
@@ -77,7 +77,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:418
+packages/quickjs-emscripten-core/dist/index.d.ts:414
 
 ***
 
@@ -87,7 +87,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:438
+packages/quickjs-emscripten-core/dist/index.d.ts:434
 
 ***
 
@@ -101,7 +101,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:419
+packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 ***
 
@@ -115,7 +115,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:420
+packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:422
+packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ContextEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ContextEvalOptions.md
@@ -25,7 +25,7 @@ don't include the stack frames before this eval in the Error() backtraces
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:480
+packages/quickjs-emscripten-core/dist/index.d.ts:521
 
 ***
 
@@ -39,7 +39,7 @@ with JS_EvalFunction().
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:478
+packages/quickjs-emscripten-core/dist/index.d.ts:519
 
 ***
 
@@ -51,7 +51,7 @@ Force "strict" mode
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:470
+packages/quickjs-emscripten-core/dist/index.d.ts:511
 
 ***
 
@@ -63,7 +63,7 @@ Force "strip" mode
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:472
+packages/quickjs-emscripten-core/dist/index.d.ts:513
 
 ***
 
@@ -75,7 +75,7 @@ Global code (default)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:468
+packages/quickjs-emscripten-core/dist/index.d.ts:509
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ContextOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ContextOptions.md
@@ -6,6 +6,9 @@
 
 # Interface: ContextOptions
 
+Options for creating a [QuickJSContext](../classes/QuickJSContext.md) or [QuickJSAsyncContext](../classes/QuickJSAsyncContext.md)
+Pass to [QuickJSRuntime#newContext](../classes/QuickJSRuntime.md#newcontext).
+
 ## Contents
 
 - [Properties](ContextOptions.md#properties)
@@ -15,15 +18,26 @@
 
 ### intrinsics?
 
-> **intrinsics**?: *typeof* `DefaultIntrinsics`
+> **intrinsics**?: [`Intrinsics`](../exports.md#intrinsics)
 
 What built-in objects and language features to enable?
 If unset, the default intrinsics will be used.
 To omit all intrinsics, pass an empty array.
 
+To remove a specific intrinsic, but retain the other defaults,
+override it from [DefaultIntrinsics](../exports.md#defaultintrinsics)
+```ts
+const contextWithoutDateOrEval = runtime.newContext({
+  intrinsics: {
+    ...DefaultIntrinsics,
+    Date: false,
+  }
+})
+```
+
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:454
+packages/quickjs-emscripten-core/dist/index.d.ts:495
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+++ b/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
@@ -28,7 +28,7 @@ The enumerable properties of this object will be passed verbatim, although they 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1366
+packages/quickjs-emscripten-core/dist/index.d.ts:1407
 
 ***
 
@@ -68,7 +68,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1364
+packages/quickjs-emscripten-core/dist/index.d.ts:1405
 
 ***
 
@@ -100,7 +100,7 @@ Debug logger
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1368
+packages/quickjs-emscripten-core/dist/index.d.ts:1409
 
 ***
 
@@ -112,7 +112,7 @@ If given, Emscripten will compile the WebAssembly.Module from these bytes.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1338
+packages/quickjs-emscripten-core/dist/index.d.ts:1379
 
 ***
 
@@ -124,7 +124,7 @@ If given, Emscripten will try to load the WebAssembly module data from this loca
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1336
+packages/quickjs-emscripten-core/dist/index.d.ts:1377
 
 ***
 
@@ -136,7 +136,7 @@ If given, Emscripten will instantiate the WebAssembly.Instance from this existin
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1340
+packages/quickjs-emscripten-core/dist/index.d.ts:1381
 
 ***
 
@@ -148,7 +148,7 @@ If given, we will provide the source map to Emscripten directly. This may only b
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1344
+packages/quickjs-emscripten-core/dist/index.d.ts:1385
 
 ***
 
@@ -160,7 +160,7 @@ If given, Emscripten will try to load the source map for the WebAssembly module 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1342
+packages/quickjs-emscripten-core/dist/index.d.ts:1383
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/Disposable.md
+++ b/doc/quickjs-emscripten/interfaces/Disposable.md
@@ -26,7 +26,7 @@ Use [Scope](../classes/Scope.md) to manage cleaning up multiple disposables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:498
+packages/quickjs-emscripten-core/dist/index.d.ts:539
 
 ## Methods
 
@@ -42,7 +42,7 @@ A method that is used to release resources held by an object. Called by the sema
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:502
+packages/quickjs-emscripten-core/dist/index.d.ts:543
 
 ***
 
@@ -58,7 +58,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:493
+packages/quickjs-emscripten-core/dist/index.d.ts:534
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModule.md
@@ -48,7 +48,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:226
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -58,7 +58,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:226
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:217
+packages/quickjs-ffi-types/dist/index.d.ts:240
 
 ***
 
@@ -68,7 +68,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:217
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:218
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 
@@ -78,7 +78,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:218
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:216
+packages/quickjs-ffi-types/dist/index.d.ts:239
 
 ***
 
@@ -88,7 +88,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:216
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:222
+packages/quickjs-ffi-types/dist/index.d.ts:245
 
 ***
 
@@ -98,7 +98,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:222
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:223
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -108,7 +108,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:223
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:220
+packages/quickjs-ffi-types/dist/index.d.ts:243
 
 ***
 
@@ -118,7 +118,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:220
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:221
+packages/quickjs-ffi-types/dist/index.d.ts:244
 
 ***
 
@@ -128,7 +128,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:221
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:219
+packages/quickjs-ffi-types/dist/index.d.ts:242
 
 ***
 
@@ -138,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:219
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:225
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -148,7 +148,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:225
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:224
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -164,7 +164,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -187,7 +187,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:234
 
 ***
 
@@ -205,7 +205,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:211
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:214
+packages/quickjs-ffi-types/dist/index.d.ts:237
 
 ***
 
@@ -223,7 +223,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:214
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:236
 
 ***
 
@@ -256,7 +256,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:238
 
 ***
 
@@ -282,7 +282,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -300,7 +300,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:187
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:212
+packages/quickjs-ffi-types/dist/index.d.ts:235
 
 ***
 
@@ -344,7 +344,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -368,7 +368,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 
@@ -393,7 +393,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:206
+packages/quickjs-ffi-types/dist/index.d.ts:229
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoader.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:271
+packages/quickjs-ffi-types/dist/index.d.ts:294
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoaderOptions.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoaderOptions.md
@@ -34,7 +34,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -56,7 +56,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -96,7 +96,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -116,7 +116,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
@@ -27,7 +27,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1125
+packages/quickjs-emscripten-core/dist/index.d.ts:1166
 
 ***
 
@@ -39,7 +39,7 @@ Memory limit, in bytes, of WebAssembly heap memory used by the QuickJS VM.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1120
+packages/quickjs-emscripten-core/dist/index.d.ts:1161
 
 ***
 
@@ -51,7 +51,7 @@ Module loader for any `import` statements or expressions.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1129
+packages/quickjs-emscripten-core/dist/index.d.ts:1170
 
 ***
 
@@ -64,7 +64,7 @@ See [shouldInterruptAfterDeadline](../exports.md#shouldinterruptafterdeadline).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1116
+packages/quickjs-emscripten-core/dist/index.d.ts:1157
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -54,7 +54,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:226
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -68,7 +68,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:226
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:217
+packages/quickjs-ffi-types/dist/index.d.ts:240
 
 ***
 
@@ -82,7 +82,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:217
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:218
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 
@@ -96,7 +96,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:218
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:216
+packages/quickjs-ffi-types/dist/index.d.ts:239
 
 ***
 
@@ -110,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:216
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:222
+packages/quickjs-ffi-types/dist/index.d.ts:245
 
 ***
 
@@ -124,7 +124,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:222
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:223
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -138,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:223
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:220
+packages/quickjs-ffi-types/dist/index.d.ts:243
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:220
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:221
+packages/quickjs-ffi-types/dist/index.d.ts:244
 
 ***
 
@@ -166,7 +166,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:221
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:219
+packages/quickjs-ffi-types/dist/index.d.ts:242
 
 ***
 
@@ -180,7 +180,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:219
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:225
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -194,7 +194,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:225
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:224
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -204,7 +204,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:224
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:267
+packages/quickjs-ffi-types/dist/index.d.ts:290
 
 ***
 
@@ -218,7 +218,7 @@ Implement this field
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:266
+packages/quickjs-ffi-types/dist/index.d.ts:289
 
 ***
 
@@ -234,7 +234,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -261,7 +261,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:234
 
 ***
 
@@ -283,7 +283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:211
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:214
+packages/quickjs-ffi-types/dist/index.d.ts:237
 
 ***
 
@@ -305,7 +305,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:214
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:236
 
 ***
 
@@ -342,7 +342,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:238
 
 ***
 
@@ -368,7 +368,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -390,7 +390,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:187
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:212
+packages/quickjs-ffi-types/dist/index.d.ts:235
 
 ***
 
@@ -434,7 +434,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -458,7 +458,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 
@@ -487,7 +487,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:206
+packages/quickjs-ffi-types/dist/index.d.ts:229
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
@@ -94,7 +94,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:352
+packages/quickjs-ffi-types/dist/index.d.ts:375
 
 ***
 
@@ -114,7 +114,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:352
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -128,7 +128,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -142,7 +142,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:430
 
 ***
 
@@ -156,7 +156,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:382
 
 ***
 
@@ -182,7 +182,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:359
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:419
 
 ***
 
@@ -208,7 +208,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:420
 
 ***
 
@@ -242,7 +242,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:418
 
 ***
 
@@ -262,7 +262,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:422
 
 ***
 
@@ -282,7 +282,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:423
 
 ***
 
@@ -302,7 +302,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:373
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -328,7 +328,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:373
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -354,7 +354,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -376,7 +376,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -398,7 +398,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:413
 
 ***
 
@@ -418,7 +418,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:372
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -436,7 +436,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:372
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:368
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -454,7 +454,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:368
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:389
 
 ***
 
@@ -474,7 +474,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:366
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:369
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -494,7 +494,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:369
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:370
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -514,7 +514,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:370
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:371
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -534,7 +534,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:371
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -554,7 +554,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -568,7 +568,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:386
 
 ***
 
@@ -588,7 +588,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:363
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -606,7 +606,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -620,7 +620,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:385
 
 ***
 
@@ -642,7 +642,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:414
 
 ***
 
@@ -664,7 +664,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:415
 
 ***
 
@@ -684,7 +684,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -704,7 +704,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -724,7 +724,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -738,7 +738,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:387
 
 ***
 
@@ -752,7 +752,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:364
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:384
 
 ***
 
@@ -772,7 +772,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -790,7 +790,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 
@@ -808,7 +808,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:376
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -830,17 +830,19 @@ packages/quickjs-ffi-types/dist/index.d.ts:376
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:377
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
 ### QTS\_NewContext
 
-> **QTS\_NewContext**: (`rt`) => [`JSContextPointer`](../exports.md#jscontextpointer)
+> **QTS\_NewContext**: (`rt`, `intrinsics`) => [`JSContextPointer`](../exports.md#jscontextpointer)
 
 #### Parameters
 
 • **rt**: [`JSRuntimePointer`](../exports.md#jsruntimepointer)
+
+• **intrinsics**: [`IntrinsicsFlags`](../exports.md#intrinsicsflags)
 
 #### Returns
 
@@ -848,7 +850,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:377
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:367
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -866,7 +868,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:367
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:377
 
 ***
 
@@ -886,7 +888,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:354
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:378
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -908,7 +910,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:378
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:432
 
 ***
 
@@ -926,7 +928,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:374
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -946,7 +948,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:374
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:375
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -966,7 +968,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:375
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
@@ -980,7 +982,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:388
 
 ***
 
@@ -1000,7 +1002,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:365
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -1022,7 +1024,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -1036,7 +1038,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:381
 
 ***
 
@@ -1056,7 +1058,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:421
 
 ***
 
@@ -1076,7 +1078,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:379
 
 ***
 
@@ -1094,7 +1096,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:356
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -1112,7 +1114,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -1130,7 +1132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:380
 
 ***
 
@@ -1148,7 +1150,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:357
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -1168,7 +1170,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -1188,7 +1190,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:383
 
 ***
 
@@ -1208,7 +1210,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:378
 
 ***
 
@@ -1232,7 +1234,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:355
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:416
 
 ***
 
@@ -1256,7 +1258,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:417
 
 ***
 
@@ -1274,7 +1276,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -1294,7 +1296,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:376
 
 ***
 
@@ -1314,7 +1316,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -1334,7 +1336,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -1354,7 +1356,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:451
+packages/quickjs-ffi-types/dist/index.d.ts:474
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:451
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:452
+packages/quickjs-ffi-types/dist/index.d.ts:475
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:452
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:450
+packages/quickjs-ffi-types/dist/index.d.ts:473
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSEmscriptenModule.md
@@ -54,7 +54,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:226
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -68,7 +68,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:226
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:217
+packages/quickjs-ffi-types/dist/index.d.ts:240
 
 ***
 
@@ -82,7 +82,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:217
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:218
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 
@@ -96,7 +96,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:218
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:216
+packages/quickjs-ffi-types/dist/index.d.ts:239
 
 ***
 
@@ -110,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:216
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:222
+packages/quickjs-ffi-types/dist/index.d.ts:245
 
 ***
 
@@ -124,7 +124,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:222
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:223
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -138,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:223
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:220
+packages/quickjs-ffi-types/dist/index.d.ts:243
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:220
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:221
+packages/quickjs-ffi-types/dist/index.d.ts:244
 
 ***
 
@@ -166,7 +166,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:221
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:219
+packages/quickjs-ffi-types/dist/index.d.ts:242
 
 ***
 
@@ -180,7 +180,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:219
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:225
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -194,7 +194,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:225
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:224
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -204,7 +204,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:224
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:262
+packages/quickjs-ffi-types/dist/index.d.ts:285
 
 ***
 
@@ -214,7 +214,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:262
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:261
+packages/quickjs-ffi-types/dist/index.d.ts:284
 
 ***
 
@@ -230,7 +230,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:185
+packages/quickjs-ffi-types/dist/index.d.ts:208
 
 ## Methods
 
@@ -257,7 +257,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:234
 
 ***
 
@@ -279,7 +279,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:211
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:214
+packages/quickjs-ffi-types/dist/index.d.ts:237
 
 ***
 
@@ -301,7 +301,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:214
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:236
 
 ***
 
@@ -338,7 +338,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:238
 
 ***
 
@@ -364,7 +364,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:187
+packages/quickjs-ffi-types/dist/index.d.ts:210
 
 ***
 
@@ -386,7 +386,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:187
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:212
+packages/quickjs-ffi-types/dist/index.d.ts:235
 
 ***
 
@@ -430,7 +430,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:181
+packages/quickjs-ffi-types/dist/index.d.ts:204
 
 ***
 
@@ -454,7 +454,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:189
+packages/quickjs-ffi-types/dist/index.d.ts:212
 
 ***
 
@@ -483,7 +483,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:206
+packages/quickjs-ffi-types/dist/index.d.ts:229
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
@@ -87,7 +87,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:283
+packages/quickjs-ffi-types/dist/index.d.ts:306
 
 ***
 
@@ -107,7 +107,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:283
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:334
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -121,7 +121,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:334
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:332
+packages/quickjs-ffi-types/dist/index.d.ts:355
 
 ***
 
@@ -135,7 +135,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:332
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:331
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -149,7 +149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:331
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:290
+packages/quickjs-ffi-types/dist/index.d.ts:313
 
 ***
 
@@ -175,7 +175,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:290
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:323
+packages/quickjs-ffi-types/dist/index.d.ts:346
 
 ***
 
@@ -209,7 +209,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:323
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:322
+packages/quickjs-ffi-types/dist/index.d.ts:345
 
 ***
 
@@ -229,7 +229,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:322
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:325
+packages/quickjs-ffi-types/dist/index.d.ts:348
 
 ***
 
@@ -249,7 +249,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:325
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:304
+packages/quickjs-ffi-types/dist/index.d.ts:327
 
 ***
 
@@ -275,7 +275,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:304
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:326
+packages/quickjs-ffi-types/dist/index.d.ts:349
 
 ***
 
@@ -297,7 +297,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:326
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:319
+packages/quickjs-ffi-types/dist/index.d.ts:342
 
 ***
 
@@ -317,7 +317,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:319
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:303
+packages/quickjs-ffi-types/dist/index.d.ts:326
 
 ***
 
@@ -335,7 +335,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:303
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:299
+packages/quickjs-ffi-types/dist/index.d.ts:322
 
 ***
 
@@ -353,7 +353,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:299
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:297
+packages/quickjs-ffi-types/dist/index.d.ts:320
 
 ***
 
@@ -373,7 +373,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:297
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:300
+packages/quickjs-ffi-types/dist/index.d.ts:323
 
 ***
 
@@ -393,7 +393,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:300
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:301
+packages/quickjs-ffi-types/dist/index.d.ts:324
 
 ***
 
@@ -413,7 +413,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:301
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:302
+packages/quickjs-ffi-types/dist/index.d.ts:325
 
 ***
 
@@ -433,7 +433,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:302
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:313
+packages/quickjs-ffi-types/dist/index.d.ts:336
 
 ***
 
@@ -453,7 +453,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:313
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:314
+packages/quickjs-ffi-types/dist/index.d.ts:337
 
 ***
 
@@ -467,7 +467,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:314
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:294
+packages/quickjs-ffi-types/dist/index.d.ts:317
 
 ***
 
@@ -487,7 +487,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:294
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:310
+packages/quickjs-ffi-types/dist/index.d.ts:333
 
 ***
 
@@ -505,7 +505,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:310
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:328
+packages/quickjs-ffi-types/dist/index.d.ts:351
 
 ***
 
@@ -519,7 +519,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:328
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
+packages/quickjs-ffi-types/dist/index.d.ts:316
 
 ***
 
@@ -541,7 +541,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:293
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:320
+packages/quickjs-ffi-types/dist/index.d.ts:343
 
 ***
 
@@ -561,7 +561,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:320
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:312
+packages/quickjs-ffi-types/dist/index.d.ts:335
 
 ***
 
@@ -581,7 +581,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:312
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:316
+packages/quickjs-ffi-types/dist/index.d.ts:339
 
 ***
 
@@ -595,7 +595,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:316
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:295
+packages/quickjs-ffi-types/dist/index.d.ts:318
 
 ***
 
@@ -609,7 +609,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:295
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:315
 
 ***
 
@@ -629,7 +629,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:292
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:317
+packages/quickjs-ffi-types/dist/index.d.ts:340
 
 ***
 
@@ -647,7 +647,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:317
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:318
+packages/quickjs-ffi-types/dist/index.d.ts:341
 
 ***
 
@@ -665,7 +665,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:318
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:307
+packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ***
 
@@ -687,17 +687,19 @@ packages/quickjs-ffi-types/dist/index.d.ts:307
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:308
+packages/quickjs-ffi-types/dist/index.d.ts:331
 
 ***
 
 ### QTS\_NewContext
 
-> **QTS\_NewContext**: (`rt`) => [`JSContextPointer`](../exports.md#jscontextpointer)
+> **QTS\_NewContext**: (`rt`, `intrinsics`) => [`JSContextPointer`](../exports.md#jscontextpointer)
 
 #### Parameters
 
 • **rt**: [`JSRuntimePointer`](../exports.md#jsruntimepointer)
+
+• **intrinsics**: [`IntrinsicsFlags`](../exports.md#intrinsicsflags)
 
 #### Returns
 
@@ -705,7 +707,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:308
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:298
+packages/quickjs-ffi-types/dist/index.d.ts:321
 
 ***
 
@@ -723,7 +725,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:298
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:285
+packages/quickjs-ffi-types/dist/index.d.ts:308
 
 ***
 
@@ -743,7 +745,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:285
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:309
+packages/quickjs-ffi-types/dist/index.d.ts:332
 
 ***
 
@@ -765,7 +767,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:309
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:333
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -783,7 +785,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:333
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:305
+packages/quickjs-ffi-types/dist/index.d.ts:328
 
 ***
 
@@ -803,7 +805,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:305
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:306
+packages/quickjs-ffi-types/dist/index.d.ts:329
 
 ***
 
@@ -823,7 +825,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:306
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:329
+packages/quickjs-ffi-types/dist/index.d.ts:352
 
 ***
 
@@ -837,7 +839,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:329
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:296
+packages/quickjs-ffi-types/dist/index.d.ts:319
 
 ***
 
@@ -857,7 +859,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:296
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:311
+packages/quickjs-ffi-types/dist/index.d.ts:334
 
 ***
 
@@ -879,7 +881,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:311
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:315
+packages/quickjs-ffi-types/dist/index.d.ts:338
 
 ***
 
@@ -893,7 +895,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:315
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:289
+packages/quickjs-ffi-types/dist/index.d.ts:312
 
 ***
 
@@ -913,7 +915,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:289
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:324
+packages/quickjs-ffi-types/dist/index.d.ts:347
 
 ***
 
@@ -933,7 +935,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:324
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:287
+packages/quickjs-ffi-types/dist/index.d.ts:310
 
 ***
 
@@ -951,7 +953,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:287
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:336
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -969,7 +971,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:336
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:338
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -987,7 +989,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:338
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:311
 
 ***
 
@@ -1005,7 +1007,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:335
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -1025,7 +1027,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:335
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:337
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -1045,7 +1047,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:337
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:291
+packages/quickjs-ffi-types/dist/index.d.ts:314
 
 ***
 
@@ -1065,7 +1067,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:291
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:286
+packages/quickjs-ffi-types/dist/index.d.ts:309
 
 ***
 
@@ -1089,7 +1091,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:286
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:321
+packages/quickjs-ffi-types/dist/index.d.ts:344
 
 ***
 
@@ -1107,7 +1109,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:321
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:330
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -1127,7 +1129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:284
+packages/quickjs-ffi-types/dist/index.d.ts:307
 
 ***
 
@@ -1147,7 +1149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:284
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:327
+packages/quickjs-ffi-types/dist/index.d.ts:350
 
 ***
 
@@ -1167,7 +1169,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:327
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:340
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -1187,7 +1189,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:340
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:339
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:460
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:461
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:459
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/RuntimeOptions.md
+++ b/doc/quickjs-emscripten/interfaces/RuntimeOptions.md
@@ -35,7 +35,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:421
+packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 ***
 
@@ -49,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:416
+packages/quickjs-emscripten-core/dist/index.d.ts:412
 
 ***
 
@@ -63,7 +63,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:417
+packages/quickjs-emscripten-core/dist/index.d.ts:413
 
 ***
 
@@ -77,7 +77,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:418
+packages/quickjs-emscripten-core/dist/index.d.ts:414
 
 ***
 
@@ -87,7 +87,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:435
+packages/quickjs-emscripten-core/dist/index.d.ts:431
 
 ***
 
@@ -101,7 +101,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:435
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:419
+packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 ***
 
@@ -115,7 +115,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:420
+packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:422
+packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/RuntimeOptionsBase.md
+++ b/doc/quickjs-emscripten/interfaces/RuntimeOptionsBase.md
@@ -31,7 +31,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:421
+packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 ***
 
@@ -41,7 +41,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:416
+packages/quickjs-emscripten-core/dist/index.d.ts:412
 
 ***
 
@@ -51,7 +51,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:417
+packages/quickjs-emscripten-core/dist/index.d.ts:413
 
 ***
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:418
+packages/quickjs-emscripten-core/dist/index.d.ts:414
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:419
+packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 ***
 
@@ -81,7 +81,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:420
+packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 ***
 
@@ -91,7 +91,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:422
+packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/SourceMapData.md
+++ b/doc/quickjs-emscripten/interfaces/SourceMapData.md
@@ -22,7 +22,7 @@
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:145
+packages/quickjs-ffi-types/dist/index.d.ts:168
 
 ***
 
@@ -32,7 +32,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:145
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:144
+packages/quickjs-ffi-types/dist/index.d.ts:167
 
 ***
 
@@ -42,7 +42,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:144
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:143
+packages/quickjs-ffi-types/dist/index.d.ts:166
 
 ***
 
@@ -52,7 +52,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:143
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:142
+packages/quickjs-ffi-types/dist/index.d.ts:165
 
 ***
 

--- a/doc/quickjs-emscripten/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten/namespaces/errors/README.md
@@ -14,6 +14,7 @@
   - [QuickJSEmscriptenModuleError](README.md#quickjsemscriptenmoduleerror)
   - [QuickJSMemoryLeakDetected](README.md#quickjsmemoryleakdetected)
   - [QuickJSNotImplemented](README.md#quickjsnotimplemented)
+  - [QuickJSUnknownIntrinsic](README.md#quickjsunknownintrinsic)
   - [QuickJSUnwrapError](README.md#quickjsunwraperror)
   - [QuickJSUseAfterFree](README.md#quickjsuseafterfree)
   - [QuickJSWrongOwner](README.md#quickjswrongowner)
@@ -23,6 +24,7 @@
   - [QuickJSEmscriptenModuleError](README.md#quickjsemscriptenmoduleerror-1)
   - [QuickJSMemoryLeakDetected](README.md#quickjsmemoryleakdetected-1)
   - [QuickJSNotImplemented](README.md#quickjsnotimplemented-1)
+  - [QuickJSUnknownIntrinsic](README.md#quickjsunknownintrinsic-1)
   - [QuickJSUnwrapError](README.md#quickjsunwraperror-1)
   - [QuickJSUseAfterFree](README.md#quickjsuseafterfree-1)
   - [QuickJSWrongOwner](README.md#quickjswrongowner-1)
@@ -35,7 +37,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1415
+packages/quickjs-emscripten-core/dist/index.d.ts:1459
 
 ***
 
@@ -45,7 +47,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1415
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1417
+packages/quickjs-emscripten-core/dist/index.d.ts:1461
 
 ***
 
@@ -55,7 +57,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1419
+packages/quickjs-emscripten-core/dist/index.d.ts:1463
 
 ***
 
@@ -65,7 +67,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1419
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1421
+packages/quickjs-emscripten-core/dist/index.d.ts:1465
 
 ***
 
@@ -75,7 +77,17 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1421
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1423
+packages/quickjs-emscripten-core/dist/index.d.ts:1467
+
+***
+
+### QuickJSUnknownIntrinsic
+
+> **QuickJSUnknownIntrinsic**: `QuickJSUnknownIntrinsic`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:1469
 
 ***
 
@@ -85,7 +97,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1423
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1425
+packages/quickjs-emscripten-core/dist/index.d.ts:1471
 
 ***
 
@@ -95,7 +107,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1425
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1427
+packages/quickjs-emscripten-core/dist/index.d.ts:1473
 
 ***
 
@@ -105,7 +117,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1427
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1429
+packages/quickjs-emscripten-core/dist/index.d.ts:1475
 
 ## Variables
 
@@ -115,7 +127,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1429
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1415
+packages/quickjs-emscripten-core/dist/index.d.ts:1459
 
 ***
 
@@ -125,7 +137,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1415
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1417
+packages/quickjs-emscripten-core/dist/index.d.ts:1461
 
 ***
 
@@ -135,7 +147,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1419
+packages/quickjs-emscripten-core/dist/index.d.ts:1463
 
 ***
 
@@ -145,7 +157,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1419
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1421
+packages/quickjs-emscripten-core/dist/index.d.ts:1465
 
 ***
 
@@ -155,7 +167,17 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1421
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1423
+packages/quickjs-emscripten-core/dist/index.d.ts:1467
+
+***
+
+### QuickJSUnknownIntrinsic
+
+> **QuickJSUnknownIntrinsic**: *typeof* `QuickJSUnknownIntrinsic`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:1469
 
 ***
 
@@ -165,7 +187,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1423
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1425
+packages/quickjs-emscripten-core/dist/index.d.ts:1471
 
 ***
 
@@ -175,7 +197,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1425
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1427
+packages/quickjs-emscripten-core/dist/index.d.ts:1473
 
 ***
 
@@ -185,7 +207,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1427
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1429
+packages/quickjs-emscripten-core/dist/index.d.ts:1475
 
 ***
 

--- a/packages/quickjs-emscripten-core/src/errors.ts
+++ b/packages/quickjs-emscripten-core/src/errors.ts
@@ -40,3 +40,7 @@ export class QuickJSMemoryLeakDetected extends Error {
 export class QuickJSEmscriptenModuleError extends Error {
   name = "QuickJSEmscriptenModuleError"
 }
+
+export class QuickJSUnknownIntrinsic extends TypeError {
+  name = "QuickJSUnknownIntrinsic"
+}

--- a/packages/quickjs-emscripten-core/src/index.ts
+++ b/packages/quickjs-emscripten-core/src/index.ts
@@ -41,7 +41,9 @@ export type {
   JSModuleNormalizeResult,
   JSModuleNormalizeFailure,
   JSModuleNormalizeSuccess,
+  Intrinsics,
 } from "./types"
+export { DefaultIntrinsics } from "./types"
 export type { ModuleEvalOptions } from "./module"
 export { QuickJSPropertyKey } from "./context"
 export { debugLog } from "./debug"

--- a/packages/quickjs-emscripten-core/src/runtime-asyncify.ts
+++ b/packages/quickjs-emscripten-core/src/runtime-asyncify.ts
@@ -19,7 +19,7 @@ import type {
   JSModuleNormalizer,
   JSModuleNormalizerAsync,
 } from "./types"
-import { DefaultIntrinsics, intrinsicsToEnum } from "./types"
+import { intrinsicsToFlags } from "./types"
 import { Lifetime } from "./lifetime"
 
 export class QuickJSAsyncRuntime extends QuickJSRuntime {
@@ -47,7 +47,7 @@ export class QuickJSAsyncRuntime extends QuickJSRuntime {
   }
 
   override newContext(options: ContextOptions = {}): QuickJSAsyncContext {
-    const intrinsics = intrinsicsToEnum(options.intrinsics)
+    const intrinsics = intrinsicsToFlags(options.intrinsics)
     const ctx = new Lifetime(
       this.ffi.QTS_NewContext(this.rt.value, intrinsics),
       undefined,

--- a/packages/quickjs-emscripten-core/src/runtime-asyncify.ts
+++ b/packages/quickjs-emscripten-core/src/runtime-asyncify.ts
@@ -19,7 +19,7 @@ import type {
   JSModuleNormalizer,
   JSModuleNormalizerAsync,
 } from "./types"
-import { DefaultIntrinsics } from "./types"
+import { DefaultIntrinsics, intrinsicsToEnum } from "./types"
 import { Lifetime } from "./lifetime"
 
 export class QuickJSAsyncRuntime extends QuickJSRuntime {
@@ -47,15 +47,16 @@ export class QuickJSAsyncRuntime extends QuickJSRuntime {
   }
 
   override newContext(options: ContextOptions = {}): QuickJSAsyncContext {
-    if (options.intrinsics && options.intrinsics !== DefaultIntrinsics) {
-      throw new Error("TODO: Custom intrinsics are not supported yet")
-    }
-
-    const ctx = new Lifetime(this.ffi.QTS_NewContext(this.rt.value), undefined, (ctx_ptr) => {
-      this.contextMap.delete(ctx_ptr)
-      this.callbacks.deleteContext(ctx_ptr)
-      this.ffi.QTS_FreeContext(ctx_ptr)
-    })
+    const intrinsics = intrinsicsToEnum(options.intrinsics)
+    const ctx = new Lifetime(
+      this.ffi.QTS_NewContext(this.rt.value, intrinsics),
+      undefined,
+      (ctx_ptr) => {
+        this.contextMap.delete(ctx_ptr)
+        this.callbacks.deleteContext(ctx_ptr)
+        this.ffi.QTS_FreeContext(ctx_ptr)
+      },
+    )
 
     const context = new QuickJSAsyncContext({
       module: this.module,

--- a/packages/quickjs-emscripten-core/src/runtime.ts
+++ b/packages/quickjs-emscripten-core/src/runtime.ts
@@ -15,7 +15,7 @@ import { Lifetime, Scope, UsingDisposable } from "./lifetime"
 import { ModuleMemory } from "./memory"
 import type { QuickJSModuleCallbacks, RuntimeCallbacks } from "./module"
 import type { ContextOptions, JSModuleLoader, JSModuleNormalizer, QuickJSHandle } from "./types"
-import { intrinsicsToEnum } from "./types"
+import { intrinsicsToFlags } from "./types"
 import type { SuccessOrFail } from "./vm-interface"
 
 /**
@@ -135,7 +135,7 @@ export class QuickJSRuntime extends UsingDisposable implements Disposable {
    * You should dispose a created context before disposing this runtime.
    */
   newContext(options: ContextOptions = {}): QuickJSContext {
-    const intrinsics = intrinsicsToEnum(options.intrinsics)
+    const intrinsics = intrinsicsToFlags(options.intrinsics)
     const ctx = new Lifetime(
       options.contextPointer || this.ffi.QTS_NewContext(this.rt.value, intrinsics),
       undefined,

--- a/packages/quickjs-emscripten-core/src/runtime.ts
+++ b/packages/quickjs-emscripten-core/src/runtime.ts
@@ -15,7 +15,7 @@ import { Lifetime, Scope, UsingDisposable } from "./lifetime"
 import { ModuleMemory } from "./memory"
 import type { QuickJSModuleCallbacks, RuntimeCallbacks } from "./module"
 import type { ContextOptions, JSModuleLoader, JSModuleNormalizer, QuickJSHandle } from "./types"
-import { DefaultIntrinsics } from "./types"
+import { intrinsicsToEnum } from "./types"
 import type { SuccessOrFail } from "./vm-interface"
 
 /**
@@ -135,12 +135,9 @@ export class QuickJSRuntime extends UsingDisposable implements Disposable {
    * You should dispose a created context before disposing this runtime.
    */
   newContext(options: ContextOptions = {}): QuickJSContext {
-    if (options.intrinsics && options.intrinsics !== DefaultIntrinsics) {
-      throw new Error("TODO: Custom intrinsics are not supported yet")
-    }
-
+    const intrinsics = intrinsicsToEnum(options.intrinsics)
     const ctx = new Lifetime(
-      options.contextPointer || this.ffi.QTS_NewContext(this.rt.value),
+      options.contextPointer || this.ffi.QTS_NewContext(this.rt.value, intrinsics),
       undefined,
       (ctx_ptr) => {
         this.contextMap.delete(ctx_ptr)

--- a/packages/quickjs-emscripten-core/src/types.ts
+++ b/packages/quickjs-emscripten-core/src/types.ts
@@ -136,11 +136,34 @@ export interface AsyncRuntimeOptions extends RuntimeOptionsBase {
   moduleLoader?: JSModuleLoaderAsync | JSModuleLoader
 }
 
+// This guy could be declared as Partial<Record<keyof typeof IntrinsicsFlags, boolean>>,
+// but it leads to bad docs.
 /**
  * Language features that can be enabled or disabled in a QuickJSContext.
  * @see {@link ContextOptions}
  */
-export type Intrinsics = Partial<Record<keyof typeof IntrinsicsFlags, boolean>>
+export type Intrinsics = {
+  BaseObjects?: boolean
+  Date?: boolean
+  Eval?: boolean
+  StringNormalize?: boolean
+  RegExp?: boolean
+  RegExpCompiler?: boolean
+  JSON?: boolean
+  Proxy?: boolean
+  MapSet?: boolean
+  TypedArrays?: boolean
+  Promise?: boolean
+  BigInt?: boolean
+  BigFloat?: boolean
+  BigDecimal?: boolean
+  OperatorOverloading?: boolean
+  BignumExt?: boolean
+}
+
+type _Assert<T, U extends T> = U
+type _intrinsicsHasKeysOfIntrinsicFlags = _Assert<keyof Intrinsics, keyof typeof IntrinsicsFlags>
+type _intrinsicsHasKeysOfIntrinsicFlags2 = _Assert<keyof typeof IntrinsicsFlags, keyof Intrinsics>
 
 /**
  * The default {@link Intrinsics} language features enabled in a QuickJSContext.

--- a/packages/quickjs-emscripten/src/quickjs.test.ts
+++ b/packages/quickjs-emscripten/src/quickjs.test.ts
@@ -14,6 +14,7 @@ import type {
   QuickJSAsyncContext,
   QuickJSFFI,
   QuickJSAsyncFFI,
+  ContextOptions,
 } from "."
 import {
   getQuickJS,
@@ -25,12 +26,15 @@ import {
   memoizePromiseFactory,
   debugLog,
   errors,
+  DefaultIntrinsics,
 } from "."
 
 const TEST_NO_ASYNC = Boolean(process.env.TEST_NO_ASYNC)
 const TEST_NG = Boolean(process.env.TEST_NG ?? true)
 
-function contextTests(getContext: () => Promise<QuickJSContext>, isDebug = false) {
+type GetTestContext = (options?: ContextOptions) => Promise<QuickJSContext>
+
+function contextTests(getContext: GetTestContext, isDebug = false) {
   let vm: QuickJSContext = undefined as any
   let ffi: QuickJSFFI | QuickJSAsyncFFI = undefined as any
   let testId = 0
@@ -439,6 +443,47 @@ function contextTests(getContext: () => Promise<QuickJSContext>, isDebug = false
         ;(await getQuickJS()).evalCode('"ok"', { maxStackSizeBytes: 1 })
       } catch (e) {
         return
+      }
+    })
+  })
+
+  describe("intrinsices", () => {
+    it("evalCode - context respects intrinsic options - Date Unavailable", async () => {
+      // Eval is required to use `evalCode`
+      const newContext = await getContext({
+        intrinsics: {
+          BaseObjects: true,
+        },
+      })
+
+      const result = newContext.evalCode(`new Date()`)
+
+      if (!result.error) {
+        assert.fail("result should be an error")
+      }
+
+      assertError(newContext.dump(result.error), {
+        name: "ReferenceError",
+        message: "'Date' is not defined",
+        stack: "    at <eval> (eval.js)\n",
+      })
+
+      result.error.dispose()
+      newContext.dispose()
+    })
+
+    it("evalCode - context executes as expected with default intrinsics", async () => {
+      // Eval is required to use `evalCode`
+      const newContext = await getContext({ intrinsics: DefaultIntrinsics })
+
+      let handle
+      try {
+        handle = newContext.unwrapResult(newContext.evalCode(`new Date()`))
+      } finally {
+        if (handle?.alive) {
+          handle.dispose()
+        }
+        newContext.dispose()
       }
     })
   })
@@ -1050,13 +1095,13 @@ function asyncContextTests(getContext: () => Promise<QuickJSAsyncContext>) {
 describe("QuickJSContext", function () {
   describe("QuickJS.newContext", function () {
     const loader = getQuickJS
-    const getContext = () => loader().then((mod) => mod.newContext())
+    const getContext: GetTestContext = (opts) => loader().then((mod) => mod.newContext(opts))
     contextTests(getContext)
   })
 
   describe("DEBUG sync module", function () {
     const loader = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SYNC))
-    const getContext = () => loader().then((mod) => mod.newContext())
+    const getContext: GetTestContext = (opts) => loader().then((mod) => mod.newContext(opts))
     contextTests(getContext, true)
   })
 
@@ -1065,7 +1110,7 @@ describe("QuickJSContext", function () {
       const loader = memoizePromiseFactory(() =>
         newQuickJSWASMModule(import("@jitl/quickjs-ng-wasmfile-release-sync")),
       )
-      const getContext = () => loader().then((mod) => mod.newContext())
+      const getContext: GetTestContext = (opts) => loader().then((mod) => mod.newContext(opts))
       contextTests(getContext)
     })
   }
@@ -1075,7 +1120,7 @@ if (!TEST_NO_ASYNC) {
   describe("QuickJSAsyncContext", () => {
     describe("newQuickJSAsyncWASMModule", function () {
       const loader = memoizePromiseFactory(() => newQuickJSAsyncWASMModule())
-      const getContext = () => loader().then((mod) => mod.newContext())
+      const getContext = (opts?: ContextOptions) => loader().then((mod) => mod.newContext(opts))
 
       describe("sync API", () => {
         contextTests(getContext)

--- a/packages/quickjs-emscripten/src/quickjs.test.ts
+++ b/packages/quickjs-emscripten/src/quickjs.test.ts
@@ -447,18 +447,20 @@ function contextTests(getContext: GetTestContext, isDebug = false) {
     })
   })
 
-  describe("intrinsices", () => {
+  describe("intrinsics", () => {
     it("evalCode - context respects intrinsic options - Date Unavailable", async () => {
       // Eval is required to use `evalCode`
       const newContext = await getContext({
         intrinsics: {
           BaseObjects: true,
+          Eval: true,
         },
       })
 
       const result = newContext.evalCode(`new Date()`)
 
       if (!result.error) {
+        result.value.dispose()
         assert.fail("result should be an error")
       }
 
@@ -1133,7 +1135,7 @@ if (!TEST_NO_ASYNC) {
 
     describe("DEBUG async module", function () {
       const loader = memoizePromiseFactory(() => newQuickJSAsyncWASMModule(DEBUG_ASYNC))
-      const getContext = () => loader().then((mod) => mod.newContext())
+      const getContext = (opts?: ContextOptions) => loader().then((mod) => mod.newContext(opts))
 
       describe("sync API", () => {
         contextTests(getContext, true)
@@ -1149,7 +1151,7 @@ if (!TEST_NO_ASYNC) {
         const loader = memoizePromiseFactory(() =>
           newQuickJSAsyncWASMModule(import("@jitl/quickjs-ng-wasmfile-release-asyncify")),
         )
-        const getContext = () => loader().then((mod) => mod.newContext())
+        const getContext = (opts?: ContextOptions) => loader().then((mod) => mod.newContext(opts))
 
         describe("sync API", () => {
           contextTests(getContext)
@@ -1195,6 +1197,7 @@ interface ErrorObj {
   stack?: unknown
 }
 function assertError(actual: ErrorObj, expected: ErrorObj) {
-  assert.strictEqual(actual.name, expected.name)
+  assert.strictEqual(`${actual.name}: ${actual.message}`, `${expected.name}: ${expected.message}`)
   assert.strictEqual(actual.message, expected.message)
+  assert.strictEqual(actual.name, expected.name)
 }

--- a/packages/quickjs-ffi-types/src/ffi-async.ts
+++ b/packages/quickjs-ffi-types/src/ffi-async.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "."
@@ -46,7 +47,7 @@ export interface QuickJSAsyncFFI {
   QTS_GetTrue: () => JSValueConstPointer
   QTS_NewRuntime: () => JSRuntimePointer
   QTS_FreeRuntime: (rt: JSRuntimePointer) => void
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer
   QTS_FreeContext: (ctx: JSContextPointer) => void
   QTS_FreeValuePointer: (ctx: JSContextPointer, value: JSValuePointer) => void
   QTS_FreeValuePointerRuntime: (rt: JSRuntimePointer, value: JSValuePointer) => void

--- a/packages/quickjs-ffi-types/src/ffi-types.ts
+++ b/packages/quickjs-ffi-types/src/ffi-types.ts
@@ -101,6 +101,11 @@ export type EvalFlags = Brand<number, "EvalFlags">
 /**
  * @private
  */
+export type IntrinsicsFlags = Brand<number, "IntrinsicsFlags">
+
+/**
+ * @private
+ */
 export type EvalDetectModule = Brand<number, "EvalDetectModule">
 
 export function assertSync<Args extends any[], R>(fn: (...args: Args) => R): (...args: Args) => R {
@@ -136,4 +141,24 @@ export const EvalFlags = {
   JS_EVAL_FLAG_COMPILE_ONLY: 1 << 5,
   /** don't include the stack frames before this eval in the Error() backtraces */
   JS_EVAL_FLAG_BACKTRACE_BARRIER: 1 << 6,
-}
+} as const
+
+/** Bitfield options for QTS_NewContext intrinsices */
+export const IntrinsicsFlags = {
+  BaseObjects: 1 << 0,
+  Date: 1 << 1,
+  Eval: 1 << 2,
+  StringNormalize: 1 << 3,
+  RegExp: 1 << 4,
+  RegExpCompiler: 1 << 5,
+  JSON: 1 << 6,
+  Proxy: 1 << 7,
+  MapSet: 1 << 8,
+  TypedArrays: 1 << 9,
+  Promise: 1 << 10,
+  BigInt: 1 << 11,
+  BigFloat: 1 << 12,
+  BigDecimal: 1 << 13,
+  OperatorOverloading: 1 << 14,
+  BignumExt: 1 << 15,
+} as const

--- a/packages/quickjs-ffi-types/src/ffi.ts
+++ b/packages/quickjs-ffi-types/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "."
 
@@ -45,7 +46,7 @@ export interface QuickJSFFI {
   QTS_GetTrue: () => JSValueConstPointer
   QTS_NewRuntime: () => JSRuntimePointer
   QTS_FreeRuntime: (rt: JSRuntimePointer) => void
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer
   QTS_FreeContext: (ctx: JSContextPointer) => void
   QTS_FreeValuePointer: (ctx: JSContextPointer, value: JSValuePointer) => void
   QTS_FreeValuePointerRuntime: (rt: JSRuntimePointer, value: JSValuePointer) => void

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-ng-wasmfile-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-release-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-browser-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-release-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-cjs-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-release-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-singlefile-mjs-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-release-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-wasmfile-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-debug-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-wasmfile-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
@@ -84,11 +85,8 @@ export class QuickJSAsyncFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/packages/variant-quickjs-wasmfile-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-release-sync/src/ffi.ts
@@ -17,6 +17,7 @@ import {
   JSBorrowedCharPointer,
   JSVoidPointer,
   EvalFlags,
+  IntrinsicsFlags,
   EvalDetectModule,
 } from "@jitl/quickjs-ffi-types"
 
@@ -83,11 +84,8 @@ export class QuickJSFFI {
     "number",
   ])
 
-  QTS_NewContext: (rt: JSRuntimePointer) => JSContextPointer = this.module.cwrap(
-    "QTS_NewContext",
-    "number",
-    ["number"],
-  )
+  QTS_NewContext: (rt: JSRuntimePointer, intrinsics: IntrinsicsFlags) => JSContextPointer =
+    this.module.cwrap("QTS_NewContext", "number", ["number", "number"])
 
   QTS_FreeContext: (ctx: JSContextPointer) => void = this.module.cwrap("QTS_FreeContext", null, [
     "number",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -153,6 +153,10 @@ function cTypeToTypescriptType(ctype: string): ParsedType {
     return { ffi: "string", typescript: "string", ctype, attributes }
   }
 
+  if (type.startsWith("enum")) {
+    return { ffi: "number", typescript: "number", ctype, attributes }
+  }
+
   let typescript = type.replace(/\*/g, "Pointer")
   let ffi: string | null = "number"
 


### PR DESCRIPTION
This is essentially a rebase of #116 after the large project change.
Allows configuring/disabling the intrinsics inside a JSContext to use less memory.