### PR TITLE
context.evalCode(..., filename, { type: "module" }) returns module exports

### DIFF
--- a/c/interface.c
+++ b/c/interface.c
@@ -655,6 +655,9 @@ JSValue qts_resolve_func_data(
 }
 
 MaybeAsync(JSValue *) QTS_Eval(JSContext *ctx, BorrowedHeapChar *js_code, size_t js_code_length, const char *filename, EvalDetectModule detectModule, EvalFlags evalFlags) {
+#ifdef QTS_DEBUG_MODE
+  char msg[500];
+#endif
   if (detectModule) {
     if (JS_DetectModule((const char *)js_code, js_code_length)) {
       QTS_DEBUG("QTS_Eval: Detected module = true");
@@ -674,37 +677,53 @@ MaybeAsync(JSValue *) QTS_Eval(JSContext *ctx, BorrowedHeapChar *js_code, size_t
     QTS_DEBUG("QTS_Eval: JS_EVAL_TYPE_MODULE");
     JSValue func_obj = JS_Eval(ctx, js_code, js_code_length, filename, evalFlags | JS_EVAL_FLAG_COMPILE_ONLY);
     if (JS_IsException(func_obj)) {
+      QTS_DEBUG("QTS_Eval: JS_EVAL_FLAG_COMPILE_ONLY exception")
       return jsvalue_to_heap(func_obj);
     }
 
     if (JS_VALUE_GET_TAG(func_obj) != JS_TAG_MODULE) {
+      QTS_DEBUG("QTS_Eval: JS_EVAL_FLAG_COMPILE_ONLY result != JS_TAG_MODULE")
       JS_FreeValue(ctx, func_obj);
       return jsvalue_to_heap(JS_ThrowInternalError(ctx, "Module code compiled to non-module object"));
     }
 
     module = JS_VALUE_GET_PTR(func_obj);
     if (module == NULL) {
+      QTS_DEBUG("QTS_Eval: JSModuleDef == NULL")
       JS_FreeValue(ctx, func_obj);
       return jsvalue_to_heap(JS_ThrowInternalError(ctx, "Module compiled to null"));
     }
 
     eval_result = JS_EvalFunction(ctx, func_obj);
-    JS_FreeValue(ctx, func_obj);
+    QTS_DEBUG("QTS_Eval: JS_EVAL_TYPE_MODULE eval_result")
+    // It seems like this is a double-free.
+    // JS_FreeValue(ctx, func_obj);
   } else {
     eval_result = JS_Eval(ctx, js_code, js_code_length, filename, evalFlags);
+    QTS_DEBUG("QTS_Eval: JS_EVAL_TYPE_GLOBAL eval_result")
   }
+
+#ifdef QTS_DEBUG_MODE
+  snprintf(msg, 500, "QTS_Eval: eval_result = %d", eval_result);
+  QTS_DEBUG(msg)
+#endif
 
   if (
       // Error - nothing more to do.
       JS_IsException(eval_result)
       // Non-module eval - return the result
       || (evalFlags & JS_EVAL_TYPE_MODULE) == 0) {
+    QTS_DEBUG("QTS_Eval: non-module or exception")
     return jsvalue_to_heap(eval_result);
   }
 
-  // We eval'd a module
+  // We eval'd a module.
   // Make our return type `ModuleExports | Promise<ModuleExports>>`
   JSPromiseStateEnum state = JS_PromiseState(ctx, eval_result);
+#ifdef QTS_DEBUG_MODE
+  snprintf(msg, 500, "QTS_Eval: eval_result JS_PromiseState = %i", state);
+  QTS_DEBUG(msg)
+#endif
   if (
       // quickjs@2024-01-14 evaluating module
       // produced a promise
@@ -712,16 +731,20 @@ MaybeAsync(JSValue *) QTS_Eval(JSContext *ctx, BorrowedHeapChar *js_code, size_t
       // quickjs in compile mode
       // quickjs-ng before rebasing on quickjs@2024-01-14
       // not a promise.
-      || state == -1) {
+      || state < 0) {
+    QTS_DEBUG("QTS_Eval: result: JS_PROMISE_FULFILLED or not a promise")
     JS_FreeValue(ctx, eval_result);
     return jsvalue_to_heap(JS_GetModuleNamespace(ctx, module));
   } else if (state == JS_PROMISE_REJECTED) {
+    QTS_DEBUG("QTS_Eval: result: JS_PROMISE_REJECTED")
     // Module failed, just return the rejected result.
     return jsvalue_to_heap(eval_result);
   } else if (state == JS_PROMISE_PENDING) {
+    QTS_DEBUG("QTS_Eval: result: JS_PROMISE_PENDING")
     // return moduleDone.then(() => module_namespace)
     JSValue module_namespace = JS_GetModuleNamespace(ctx, module);
     if (JS_IsException(module_namespace)) {
+      QTS_DEBUG("QTS_Eval: module_namespace exception")
       JS_FreeValue(ctx, eval_result);
       return jsvalue_to_heap(module_namespace);
     }
@@ -729,12 +752,14 @@ MaybeAsync(JSValue *) QTS_Eval(JSContext *ctx, BorrowedHeapChar *js_code, size_t
     JSValue then_resolve_module_namespace = JS_NewCFunctionData(ctx, &qts_resolve_func_data, 0, 0, 1, &module_namespace);
     JS_FreeValue(ctx, module_namespace);
     if (JS_IsException(then_resolve_module_namespace)) {
+      QTS_DEBUG("QTS_Eval: then_resolve_module_namespace exception")
       JS_FreeValue(ctx, eval_result);
       return jsvalue_to_heap(then_resolve_module_namespace);
     }
 
     JSAtom then_atom = JS_NewAtom(ctx, "then");
     JSValue new_promise = JS_Invoke(ctx, eval_result, then_atom, 1, &then_resolve_module_namespace);
+    QTS_DEBUG("QTS_Eval: new_promise = promise.then(() => resolveModuleNamespace())")
     JS_FreeAtom(ctx, then_atom);
     JS_FreeValue(ctx, then_resolve_module_namespace);
     JS_FreeValue(ctx, eval_result);
@@ -742,6 +767,7 @@ MaybeAsync(JSValue *) QTS_Eval(JSContext *ctx, BorrowedHeapChar *js_code, size_t
     return jsvalue_to_heap(new_promise);
   } else {
     // Unknown case
+    QTS_DEBUG("QTS_Eval: unknown JSPromiseStateEnum")
     return jsvalue_to_heap(eval_result);
   }
 }
@@ -801,6 +827,14 @@ JSValue *QTS_NewPromiseCapability(JSContext *ctx, JSValue **resolve_funcs_out) {
   resolve_funcs_out[0] = jsvalue_to_heap(resolve_funcs[0]);
   resolve_funcs_out[1] = jsvalue_to_heap(resolve_funcs[1]);
   return jsvalue_to_heap(promise);
+}
+
+JSPromiseStateEnum QTS_PromiseState(JSContext *ctx, JSValueConst *promise) {
+  return JS_PromiseState(ctx, *promise);
+}
+
+JSValue *QTS_PromiseResult(JSContext *ctx, JSValueConst *promise) {
+  return jsvalue_to_heap(JS_PromiseResult(ctx, *promise));
 }
 
 void QTS_TestStringArg(const char *string) {

--- a/c/interface.c
+++ b/c/interface.c
@@ -727,11 +727,11 @@ MaybeAsync(JSValue *) QTS_Eval(JSContext *ctx, BorrowedHeapChar *js_code, size_t
   if (
       // quickjs@2024-01-14 evaluating module
       // produced a promise
-      state == JS_PROMISE_FULFILLED
+      (state == JS_PROMISE_FULFILLED)
       // quickjs in compile mode
       // quickjs-ng before rebasing on quickjs@2024-01-14
       // not a promise.
-      || state < 0) {
+      || (state == -1)) {
     QTS_DEBUG("QTS_Eval: result: JS_PROMISE_FULFILLED or not a promise")
     JS_FreeValue(ctx, eval_result);
     return jsvalue_to_heap(JS_GetModuleNamespace(ctx, module));

--- a/doc/@jitl/quickjs-ffi-types/exports.md
+++ b/doc/@jitl/quickjs-ffi-types/exports.md
@@ -17,6 +17,7 @@
   - [JSContextPointer](exports.md#jscontextpointer)
   - [JSContextPointerPointer](exports.md#jscontextpointerpointer)
   - [JSModuleDefPointer](exports.md#jsmoduledefpointer)
+  - [JSPromiseStateEnum](exports.md#jspromisestateenum)
   - [JSRuntimePointer](exports.md#jsruntimepointer)
   - [JSValueConstPointer](exports.md#jsvalueconstpointer)
   - [JSValueConstPointerPointer](exports.md#jsvalueconstpointerpointer)
@@ -31,6 +32,7 @@
 - [Variables](exports.md#variables)
   - [EvalFlags](exports.md#evalflags)
   - [IntrinsicsFlags](exports.md#intrinsicsflags)
+  - [JSPromiseStateEnum](exports.md#jspromisestateenum-1)
 - [Functions](exports.md#functions)
   - [assertSync()](exports.md#assertsync)
 
@@ -128,6 +130,18 @@ for the Emscripten stack.
 #### Source
 
 [packages/quickjs-ffi-types/src/ffi-types.ts:29](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L29)
+
+***
+
+### JSPromiseStateEnum
+
+> **JSPromiseStateEnum**: `Brand`\<*typeof* [`JSPromiseStateEnum`](exports.md#jspromisestateenum-1)\[keyof *typeof* [`JSPromiseStateEnum`](exports.md#jspromisestateenum-1)\], `"JSPromiseStateEnum"`\>
+
+State of a promise.
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi-types.ts:114](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L114)
 
 ***
 
@@ -408,6 +422,30 @@ Bitfield options for QTS_NewContext intrinsices
 
 [packages/quickjs-ffi-types/src/ffi-types.ts:104](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L104)
 
+***
+
+### JSPromiseStateEnum
+
+> **JSPromiseStateEnum**: `Object`
+
+#### Type declaration
+
+##### Fulfilled
+
+> **`readonly`** **Fulfilled**: `1` = `1`
+
+##### Pending
+
+> **`readonly`** **Pending**: `0` = `0`
+
+##### Rejected
+
+> **`readonly`** **Rejected**: `2` = `2`
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi-types.ts:114](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L114)
+
 ## Functions
 
 ### assertSync()
@@ -439,7 +477,7 @@ Bitfield options for QTS_NewContext intrinsices
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-types.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L111)
+[packages/quickjs-ffi-types/src/ffi-types.ts:119](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-types.ts#L119)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncFFI.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncFFI.md
@@ -40,6 +40,7 @@ library.
   - [QTS\_GetFalse](QuickJSAsyncFFI.md#qts-getfalse)
   - [QTS\_GetFloat64](QuickJSAsyncFFI.md#qts-getfloat64)
   - [QTS\_GetGlobalObject](QuickJSAsyncFFI.md#qts-getglobalobject)
+  - [QTS\_GetModuleNamespace](QuickJSAsyncFFI.md#qts-getmodulenamespace)
   - [QTS\_GetNull](QuickJSAsyncFFI.md#qts-getnull)
   - [QTS\_GetProp](QuickJSAsyncFFI.md#qts-getprop)
   - [QTS\_GetProp\_MaybeAsync](QuickJSAsyncFFI.md#qts-getprop-maybeasync)
@@ -114,7 +115,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:194](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L194)
+[packages/quickjs-ffi-types/src/ffi-async.ts:200](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L200)
 
 ***
 
@@ -128,7 +129,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:192](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L192)
+[packages/quickjs-ffi-types/src/ffi-async.ts:198](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L198)
 
 ***
 
@@ -142,7 +143,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L191)
+[packages/quickjs-ffi-types/src/ffi-async.ts:197](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L197)
 
 ***
 
@@ -308,13 +309,15 @@ Set at compile time.
 
 ### QTS\_Eval
 
-> **QTS\_Eval**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+> **QTS\_Eval**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -334,13 +337,15 @@ Set at compile time.
 
 ### QTS\_Eval\_MaybeAsync
 
-> **QTS\_Eval\_MaybeAsync**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer) \| `Promise`\<[`JSValuePointer`](../exports.md#jsvaluepointer)\>
+> **QTS\_Eval\_MaybeAsync**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer) \| `Promise`\<[`JSValuePointer`](../exports.md#jsvaluepointer)\>
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -354,7 +359,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:174](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L174)
+[packages/quickjs-ffi-types/src/ffi-async.ts:175](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L175)
 
 ***
 
@@ -606,7 +611,27 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:185](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L185)
+[packages/quickjs-ffi-types/src/ffi-async.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L191)
+
+***
+
+### QTS\_GetModuleNamespace
+
+> **QTS\_GetModuleNamespace**: (`ctx`, `module_func_obj`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **module\_func\_obj**: [`JSValuePointer`](../exports.md#jsvaluepointer) \| [`JSValueConstPointer`](../exports.md#jsvalueconstpointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi-async.ts:183](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L183)
 
 ***
 
@@ -910,7 +935,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:193](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L193)
+[packages/quickjs-ffi-types/src/ffi-async.ts:199](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L199)
 
 ***
 
@@ -968,7 +993,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:186](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L186)
+[packages/quickjs-ffi-types/src/ffi-async.ts:192](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L192)
 
 ***
 
@@ -1096,7 +1121,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:199](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L199)
+[packages/quickjs-ffi-types/src/ffi-async.ts:205](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L205)
 
 ***
 
@@ -1114,7 +1139,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:201](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L201)
+[packages/quickjs-ffi-types/src/ffi-async.ts:207](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L207)
 
 ***
 
@@ -1150,7 +1175,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:198](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L198)
+[packages/quickjs-ffi-types/src/ffi-async.ts:204](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L204)
 
 ***
 
@@ -1170,7 +1195,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:200](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L200)
+[packages/quickjs-ffi-types/src/ffi-async.ts:206](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L206)
 
 ***
 
@@ -1276,7 +1301,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:190](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L190)
+[packages/quickjs-ffi-types/src/ffi-async.ts:196](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L196)
 
 ***
 
@@ -1316,7 +1341,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L181)
+[packages/quickjs-ffi-types/src/ffi-async.ts:187](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L187)
 
 ***
 
@@ -1336,7 +1361,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:206](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L206)
+[packages/quickjs-ffi-types/src/ffi-async.ts:212](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L212)
 
 ***
 
@@ -1356,7 +1381,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:202](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L202)
+[packages/quickjs-ffi-types/src/ffi-async.ts:208](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L208)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncFFI.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncFFI.md
@@ -63,6 +63,8 @@ library.
   - [QTS\_NewRuntime](QuickJSAsyncFFI.md#qts-newruntime)
   - [QTS\_NewString](QuickJSAsyncFFI.md#qts-newstring)
   - [QTS\_NewSymbol](QuickJSAsyncFFI.md#qts-newsymbol)
+  - [QTS\_PromiseResult](QuickJSAsyncFFI.md#qts-promiseresult)
+  - [QTS\_PromiseState](QuickJSAsyncFFI.md#qts-promisestate)
   - [QTS\_RecoverableLeakCheck](QuickJSAsyncFFI.md#qts-recoverableleakcheck)
   - [QTS\_ResolveException](QuickJSAsyncFFI.md#qts-resolveexception)
   - [QTS\_RuntimeComputeMemoryUsage](QuickJSAsyncFFI.md#qts-runtimecomputememoryusage)
@@ -95,7 +97,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L34)
+[packages/quickjs-ffi-types/src/ffi-async.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L35)
 
 ***
 
@@ -115,7 +117,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:200](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L200)
+[packages/quickjs-ffi-types/src/ffi-async.ts:209](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L209)
 
 ***
 
@@ -129,7 +131,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:198](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L198)
+[packages/quickjs-ffi-types/src/ffi-async.ts:207](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L207)
 
 ***
 
@@ -143,7 +145,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:197](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L197)
+[packages/quickjs-ffi-types/src/ffi-async.ts:206](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L206)
 
 ***
 
@@ -157,7 +159,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L42)
+[packages/quickjs-ffi-types/src/ffi-async.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L43)
 
 ***
 
@@ -183,7 +185,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:144](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L144)
+[packages/quickjs-ffi-types/src/ffi-async.ts:145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L145)
 
 ***
 
@@ -209,7 +211,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L151)
+[packages/quickjs-ffi-types/src/ffi-async.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L152)
 
 ***
 
@@ -243,7 +245,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:133](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L133)
+[packages/quickjs-ffi-types/src/ffi-async.ts:134](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L134)
 
 ***
 
@@ -263,7 +265,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L159)
+[packages/quickjs-ffi-types/src/ffi-async.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L160)
 
 ***
 
@@ -283,7 +285,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L163)
+[packages/quickjs-ffi-types/src/ffi-async.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L164)
 
 ***
 
@@ -303,7 +305,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:56](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L56)
+[packages/quickjs-ffi-types/src/ffi-async.ts:57](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L57)
 
 ***
 
@@ -331,7 +333,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L167)
+[packages/quickjs-ffi-types/src/ffi-async.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L168)
 
 ***
 
@@ -359,7 +361,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:175](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L175)
+[packages/quickjs-ffi-types/src/ffi-async.ts:176](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L176)
 
 ***
 
@@ -381,7 +383,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L101)
+[packages/quickjs-ffi-types/src/ffi-async.ts:102](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L102)
 
 ***
 
@@ -403,7 +405,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:106](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L106)
+[packages/quickjs-ffi-types/src/ffi-async.ts:107](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L107)
 
 ***
 
@@ -423,7 +425,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L55)
+[packages/quickjs-ffi-types/src/ffi-async.ts:56](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L56)
 
 ***
 
@@ -441,7 +443,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L51)
+[packages/quickjs-ffi-types/src/ffi-async.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L52)
 
 ***
 
@@ -459,7 +461,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L49)
+[packages/quickjs-ffi-types/src/ffi-async.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L50)
 
 ***
 
@@ -479,7 +481,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L52)
+[packages/quickjs-ffi-types/src/ffi-async.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L53)
 
 ***
 
@@ -499,7 +501,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L53)
+[packages/quickjs-ffi-types/src/ffi-async.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L54)
 
 ***
 
@@ -519,7 +521,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L54)
+[packages/quickjs-ffi-types/src/ffi-async.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L55)
 
 ***
 
@@ -539,7 +541,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:78](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L78)
+[packages/quickjs-ffi-types/src/ffi-async.ts:79](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L79)
 
 ***
 
@@ -559,7 +561,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:82](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L82)
+[packages/quickjs-ffi-types/src/ffi-async.ts:83](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L83)
 
 ***
 
@@ -573,7 +575,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L46)
+[packages/quickjs-ffi-types/src/ffi-async.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L47)
 
 ***
 
@@ -593,7 +595,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L72)
+[packages/quickjs-ffi-types/src/ffi-async.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L73)
 
 ***
 
@@ -611,7 +613,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:191](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L191)
+[packages/quickjs-ffi-types/src/ffi-async.ts:192](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L192)
 
 ***
 
@@ -631,7 +633,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:183](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L183)
+[packages/quickjs-ffi-types/src/ffi-async.ts:184](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L184)
 
 ***
 
@@ -645,7 +647,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L45)
+[packages/quickjs-ffi-types/src/ffi-async.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L46)
 
 ***
 
@@ -667,7 +669,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:111](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L111)
+[packages/quickjs-ffi-types/src/ffi-async.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L112)
 
 ***
 
@@ -689,7 +691,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:116](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L116)
+[packages/quickjs-ffi-types/src/ffi-async.ts:117](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L117)
 
 ***
 
@@ -709,7 +711,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L74)
+[packages/quickjs-ffi-types/src/ffi-async.ts:75](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L75)
 
 ***
 
@@ -729,7 +731,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L91)
+[packages/quickjs-ffi-types/src/ffi-async.ts:92](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L92)
 
 ***
 
@@ -749,7 +751,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L95)
+[packages/quickjs-ffi-types/src/ffi-async.ts:96](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L96)
 
 ***
 
@@ -763,7 +765,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L47)
+[packages/quickjs-ffi-types/src/ffi-async.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L48)
 
 ***
 
@@ -777,7 +779,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L44)
+[packages/quickjs-ffi-types/src/ffi-async.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L45)
 
 ***
 
@@ -797,7 +799,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L99)
+[packages/quickjs-ffi-types/src/ffi-async.ts:100](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L100)
 
 ***
 
@@ -815,7 +817,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:100](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L100)
+[packages/quickjs-ffi-types/src/ffi-async.ts:101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L101)
 
 ***
 
@@ -833,7 +835,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:65](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L65)
+[packages/quickjs-ffi-types/src/ffi-async.ts:66](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L66)
 
 ***
 
@@ -855,7 +857,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:66](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L66)
+[packages/quickjs-ffi-types/src/ffi-async.ts:67](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L67)
 
 ***
 
@@ -875,7 +877,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L50)
+[packages/quickjs-ffi-types/src/ffi-async.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L51)
 
 ***
 
@@ -893,7 +895,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L37)
+[packages/quickjs-ffi-types/src/ffi-async.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L38)
 
 ***
 
@@ -913,7 +915,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L71)
+[packages/quickjs-ffi-types/src/ffi-async.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L72)
 
 ***
 
@@ -935,7 +937,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:199](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L199)
+[packages/quickjs-ffi-types/src/ffi-async.ts:208](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L208)
 
 ***
 
@@ -953,7 +955,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:60](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L60)
+[packages/quickjs-ffi-types/src/ffi-async.ts:61](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L61)
 
 ***
 
@@ -973,7 +975,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:61](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L61)
+[packages/quickjs-ffi-types/src/ffi-async.ts:62](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L62)
 
 ***
 
@@ -993,7 +995,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:192](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L192)
+[packages/quickjs-ffi-types/src/ffi-async.ts:193](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L193)
 
 ***
 
@@ -1007,7 +1009,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L48)
+[packages/quickjs-ffi-types/src/ffi-async.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L49)
 
 ***
 
@@ -1027,7 +1029,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L73)
+[packages/quickjs-ffi-types/src/ffi-async.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L74)
 
 ***
 
@@ -1049,7 +1051,47 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:86](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L86)
+[packages/quickjs-ffi-types/src/ffi-async.ts:87](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L87)
+
+***
+
+### QTS\_PromiseResult
+
+> **QTS\_PromiseResult**: (`ctx`, `promise`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValuePointer`](../exports.md#jsvaluepointer) \| [`JSValueConstPointer`](../exports.md#jsvalueconstpointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi-async.ts:201](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L201)
+
+***
+
+### QTS\_PromiseState
+
+> **QTS\_PromiseState**: (`ctx`, `promise`) => [`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValuePointer`](../exports.md#jsvaluepointer) \| [`JSValueConstPointer`](../exports.md#jsvalueconstpointer)
+
+#### Returns
+
+[`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi-async.ts:197](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L197)
 
 ***
 
@@ -1063,7 +1105,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L41)
+[packages/quickjs-ffi-types/src/ffi-async.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L42)
 
 ***
 
@@ -1083,7 +1125,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L158)
+[packages/quickjs-ffi-types/src/ffi-async.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L159)
 
 ***
 
@@ -1103,7 +1145,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L39)
+[packages/quickjs-ffi-types/src/ffi-async.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L40)
 
 ***
 
@@ -1121,7 +1163,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:205](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L205)
+[packages/quickjs-ffi-types/src/ffi-async.ts:214](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L214)
 
 ***
 
@@ -1139,7 +1181,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:207](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L207)
+[packages/quickjs-ffi-types/src/ffi-async.ts:216](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L216)
 
 ***
 
@@ -1157,7 +1199,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L40)
+[packages/quickjs-ffi-types/src/ffi-async.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L41)
 
 ***
 
@@ -1175,7 +1217,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:204](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L204)
+[packages/quickjs-ffi-types/src/ffi-async.ts:213](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L213)
 
 ***
 
@@ -1195,7 +1237,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:206](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L206)
+[packages/quickjs-ffi-types/src/ffi-async.ts:215](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L215)
 
 ***
 
@@ -1215,7 +1257,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L43)
+[packages/quickjs-ffi-types/src/ffi-async.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L44)
 
 ***
 
@@ -1235,7 +1277,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L38)
+[packages/quickjs-ffi-types/src/ffi-async.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L39)
 
 ***
 
@@ -1259,7 +1301,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:121](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L121)
+[packages/quickjs-ffi-types/src/ffi-async.ts:122](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L122)
 
 ***
 
@@ -1283,7 +1325,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:127](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L127)
+[packages/quickjs-ffi-types/src/ffi-async.ts:128](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L128)
 
 ***
 
@@ -1301,7 +1343,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:196](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L196)
+[packages/quickjs-ffi-types/src/ffi-async.ts:205](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L205)
 
 ***
 
@@ -1321,7 +1363,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L36)
+[packages/quickjs-ffi-types/src/ffi-async.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L37)
 
 ***
 
@@ -1341,7 +1383,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:187](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L187)
+[packages/quickjs-ffi-types/src/ffi-async.ts:188](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L188)
 
 ***
 
@@ -1361,7 +1403,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:212](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L212)
+[packages/quickjs-ffi-types/src/ffi-async.ts:221](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L221)
 
 ***
 
@@ -1381,7 +1423,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi-async.ts:208](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L208)
+[packages/quickjs-ffi-types/src/ffi-async.ts:217](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi-async.ts#L217)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSFFI.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSFFI.md
@@ -57,6 +57,8 @@ library.
   - [QTS\_NewRuntime](QuickJSFFI.md#qts-newruntime)
   - [QTS\_NewString](QuickJSFFI.md#qts-newstring)
   - [QTS\_NewSymbol](QuickJSFFI.md#qts-newsymbol)
+  - [QTS\_PromiseResult](QuickJSFFI.md#qts-promiseresult)
+  - [QTS\_PromiseState](QuickJSFFI.md#qts-promisestate)
   - [QTS\_RecoverableLeakCheck](QuickJSFFI.md#qts-recoverableleakcheck)
   - [QTS\_ResolveException](QuickJSFFI.md#qts-resolveexception)
   - [QTS\_RuntimeComputeMemoryUsage](QuickJSFFI.md#qts-runtimecomputememoryusage)
@@ -88,7 +90,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:33](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L33)
+[packages/quickjs-ffi-types/src/ffi.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L34)
 
 ***
 
@@ -108,7 +110,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L160)
+[packages/quickjs-ffi-types/src/ffi.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L169)
 
 ***
 
@@ -122,7 +124,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L158)
+[packages/quickjs-ffi-types/src/ffi.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L167)
 
 ***
 
@@ -136,7 +138,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L157)
+[packages/quickjs-ffi-types/src/ffi.ts:166](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L166)
 
 ***
 
@@ -150,7 +152,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L41)
+[packages/quickjs-ffi-types/src/ffi.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L42)
 
 ***
 
@@ -176,7 +178,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:123](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L123)
+[packages/quickjs-ffi-types/src/ffi.ts:124](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L124)
 
 ***
 
@@ -210,7 +212,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:112](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L112)
+[packages/quickjs-ffi-types/src/ffi.ts:113](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L113)
 
 ***
 
@@ -230,7 +232,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:131](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L131)
+[packages/quickjs-ffi-types/src/ffi.ts:132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L132)
 
 ***
 
@@ -250,7 +252,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L55)
+[packages/quickjs-ffi-types/src/ffi.ts:56](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L56)
 
 ***
 
@@ -278,7 +280,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:135](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L135)
+[packages/quickjs-ffi-types/src/ffi.ts:136](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L136)
 
 ***
 
@@ -300,7 +302,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:96](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L96)
+[packages/quickjs-ffi-types/src/ffi.ts:97](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L97)
 
 ***
 
@@ -320,7 +322,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L54)
+[packages/quickjs-ffi-types/src/ffi.ts:55](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L55)
 
 ***
 
@@ -338,7 +340,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L50)
+[packages/quickjs-ffi-types/src/ffi.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L51)
 
 ***
 
@@ -356,7 +358,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L48)
+[packages/quickjs-ffi-types/src/ffi.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L49)
 
 ***
 
@@ -376,7 +378,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L51)
+[packages/quickjs-ffi-types/src/ffi.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L52)
 
 ***
 
@@ -396,7 +398,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L52)
+[packages/quickjs-ffi-types/src/ffi.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L53)
 
 ***
 
@@ -416,7 +418,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:53](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L53)
+[packages/quickjs-ffi-types/src/ffi.ts:54](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L54)
 
 ***
 
@@ -436,7 +438,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:77](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L77)
+[packages/quickjs-ffi-types/src/ffi.ts:78](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L78)
 
 ***
 
@@ -456,7 +458,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:81](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L81)
+[packages/quickjs-ffi-types/src/ffi.ts:82](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L82)
 
 ***
 
@@ -470,7 +472,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L45)
+[packages/quickjs-ffi-types/src/ffi.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L46)
 
 ***
 
@@ -490,7 +492,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L71)
+[packages/quickjs-ffi-types/src/ffi.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L72)
 
 ***
 
@@ -508,7 +510,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L151)
+[packages/quickjs-ffi-types/src/ffi.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L152)
 
 ***
 
@@ -528,7 +530,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:143](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L143)
+[packages/quickjs-ffi-types/src/ffi.ts:144](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L144)
 
 ***
 
@@ -542,7 +544,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L44)
+[packages/quickjs-ffi-types/src/ffi.ts:45](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L45)
 
 ***
 
@@ -564,7 +566,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L101)
+[packages/quickjs-ffi-types/src/ffi.ts:102](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L102)
 
 ***
 
@@ -584,7 +586,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L73)
+[packages/quickjs-ffi-types/src/ffi.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L74)
 
 ***
 
@@ -604,7 +606,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:90](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L90)
+[packages/quickjs-ffi-types/src/ffi.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L91)
 
 ***
 
@@ -618,7 +620,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L46)
+[packages/quickjs-ffi-types/src/ffi.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L47)
 
 ***
 
@@ -632,7 +634,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L43)
+[packages/quickjs-ffi-types/src/ffi.ts:44](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L44)
 
 ***
 
@@ -652,7 +654,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:94](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L94)
+[packages/quickjs-ffi-types/src/ffi.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L95)
 
 ***
 
@@ -670,7 +672,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L95)
+[packages/quickjs-ffi-types/src/ffi.ts:96](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L96)
 
 ***
 
@@ -688,7 +690,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:64](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L64)
+[packages/quickjs-ffi-types/src/ffi.ts:65](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L65)
 
 ***
 
@@ -710,7 +712,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:65](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L65)
+[packages/quickjs-ffi-types/src/ffi.ts:66](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L66)
 
 ***
 
@@ -730,7 +732,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L49)
+[packages/quickjs-ffi-types/src/ffi.ts:50](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L50)
 
 ***
 
@@ -748,7 +750,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L36)
+[packages/quickjs-ffi-types/src/ffi.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L37)
 
 ***
 
@@ -768,7 +770,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:70](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L70)
+[packages/quickjs-ffi-types/src/ffi.ts:71](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L71)
 
 ***
 
@@ -790,7 +792,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L159)
+[packages/quickjs-ffi-types/src/ffi.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L168)
 
 ***
 
@@ -808,7 +810,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:59](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L59)
+[packages/quickjs-ffi-types/src/ffi.ts:60](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L60)
 
 ***
 
@@ -828,7 +830,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:60](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L60)
+[packages/quickjs-ffi-types/src/ffi.ts:61](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L61)
 
 ***
 
@@ -848,7 +850,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L152)
+[packages/quickjs-ffi-types/src/ffi.ts:153](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L153)
 
 ***
 
@@ -862,7 +864,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L47)
+[packages/quickjs-ffi-types/src/ffi.ts:48](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L48)
 
 ***
 
@@ -882,7 +884,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L72)
+[packages/quickjs-ffi-types/src/ffi.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L73)
 
 ***
 
@@ -904,7 +906,47 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L85)
+[packages/quickjs-ffi-types/src/ffi.ts:86](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L86)
+
+***
+
+### QTS\_PromiseResult
+
+> **QTS\_PromiseResult**: (`ctx`, `promise`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValuePointer`](../exports.md#jsvaluepointer) \| [`JSValueConstPointer`](../exports.md#jsvalueconstpointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L161)
+
+***
+
+### QTS\_PromiseState
+
+> **QTS\_PromiseState**: (`ctx`, `promise`) => [`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValuePointer`](../exports.md#jsvaluepointer) \| [`JSValueConstPointer`](../exports.md#jsvalueconstpointer)
+
+#### Returns
+
+[`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L157)
 
 ***
 
@@ -918,7 +960,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L40)
+[packages/quickjs-ffi-types/src/ffi.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L41)
 
 ***
 
@@ -938,7 +980,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:130](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L130)
+[packages/quickjs-ffi-types/src/ffi.ts:131](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L131)
 
 ***
 
@@ -958,7 +1000,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L38)
+[packages/quickjs-ffi-types/src/ffi.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L39)
 
 ***
 
@@ -976,7 +1018,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L165)
+[packages/quickjs-ffi-types/src/ffi.ts:174](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L174)
 
 ***
 
@@ -994,7 +1036,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L167)
+[packages/quickjs-ffi-types/src/ffi.ts:176](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L176)
 
 ***
 
@@ -1012,7 +1054,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:39](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L39)
+[packages/quickjs-ffi-types/src/ffi.ts:40](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L40)
 
 ***
 
@@ -1030,7 +1072,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L164)
+[packages/quickjs-ffi-types/src/ffi.ts:173](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L173)
 
 ***
 
@@ -1050,7 +1092,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:166](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L166)
+[packages/quickjs-ffi-types/src/ffi.ts:175](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L175)
 
 ***
 
@@ -1070,7 +1112,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L42)
+[packages/quickjs-ffi-types/src/ffi.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L43)
 
 ***
 
@@ -1090,7 +1132,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L37)
+[packages/quickjs-ffi-types/src/ffi.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L38)
 
 ***
 
@@ -1114,7 +1156,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:106](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L106)
+[packages/quickjs-ffi-types/src/ffi.ts:107](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L107)
 
 ***
 
@@ -1132,7 +1174,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:156](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L156)
+[packages/quickjs-ffi-types/src/ffi.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L165)
 
 ***
 
@@ -1152,7 +1194,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L35)
+[packages/quickjs-ffi-types/src/ffi.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L36)
 
 ***
 
@@ -1172,7 +1214,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:147](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L147)
+[packages/quickjs-ffi-types/src/ffi.ts:148](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L148)
 
 ***
 
@@ -1192,7 +1234,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:172](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L172)
+[packages/quickjs-ffi-types/src/ffi.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L181)
 
 ***
 
@@ -1212,7 +1254,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L168)
+[packages/quickjs-ffi-types/src/ffi.ts:177](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L177)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSFFI.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSFFI.md
@@ -36,6 +36,7 @@ library.
   - [QTS\_GetFalse](QuickJSFFI.md#qts-getfalse)
   - [QTS\_GetFloat64](QuickJSFFI.md#qts-getfloat64)
   - [QTS\_GetGlobalObject](QuickJSFFI.md#qts-getglobalobject)
+  - [QTS\_GetModuleNamespace](QuickJSFFI.md#qts-getmodulenamespace)
   - [QTS\_GetNull](QuickJSFFI.md#qts-getnull)
   - [QTS\_GetProp](QuickJSFFI.md#qts-getprop)
   - [QTS\_GetString](QuickJSFFI.md#qts-getstring)
@@ -107,7 +108,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:155](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L155)
+[packages/quickjs-ffi-types/src/ffi.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L160)
 
 ***
 
@@ -121,7 +122,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:153](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L153)
+[packages/quickjs-ffi-types/src/ffi.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L158)
 
 ***
 
@@ -135,7 +136,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L152)
+[packages/quickjs-ffi-types/src/ffi.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L157)
 
 ***
 
@@ -255,13 +256,15 @@ Set at compile time.
 
 ### QTS\_Eval
 
-> **QTS\_Eval**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+> **QTS\_Eval**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -505,7 +508,27 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:146](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L146)
+[packages/quickjs-ffi-types/src/ffi.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L151)
+
+***
+
+### QTS\_GetModuleNamespace
+
+> **QTS\_GetModuleNamespace**: (`ctx`, `module_func_obj`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **module\_func\_obj**: [`JSValuePointer`](../exports.md#jsvaluepointer) \| [`JSValueConstPointer`](../exports.md#jsvalueconstpointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+[packages/quickjs-ffi-types/src/ffi.ts:143](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L143)
 
 ***
 
@@ -767,7 +790,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:154](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L154)
+[packages/quickjs-ffi-types/src/ffi.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L159)
 
 ***
 
@@ -825,7 +848,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:147](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L147)
+[packages/quickjs-ffi-types/src/ffi.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L152)
 
 ***
 
@@ -953,7 +976,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L160)
+[packages/quickjs-ffi-types/src/ffi.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L165)
 
 ***
 
@@ -971,7 +994,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L162)
+[packages/quickjs-ffi-types/src/ffi.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L167)
 
 ***
 
@@ -1007,7 +1030,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L159)
+[packages/quickjs-ffi-types/src/ffi.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L164)
 
 ***
 
@@ -1027,7 +1050,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L161)
+[packages/quickjs-ffi-types/src/ffi.ts:166](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L166)
 
 ***
 
@@ -1109,7 +1132,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L151)
+[packages/quickjs-ffi-types/src/ffi.ts:156](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L156)
 
 ***
 
@@ -1149,7 +1172,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:142](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L142)
+[packages/quickjs-ffi-types/src/ffi.ts:147](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L147)
 
 ***
 
@@ -1169,7 +1192,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L167)
+[packages/quickjs-ffi-types/src/ffi.ts:172](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L172)
 
 ***
 
@@ -1189,7 +1212,7 @@ Set at compile time.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/ffi.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L163)
+[packages/quickjs-ffi-types/src/ffi.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/ffi.ts#L168)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
@@ -102,7 +102,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L181)
+[packages/quickjs-emscripten-core/src/context.ts:182](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L182)
 
 ## Properties
 
@@ -136,7 +136,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:209](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L209)
+[packages/quickjs-emscripten-core/src/context.ts:210](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L210)
 
 ***
 
@@ -152,7 +152,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:267](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L267)
+[packages/quickjs-emscripten-core/src/context.ts:268](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L268)
 
 ***
 
@@ -170,7 +170,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:282](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L282)
+[packages/quickjs-emscripten-core/src/context.ts:283](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L283)
 
 ***
 
@@ -186,7 +186,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:241](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L241)
+[packages/quickjs-emscripten-core/src/context.ts:242](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L242)
 
 ***
 
@@ -202,7 +202,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:254](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L254)
+[packages/quickjs-emscripten-core/src/context.ts:255](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L255)
 
 ***
 
@@ -218,7 +218,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:228](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L228)
+[packages/quickjs-emscripten-core/src/context.ts:229](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L229)
 
 ## Methods
 
@@ -276,7 +276,7 @@ value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:815](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L815)
+[packages/quickjs-emscripten-core/src/context.ts:821](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L821)
 
 ***
 
@@ -309,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1126)
+[packages/quickjs-emscripten-core/src/context.ts:1132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1132)
 
 ***
 
@@ -340,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:766](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L766)
+[packages/quickjs-emscripten-core/src/context.ts:772](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L772)
 
 ***
 
@@ -365,7 +365,7 @@ will result in an error.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:219](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L219)
+[packages/quickjs-emscripten-core/src/context.ts:220](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L220)
 
 ***
 
@@ -390,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:952](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L952)
+[packages/quickjs-emscripten-core/src/context.ts:958](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L958)
 
 ***
 
@@ -424,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1109](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1109)
+[packages/quickjs-emscripten-core/src/context.ts:1115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1115)
 
 ***
 
@@ -487,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:875](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L875)
+[packages/quickjs-emscripten-core/src/context.ts:881](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L881)
 
 ***
 
@@ -537,7 +537,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:641](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L641)
+[packages/quickjs-emscripten-core/src/context.ts:642](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L642)
 
 ***
 
@@ -561,7 +561,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:632](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L632)
+[packages/quickjs-emscripten-core/src/context.ts:633](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L633)
 
 ***
 
@@ -587,7 +587,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:603](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L603)
+[packages/quickjs-emscripten-core/src/context.ts:604](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L604)
 
 ***
 
@@ -609,7 +609,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:653](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L653)
+[packages/quickjs-emscripten-core/src/context.ts:654](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L654)
 
 ***
 
@@ -639,7 +639,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:730](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L730)
+[packages/quickjs-emscripten-core/src/context.ts:736](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L736)
 
 ***
 
@@ -663,7 +663,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:611](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L611)
+[packages/quickjs-emscripten-core/src/context.ts:612](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L612)
 
 ***
 
@@ -688,7 +688,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:620](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L620)
+[packages/quickjs-emscripten-core/src/context.ts:621](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L621)
 
 ***
 
@@ -709,7 +709,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:381](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L381)
+[packages/quickjs-emscripten-core/src/context.ts:382](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L382)
 
 ***
 
@@ -733,7 +733,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:389](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L389)
+[packages/quickjs-emscripten-core/src/context.ts:390](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L390)
 
 ***
 
@@ -789,7 +789,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:347](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L347)
+[packages/quickjs-emscripten-core/src/context.ts:348](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L348)
 
 ***
 
@@ -817,7 +817,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:558](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L558)
+[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
 
 #### newError(message)
 
@@ -837,7 +837,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
+[packages/quickjs-emscripten-core/src/context.ts:560](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L560)
 
 #### newError(undefined)
 
@@ -853,7 +853,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:560](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L560)
+[packages/quickjs-emscripten-core/src/context.ts:561](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L561)
 
 ***
 
@@ -970,7 +970,7 @@ return deferred.handle
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:552](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L552)
+[packages/quickjs-emscripten-core/src/context.ts:553](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L553)
 
 ***
 
@@ -994,7 +994,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:306](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L306)
+[packages/quickjs-emscripten-core/src/context.ts:307](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L307)
 
 ***
 
@@ -1021,7 +1021,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:367](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L367)
+[packages/quickjs-emscripten-core/src/context.ts:368](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L368)
 
 ***
 
@@ -1046,7 +1046,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:402](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L402)
+[packages/quickjs-emscripten-core/src/context.ts:403](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L403)
 
 #### newPromise(promise)
 
@@ -1072,7 +1072,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:410](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L410)
+[packages/quickjs-emscripten-core/src/context.ts:411](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L411)
 
 #### newPromise(newPromiseFn)
 
@@ -1097,7 +1097,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:417](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L417)
+[packages/quickjs-emscripten-core/src/context.ts:418](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L418)
 
 ***
 
@@ -1121,7 +1121,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:313](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L313)
+[packages/quickjs-emscripten-core/src/context.ts:314](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L314)
 
 ***
 
@@ -1146,7 +1146,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:336](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L336)
+[packages/quickjs-emscripten-core/src/context.ts:337](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L337)
 
 ***
 
@@ -1171,7 +1171,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:324](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L324)
+[packages/quickjs-emscripten-core/src/context.ts:325](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L325)
 
 ***
 
@@ -1203,7 +1203,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:687](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L687)
+[packages/quickjs-emscripten-core/src/context.ts:693](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L693)
 
 ***
 
@@ -1240,7 +1240,7 @@ properties.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:751](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L751)
+[packages/quickjs-emscripten-core/src/context.ts:757](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L757)
 
 ***
 
@@ -1264,7 +1264,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:912](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L912)
+[packages/quickjs-emscripten-core/src/context.ts:918](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L918)
 
 ***
 
@@ -1292,7 +1292,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:594](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L594)
+[packages/quickjs-emscripten-core/src/context.ts:595](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L595)
 
 ***
 
@@ -1323,7 +1323,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:981](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L981)
+[packages/quickjs-emscripten-core/src/context.ts:987](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L987)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
@@ -276,7 +276,7 @@ value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:821](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L821)
+[packages/quickjs-emscripten-core/src/context.ts:834](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L834)
 
 ***
 
@@ -309,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1132)
+[packages/quickjs-emscripten-core/src/context.ts:1145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1145)
 
 ***
 
@@ -340,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:772](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L772)
+[packages/quickjs-emscripten-core/src/context.ts:785](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L785)
 
 ***
 
@@ -390,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:958](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L958)
+[packages/quickjs-emscripten-core/src/context.ts:971](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L971)
 
 ***
 
@@ -424,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1115)
+[packages/quickjs-emscripten-core/src/context.ts:1128](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1128)
 
 ***
 
@@ -487,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:881](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L881)
+[packages/quickjs-emscripten-core/src/context.ts:894](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L894)
 
 ***
 
@@ -595,6 +595,18 @@ Converts `handle` into a Javascript number.
 
 > **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
 
+Get the current state of a QuickJS promise, see [JSPromiseState](../exports.md#jspromisestate) for the possible states.
+This can be used to expect a promise to be fulfilled when combined with [unwrapResult](QuickJSAsyncContext.md#unwrapresult):
+
+```typescript
+const promiseHandle = context.evalCode(`Promise.resolve(42)`);
+const resultHandle = context.unwrapResult(
+ context.getPromiseState(promiseHandle)
+);
+context.getNumber(resultHandle) === 42; // true
+resultHandle.dispose();
+```
+
 #### Parameters
 
 • **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
@@ -609,7 +621,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:654](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L654)
+[packages/quickjs-emscripten-core/src/context.ts:667](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L667)
 
 ***
 
@@ -639,7 +651,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:736](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L736)
+[packages/quickjs-emscripten-core/src/context.ts:749](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L749)
 
 ***
 
@@ -1203,7 +1215,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:693](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L693)
+[packages/quickjs-emscripten-core/src/context.ts:706](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L706)
 
 ***
 
@@ -1240,7 +1252,7 @@ properties.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:757](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L757)
+[packages/quickjs-emscripten-core/src/context.ts:770](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L770)
 
 ***
 
@@ -1264,7 +1276,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:918](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L918)
+[packages/quickjs-emscripten-core/src/context.ts:931](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L931)
 
 ***
 
@@ -1323,7 +1335,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:987](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L987)
+[packages/quickjs-emscripten-core/src/context.ts:1000](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1000)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
@@ -308,7 +308,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1081](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1081)
+[packages/quickjs-emscripten-core/src/context.ts:1101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1101)
 
 ***
 
@@ -389,7 +389,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:907](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L907)
+[packages/quickjs-emscripten-core/src/context.ts:927](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L927)
 
 ***
 
@@ -423,7 +423,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1064](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1064)
+[packages/quickjs-emscripten-core/src/context.ts:1084](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1084)
 
 ***
 
@@ -432,7 +432,20 @@ socket.write(dataLifetime?.value)
 > **evalCode**(`code`, `filename`, `options`?): [`VmCallResult`](../exports.md#vmcallresultvmhandle)\<[`QuickJSHandle`](../exports.md#quickjshandle)\>
 
 Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
-Evaluates the Javascript source `code` in the global scope of this VM.
+
+Evaluates `code`, as though it's in a file named `filename`, with options `options`.
+
+- When `options.type` is `"global"`, the code is evaluated in the global
+  scope of the QuickJSContext, and the return value is the result of the last
+  expression.
+- When `options.type` is `"module"`, the code is evaluated is a module scope.
+  It may use `import` and `export` if [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#setModuleLoader](QuickJSRuntime.md#setmoduleloader) was called.
+  It may use top-level await if supported by the underlying QuickJS library.
+  The return value is the module's exports, or a promise for the module's exports.
+- When `options.type` is unset, the code is evaluated as a module if it
+  contains an `import` or `export` statement, otherwise it is evaluated in
+  the global scope.
+
 When working with async code, you many need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#executePendingJobs](QuickJSRuntime.md#executependingjobs)
 to execute callbacks pending after synchronous evaluation returns.
 
@@ -473,7 +486,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:837](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L837)
+[packages/quickjs-emscripten-core/src/context.ts:850](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L850)
 
 ***
 
@@ -729,7 +742,7 @@ See [Emscripten's docs on Asyncify](https://emscripten.org/docs/porting/asyncify
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context-asyncify.ts:90](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context-asyncify.ts#L90)
+[packages/quickjs-emscripten-core/src/context-asyncify.ts:91](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context-asyncify.ts#L91)
 
 ***
 
@@ -1228,7 +1241,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:867](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L867)
+[packages/quickjs-emscripten-core/src/context.ts:887](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L887)
 
 ***
 
@@ -1287,7 +1300,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:936](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L936)
+[packages/quickjs-emscripten-core/src/context.ts:956](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L956)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSAsyncContext.md
@@ -39,6 +39,7 @@ host functions as though they were synchronous.
   - [getArrayBuffer()](QuickJSAsyncContext.md#getarraybuffer)
   - [getBigInt()](QuickJSAsyncContext.md#getbigint)
   - [getNumber()](QuickJSAsyncContext.md#getnumber)
+  - [getPromiseState()](QuickJSAsyncContext.md#getpromisestate)
   - [getProp()](QuickJSAsyncContext.md#getprop)
   - [getString()](QuickJSAsyncContext.md#getstring)
   - [getSymbol()](QuickJSAsyncContext.md#getsymbol)
@@ -101,7 +102,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:180](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L180)
+[packages/quickjs-emscripten-core/src/context.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L181)
 
 ## Properties
 
@@ -135,7 +136,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:208](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L208)
+[packages/quickjs-emscripten-core/src/context.ts:209](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L209)
 
 ***
 
@@ -151,7 +152,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:266](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L266)
+[packages/quickjs-emscripten-core/src/context.ts:267](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L267)
 
 ***
 
@@ -169,7 +170,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:281](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L281)
+[packages/quickjs-emscripten-core/src/context.ts:282](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L282)
 
 ***
 
@@ -185,7 +186,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:240](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L240)
+[packages/quickjs-emscripten-core/src/context.ts:241](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L241)
 
 ***
 
@@ -201,7 +202,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:253](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L253)
+[packages/quickjs-emscripten-core/src/context.ts:254](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L254)
 
 ***
 
@@ -217,7 +218,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:227](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L227)
+[packages/quickjs-emscripten-core/src/context.ts:228](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L228)
 
 ## Methods
 
@@ -275,7 +276,7 @@ value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:790](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L790)
+[packages/quickjs-emscripten-core/src/context.ts:815](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L815)
 
 ***
 
@@ -308,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1101)
+[packages/quickjs-emscripten-core/src/context.ts:1126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1126)
 
 ***
 
@@ -339,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:741](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L741)
+[packages/quickjs-emscripten-core/src/context.ts:766](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L766)
 
 ***
 
@@ -364,7 +365,7 @@ will result in an error.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:218](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L218)
+[packages/quickjs-emscripten-core/src/context.ts:219](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L219)
 
 ***
 
@@ -389,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:927](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L927)
+[packages/quickjs-emscripten-core/src/context.ts:952](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L952)
 
 ***
 
@@ -423,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1084](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1084)
+[packages/quickjs-emscripten-core/src/context.ts:1109](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1109)
 
 ***
 
@@ -486,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:850](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L850)
+[packages/quickjs-emscripten-core/src/context.ts:875](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L875)
 
 ***
 
@@ -536,7 +537,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:640](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L640)
+[packages/quickjs-emscripten-core/src/context.ts:641](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L641)
 
 ***
 
@@ -560,7 +561,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:631](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L631)
+[packages/quickjs-emscripten-core/src/context.ts:632](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L632)
 
 ***
 
@@ -586,7 +587,29 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:602](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L602)
+[packages/quickjs-emscripten-core/src/context.ts:603](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L603)
+
+***
+
+### getPromiseState()
+
+> **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Parameters
+
+• **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Returns
+
+[`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Inherited from
+
+[`quickjs-emscripten-core.QuickJSContext.getPromiseState`](QuickJSContext.md#getpromisestate)
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/context.ts:653](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L653)
 
 ***
 
@@ -616,7 +639,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:705](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L705)
+[packages/quickjs-emscripten-core/src/context.ts:730](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L730)
 
 ***
 
@@ -640,7 +663,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:610](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L610)
+[packages/quickjs-emscripten-core/src/context.ts:611](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L611)
 
 ***
 
@@ -665,7 +688,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:619](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L619)
+[packages/quickjs-emscripten-core/src/context.ts:620](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L620)
 
 ***
 
@@ -686,7 +709,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:380](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L380)
+[packages/quickjs-emscripten-core/src/context.ts:381](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L381)
 
 ***
 
@@ -710,7 +733,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:388](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L388)
+[packages/quickjs-emscripten-core/src/context.ts:389](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L389)
 
 ***
 
@@ -766,7 +789,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:346](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L346)
+[packages/quickjs-emscripten-core/src/context.ts:347](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L347)
 
 ***
 
@@ -794,7 +817,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:557](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L557)
+[packages/quickjs-emscripten-core/src/context.ts:558](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L558)
 
 #### newError(message)
 
@@ -814,7 +837,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:558](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L558)
+[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
 
 #### newError(undefined)
 
@@ -830,7 +853,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
+[packages/quickjs-emscripten-core/src/context.ts:560](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L560)
 
 ***
 
@@ -947,7 +970,7 @@ return deferred.handle
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:551](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L551)
+[packages/quickjs-emscripten-core/src/context.ts:552](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L552)
 
 ***
 
@@ -971,7 +994,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:305](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L305)
+[packages/quickjs-emscripten-core/src/context.ts:306](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L306)
 
 ***
 
@@ -998,7 +1021,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:366](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L366)
+[packages/quickjs-emscripten-core/src/context.ts:367](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L367)
 
 ***
 
@@ -1023,7 +1046,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:401](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L401)
+[packages/quickjs-emscripten-core/src/context.ts:402](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L402)
 
 #### newPromise(promise)
 
@@ -1049,7 +1072,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:409](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L409)
+[packages/quickjs-emscripten-core/src/context.ts:410](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L410)
 
 #### newPromise(newPromiseFn)
 
@@ -1074,7 +1097,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:416](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L416)
+[packages/quickjs-emscripten-core/src/context.ts:417](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L417)
 
 ***
 
@@ -1098,7 +1121,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:312](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L312)
+[packages/quickjs-emscripten-core/src/context.ts:313](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L313)
 
 ***
 
@@ -1123,7 +1146,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:335](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L335)
+[packages/quickjs-emscripten-core/src/context.ts:336](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L336)
 
 ***
 
@@ -1148,7 +1171,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:323](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L323)
+[packages/quickjs-emscripten-core/src/context.ts:324](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L324)
 
 ***
 
@@ -1180,7 +1203,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:662](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L662)
+[packages/quickjs-emscripten-core/src/context.ts:687](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L687)
 
 ***
 
@@ -1217,7 +1240,7 @@ properties.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:726](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L726)
+[packages/quickjs-emscripten-core/src/context.ts:751](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L751)
 
 ***
 
@@ -1241,7 +1264,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:887](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L887)
+[packages/quickjs-emscripten-core/src/context.ts:912](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L912)
 
 ***
 
@@ -1269,7 +1292,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:593](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L593)
+[packages/quickjs-emscripten-core/src/context.ts:594](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L594)
 
 ***
 
@@ -1300,7 +1323,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:956](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L956)
+[packages/quickjs-emscripten-core/src/context.ts:981](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L981)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSContext.md
@@ -332,7 +332,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1081](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1081)
+[packages/quickjs-emscripten-core/src/context.ts:1101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1101)
 
 ***
 
@@ -413,7 +413,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:907](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L907)
+[packages/quickjs-emscripten-core/src/context.ts:927](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L927)
 
 ***
 
@@ -443,7 +443,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1064](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1064)
+[packages/quickjs-emscripten-core/src/context.ts:1084](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1084)
 
 ***
 
@@ -452,7 +452,20 @@ socket.write(dataLifetime?.value)
 > **evalCode**(`code`, `filename`, `options`?): [`VmCallResult`](../exports.md#vmcallresultvmhandle)\<[`QuickJSHandle`](../exports.md#quickjshandle)\>
 
 Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
-Evaluates the Javascript source `code` in the global scope of this VM.
+
+Evaluates `code`, as though it's in a file named `filename`, with options `options`.
+
+- When `options.type` is `"global"`, the code is evaluated in the global
+  scope of the QuickJSContext, and the return value is the result of the last
+  expression.
+- When `options.type` is `"module"`, the code is evaluated is a module scope.
+  It may use `import` and `export` if [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#setModuleLoader](QuickJSRuntime.md#setmoduleloader) was called.
+  It may use top-level await if supported by the underlying QuickJS library.
+  The return value is the module's exports, or a promise for the module's exports.
+- When `options.type` is unset, the code is evaluated as a module if it
+  contains an `import` or `export` statement, otherwise it is evaluated in
+  the global scope.
+
 When working with async code, you many need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#executePendingJobs](QuickJSRuntime.md#executependingjobs)
 to execute callbacks pending after synchronous evaluation returns.
 
@@ -493,7 +506,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:837](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L837)
+[packages/quickjs-emscripten-core/src/context.ts:850](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L850)
 
 ***
 
@@ -1126,7 +1139,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:867](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L867)
+[packages/quickjs-emscripten-core/src/context.ts:887](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L887)
 
 ***
 
@@ -1181,7 +1194,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:936](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L936)
+[packages/quickjs-emscripten-core/src/context.ts:956](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L956)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSContext.md
@@ -130,7 +130,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L181)
+[packages/quickjs-emscripten-core/src/context.ts:182](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L182)
 
 ## Properties
 
@@ -142,7 +142,7 @@ The runtime that created this context.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L151)
+[packages/quickjs-emscripten-core/src/context.ts:152](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L152)
 
 ## Accessors
 
@@ -160,7 +160,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:209](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L209)
+[packages/quickjs-emscripten-core/src/context.ts:210](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L210)
 
 ***
 
@@ -176,7 +176,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:267](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L267)
+[packages/quickjs-emscripten-core/src/context.ts:268](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L268)
 
 ***
 
@@ -194,7 +194,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:282](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L282)
+[packages/quickjs-emscripten-core/src/context.ts:283](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L283)
 
 ***
 
@@ -210,7 +210,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:241](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L241)
+[packages/quickjs-emscripten-core/src/context.ts:242](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L242)
 
 ***
 
@@ -226,7 +226,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:254](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L254)
+[packages/quickjs-emscripten-core/src/context.ts:255](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L255)
 
 ***
 
@@ -242,7 +242,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:228](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L228)
+[packages/quickjs-emscripten-core/src/context.ts:229](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L229)
 
 ## Methods
 
@@ -304,7 +304,7 @@ value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:815](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L815)
+[packages/quickjs-emscripten-core/src/context.ts:821](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L821)
 
 ***
 
@@ -333,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1126)
+[packages/quickjs-emscripten-core/src/context.ts:1132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1132)
 
 ***
 
@@ -364,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:766](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L766)
+[packages/quickjs-emscripten-core/src/context.ts:772](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L772)
 
 ***
 
@@ -393,7 +393,7 @@ will result in an error.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:219](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L219)
+[packages/quickjs-emscripten-core/src/context.ts:220](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L220)
 
 ***
 
@@ -414,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:952](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L952)
+[packages/quickjs-emscripten-core/src/context.ts:958](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L958)
 
 ***
 
@@ -444,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1109](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1109)
+[packages/quickjs-emscripten-core/src/context.ts:1115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1115)
 
 ***
 
@@ -507,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:875](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L875)
+[packages/quickjs-emscripten-core/src/context.ts:881](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L881)
 
 ***
 
@@ -527,7 +527,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:641](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L641)
+[packages/quickjs-emscripten-core/src/context.ts:642](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L642)
 
 ***
 
@@ -547,7 +547,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:632](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L632)
+[packages/quickjs-emscripten-core/src/context.ts:633](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L633)
 
 ***
 
@@ -573,7 +573,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:603](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L603)
+[packages/quickjs-emscripten-core/src/context.ts:604](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L604)
 
 ***
 
@@ -591,7 +591,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:653](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L653)
+[packages/quickjs-emscripten-core/src/context.ts:654](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L654)
 
 ***
 
@@ -621,7 +621,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:730](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L730)
+[packages/quickjs-emscripten-core/src/context.ts:736](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L736)
 
 ***
 
@@ -645,7 +645,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:611](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L611)
+[packages/quickjs-emscripten-core/src/context.ts:612](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L612)
 
 ***
 
@@ -666,7 +666,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:620](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L620)
+[packages/quickjs-emscripten-core/src/context.ts:621](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L621)
 
 ***
 
@@ -683,7 +683,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:381](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L381)
+[packages/quickjs-emscripten-core/src/context.ts:382](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L382)
 
 ***
 
@@ -703,7 +703,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:389](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L389)
+[packages/quickjs-emscripten-core/src/context.ts:390](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L390)
 
 ***
 
@@ -723,7 +723,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:347](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L347)
+[packages/quickjs-emscripten-core/src/context.ts:348](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L348)
 
 ***
 
@@ -747,7 +747,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:558](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L558)
+[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
 
 #### newError(message)
 
@@ -763,7 +763,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
+[packages/quickjs-emscripten-core/src/context.ts:560](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L560)
 
 #### newError(undefined)
 
@@ -775,7 +775,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:560](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L560)
+[packages/quickjs-emscripten-core/src/context.ts:561](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L561)
 
 ***
 
@@ -892,7 +892,7 @@ return deferred.handle
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:552](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L552)
+[packages/quickjs-emscripten-core/src/context.ts:553](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L553)
 
 ***
 
@@ -916,7 +916,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:306](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L306)
+[packages/quickjs-emscripten-core/src/context.ts:307](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L307)
 
 ***
 
@@ -943,7 +943,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:367](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L367)
+[packages/quickjs-emscripten-core/src/context.ts:368](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L368)
 
 ***
 
@@ -964,7 +964,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:402](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L402)
+[packages/quickjs-emscripten-core/src/context.ts:403](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L403)
 
 #### newPromise(promise)
 
@@ -986,7 +986,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:410](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L410)
+[packages/quickjs-emscripten-core/src/context.ts:411](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L411)
 
 #### newPromise(newPromiseFn)
 
@@ -1007,7 +1007,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:417](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L417)
+[packages/quickjs-emscripten-core/src/context.ts:418](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L418)
 
 ***
 
@@ -1031,7 +1031,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:313](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L313)
+[packages/quickjs-emscripten-core/src/context.ts:314](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L314)
 
 ***
 
@@ -1052,7 +1052,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:336](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L336)
+[packages/quickjs-emscripten-core/src/context.ts:337](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L337)
 
 ***
 
@@ -1073,7 +1073,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:324](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L324)
+[packages/quickjs-emscripten-core/src/context.ts:325](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L325)
 
 ***
 
@@ -1101,7 +1101,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:687](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L687)
+[packages/quickjs-emscripten-core/src/context.ts:693](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L693)
 
 ***
 
@@ -1138,7 +1138,7 @@ properties.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:751](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L751)
+[packages/quickjs-emscripten-core/src/context.ts:757](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L757)
 
 ***
 
@@ -1158,7 +1158,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:912](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L912)
+[packages/quickjs-emscripten-core/src/context.ts:918](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L918)
 
 ***
 
@@ -1186,7 +1186,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:594](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L594)
+[packages/quickjs-emscripten-core/src/context.ts:595](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L595)
 
 ***
 
@@ -1213,7 +1213,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:981](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L981)
+[packages/quickjs-emscripten-core/src/context.ts:987](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L987)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSContext.md
@@ -304,7 +304,7 @@ value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:821](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L821)
+[packages/quickjs-emscripten-core/src/context.ts:834](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L834)
 
 ***
 
@@ -333,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1132)
+[packages/quickjs-emscripten-core/src/context.ts:1145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1145)
 
 ***
 
@@ -364,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:772](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L772)
+[packages/quickjs-emscripten-core/src/context.ts:785](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L785)
 
 ***
 
@@ -414,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:958](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L958)
+[packages/quickjs-emscripten-core/src/context.ts:971](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L971)
 
 ***
 
@@ -444,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1115](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1115)
+[packages/quickjs-emscripten-core/src/context.ts:1128](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1128)
 
 ***
 
@@ -507,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:881](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L881)
+[packages/quickjs-emscripten-core/src/context.ts:894](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L894)
 
 ***
 
@@ -581,6 +581,18 @@ Converts `handle` into a Javascript number.
 
 > **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
 
+Get the current state of a QuickJS promise, see [JSPromiseState](../exports.md#jspromisestate) for the possible states.
+This can be used to expect a promise to be fulfilled when combined with [unwrapResult](QuickJSContext.md#unwrapresult):
+
+```typescript
+const promiseHandle = context.evalCode(`Promise.resolve(42)`);
+const resultHandle = context.unwrapResult(
+ context.getPromiseState(promiseHandle)
+);
+context.getNumber(resultHandle) === 42; // true
+resultHandle.dispose();
+```
+
 #### Parameters
 
 • **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
@@ -591,7 +603,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:654](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L654)
+[packages/quickjs-emscripten-core/src/context.ts:667](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L667)
 
 ***
 
@@ -621,7 +633,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:736](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L736)
+[packages/quickjs-emscripten-core/src/context.ts:749](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L749)
 
 ***
 
@@ -1101,7 +1113,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:693](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L693)
+[packages/quickjs-emscripten-core/src/context.ts:706](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L706)
 
 ***
 
@@ -1138,7 +1150,7 @@ properties.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:757](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L757)
+[packages/quickjs-emscripten-core/src/context.ts:770](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L770)
 
 ***
 
@@ -1158,7 +1170,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:918](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L918)
+[packages/quickjs-emscripten-core/src/context.ts:931](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L931)
 
 ***
 
@@ -1213,7 +1225,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:987](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L987)
+[packages/quickjs-emscripten-core/src/context.ts:1000](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1000)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSContext.md
@@ -63,6 +63,7 @@ See [QuickJSRuntime](QuickJSRuntime.md) for more information.
   - [getArrayBuffer()](QuickJSContext.md#getarraybuffer)
   - [getBigInt()](QuickJSContext.md#getbigint)
   - [getNumber()](QuickJSContext.md#getnumber)
+  - [getPromiseState()](QuickJSContext.md#getpromisestate)
   - [getProp()](QuickJSContext.md#getprop)
   - [getString()](QuickJSContext.md#getstring)
   - [getSymbol()](QuickJSContext.md#getsymbol)
@@ -129,7 +130,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:180](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L180)
+[packages/quickjs-emscripten-core/src/context.ts:181](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L181)
 
 ## Properties
 
@@ -141,7 +142,7 @@ The runtime that created this context.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:150](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L150)
+[packages/quickjs-emscripten-core/src/context.ts:151](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L151)
 
 ## Accessors
 
@@ -159,7 +160,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:208](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L208)
+[packages/quickjs-emscripten-core/src/context.ts:209](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L209)
 
 ***
 
@@ -175,7 +176,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:266](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L266)
+[packages/quickjs-emscripten-core/src/context.ts:267](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L267)
 
 ***
 
@@ -193,7 +194,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:281](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L281)
+[packages/quickjs-emscripten-core/src/context.ts:282](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L282)
 
 ***
 
@@ -209,7 +210,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:240](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L240)
+[packages/quickjs-emscripten-core/src/context.ts:241](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L241)
 
 ***
 
@@ -225,7 +226,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:253](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L253)
+[packages/quickjs-emscripten-core/src/context.ts:254](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L254)
 
 ***
 
@@ -241,7 +242,7 @@ You can set properties to create global variables.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:227](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L227)
+[packages/quickjs-emscripten-core/src/context.ts:228](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L228)
 
 ## Methods
 
@@ -303,7 +304,7 @@ value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:790](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L790)
+[packages/quickjs-emscripten-core/src/context.ts:815](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L815)
 
 ***
 
@@ -332,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1101](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1101)
+[packages/quickjs-emscripten-core/src/context.ts:1126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1126)
 
 ***
 
@@ -363,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:741](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L741)
+[packages/quickjs-emscripten-core/src/context.ts:766](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L766)
 
 ***
 
@@ -392,7 +393,7 @@ will result in an error.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:218](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L218)
+[packages/quickjs-emscripten-core/src/context.ts:219](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L219)
 
 ***
 
@@ -413,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:927](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L927)
+[packages/quickjs-emscripten-core/src/context.ts:952](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L952)
 
 ***
 
@@ -443,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:1084](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1084)
+[packages/quickjs-emscripten-core/src/context.ts:1109](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L1109)
 
 ***
 
@@ -506,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:850](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L850)
+[packages/quickjs-emscripten-core/src/context.ts:875](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L875)
 
 ***
 
@@ -526,7 +527,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:640](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L640)
+[packages/quickjs-emscripten-core/src/context.ts:641](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L641)
 
 ***
 
@@ -546,7 +547,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:631](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L631)
+[packages/quickjs-emscripten-core/src/context.ts:632](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L632)
 
 ***
 
@@ -572,7 +573,25 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:602](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L602)
+[packages/quickjs-emscripten-core/src/context.ts:603](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L603)
+
+***
+
+### getPromiseState()
+
+> **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Parameters
+
+• **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Returns
+
+[`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/context.ts:653](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L653)
 
 ***
 
@@ -602,7 +621,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:705](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L705)
+[packages/quickjs-emscripten-core/src/context.ts:730](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L730)
 
 ***
 
@@ -626,7 +645,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:610](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L610)
+[packages/quickjs-emscripten-core/src/context.ts:611](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L611)
 
 ***
 
@@ -647,7 +666,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:619](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L619)
+[packages/quickjs-emscripten-core/src/context.ts:620](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L620)
 
 ***
 
@@ -664,7 +683,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:380](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L380)
+[packages/quickjs-emscripten-core/src/context.ts:381](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L381)
 
 ***
 
@@ -684,7 +703,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:388](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L388)
+[packages/quickjs-emscripten-core/src/context.ts:389](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L389)
 
 ***
 
@@ -704,7 +723,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:346](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L346)
+[packages/quickjs-emscripten-core/src/context.ts:347](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L347)
 
 ***
 
@@ -728,7 +747,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:557](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L557)
+[packages/quickjs-emscripten-core/src/context.ts:558](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L558)
 
 #### newError(message)
 
@@ -744,7 +763,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:558](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L558)
+[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
 
 #### newError(undefined)
 
@@ -756,7 +775,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:559](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L559)
+[packages/quickjs-emscripten-core/src/context.ts:560](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L560)
 
 ***
 
@@ -873,7 +892,7 @@ return deferred.handle
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:551](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L551)
+[packages/quickjs-emscripten-core/src/context.ts:552](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L552)
 
 ***
 
@@ -897,7 +916,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:305](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L305)
+[packages/quickjs-emscripten-core/src/context.ts:306](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L306)
 
 ***
 
@@ -924,7 +943,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:366](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L366)
+[packages/quickjs-emscripten-core/src/context.ts:367](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L367)
 
 ***
 
@@ -945,7 +964,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:401](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L401)
+[packages/quickjs-emscripten-core/src/context.ts:402](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L402)
 
 #### newPromise(promise)
 
@@ -967,7 +986,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:409](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L409)
+[packages/quickjs-emscripten-core/src/context.ts:410](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L410)
 
 #### newPromise(newPromiseFn)
 
@@ -988,7 +1007,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:416](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L416)
+[packages/quickjs-emscripten-core/src/context.ts:417](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L417)
 
 ***
 
@@ -1012,7 +1031,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:312](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L312)
+[packages/quickjs-emscripten-core/src/context.ts:313](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L313)
 
 ***
 
@@ -1033,7 +1052,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:335](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L335)
+[packages/quickjs-emscripten-core/src/context.ts:336](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L336)
 
 ***
 
@@ -1054,7 +1073,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:323](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L323)
+[packages/quickjs-emscripten-core/src/context.ts:324](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L324)
 
 ***
 
@@ -1082,7 +1101,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:662](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L662)
+[packages/quickjs-emscripten-core/src/context.ts:687](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L687)
 
 ***
 
@@ -1119,7 +1138,7 @@ properties.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:726](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L726)
+[packages/quickjs-emscripten-core/src/context.ts:751](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L751)
 
 ***
 
@@ -1139,7 +1158,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:887](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L887)
+[packages/quickjs-emscripten-core/src/context.ts:912](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L912)
 
 ***
 
@@ -1167,7 +1186,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:593](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L593)
+[packages/quickjs-emscripten-core/src/context.ts:594](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L594)
 
 ***
 
@@ -1194,7 +1213,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:956](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L956)
+[packages/quickjs-emscripten-core/src/context.ts:981](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L981)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L74)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:95](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L95)
 
 ## Properties
 
@@ -94,7 +94,7 @@ this constructor directly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L52)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:73](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L73)
 
 ***
 
@@ -108,7 +108,7 @@ are finished with it.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:59](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L59)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:80](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L80)
 
 ***
 
@@ -118,7 +118,7 @@ are finished with it.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L51)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:72](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L72)
 
 ***
 
@@ -130,7 +130,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:64](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L64)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L85)
 
 ## Accessors
 
@@ -148,7 +148,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L145)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:166](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L166)
 
 ## Methods
 
@@ -196,7 +196,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:149](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L149)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:170](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L170)
 
 ***
 
@@ -221,7 +221,7 @@ callbacks.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L126)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:147](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L147)
 
 ***
 
@@ -246,7 +246,7 @@ callbacks.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L99)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:120](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L120)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:57](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L57)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:74](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L74)
 
 ## Properties
 
@@ -94,7 +94,7 @@ this constructor directly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L35)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L52)
 
 ***
 
@@ -108,7 +108,7 @@ are finished with it.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L42)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:59](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L59)
 
 ***
 
@@ -118,7 +118,7 @@ are finished with it.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L34)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:51](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L51)
 
 ***
 
@@ -130,7 +130,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L47)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:64](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L64)
 
 ## Accessors
 
@@ -148,7 +148,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:128](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L128)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:145](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L145)
 
 ## Methods
 
@@ -196,7 +196,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L132)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:149](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L149)
 
 ***
 
@@ -221,7 +221,7 @@ callbacks.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:109](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L109)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:126](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L126)
 
 ***
 
@@ -246,7 +246,7 @@ callbacks.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:82](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L82)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:99](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L99)
 
 ***
 

--- a/doc/quickjs-emscripten-core/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten-core/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:52](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L52)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:57](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L57)
 
 ## Properties
 
@@ -94,7 +94,7 @@ this constructor directly.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:30](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L30)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L35)
 
 ***
 
@@ -108,7 +108,7 @@ are finished with it.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:37](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L37)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L42)
 
 ***
 
@@ -118,7 +118,7 @@ are finished with it.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:29](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L29)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L34)
 
 ***
 
@@ -130,7 +130,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L42)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L47)
 
 ## Accessors
 
@@ -148,7 +148,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose-1)d
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:123](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L123)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:128](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L128)
 
 ## Methods
 
@@ -196,7 +196,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:127](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L127)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:132](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L132)
 
 ***
 
@@ -221,7 +221,7 @@ callbacks.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:104](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L104)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:109](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L109)
 
 ***
 
@@ -246,7 +246,7 @@ callbacks.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:77](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L77)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:82](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L82)
 
 ***
 

--- a/doc/quickjs-emscripten-core/exports.md
+++ b/doc/quickjs-emscripten-core/exports.md
@@ -153,7 +153,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:66
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:481
+packages/quickjs-ffi-types/dist/index.d.ts:483
 
 ***
 
@@ -565,7 +565,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:71
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:281](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L281)
+[packages/quickjs-emscripten-core/src/types.ts:286](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L286)
 
 ***
 
@@ -654,7 +654,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:480
+packages/quickjs-ffi-types/dist/index.d.ts:482
 
 ***
 

--- a/doc/quickjs-emscripten-core/exports.md
+++ b/doc/quickjs-emscripten-core/exports.md
@@ -29,6 +29,8 @@
   - [JSModuleNormalizeFailure](exports.md#jsmodulenormalizefailure)
   - [JSModuleNormalizeResult](exports.md#jsmodulenormalizeresult)
   - [JSModuleNormalizeSuccess](exports.md#jsmodulenormalizesuccess)
+  - [JSPromiseState](exports.md#jspromisestate)
+  - [JSPromiseStateEnum](exports.md#jspromisestateenum)
   - [JSRuntimePointer](exports.md#jsruntimepointer)
   - [JSValue](exports.md#jsvalue)
   - [JSValueConst](exports.md#jsvalueconst)
@@ -55,6 +57,7 @@
   - [DefaultIntrinsics](exports.md#defaultintrinsics)
   - [EvalFlags](exports.md#evalflags)
   - [IntrinsicsFlags](exports.md#intrinsicsflags)
+  - [JSPromiseStateEnum](exports.md#jspromisestateenum-1)
 - [Functions](exports.md#functions)
   - [assertSync()](exports.md#assertsync)
   - [isFail()](exports.md#isfail)
@@ -153,7 +156,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:66
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:483
+packages/quickjs-ffi-types/dist/index.d.ts:496
 
 ***
 
@@ -163,7 +166,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:483
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:295
+packages/quickjs-ffi-types/dist/index.d.ts:304
 
 ***
 
@@ -396,6 +399,28 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 #### Source
 
 [packages/quickjs-emscripten-core/src/types.ts:85](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L85)
+
+***
+
+### JSPromiseState
+
+> **JSPromiseState**: `Object` \| `Object` \| `Object`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:7](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L7)
+
+***
+
+### JSPromiseStateEnum
+
+> **JSPromiseStateEnum**: `Brand`\<*typeof* [`JSPromiseStateEnum`](exports.md#jspromisestateenum-1)\[keyof *typeof* [`JSPromiseStateEnum`](exports.md#jspromisestateenum-1)\], `"JSPromiseStateEnum"`\>
+
+State of a promise.
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:140
 
 ***
 
@@ -644,7 +669,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:41](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L41)
+[packages/quickjs-emscripten-core/src/context.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L42)
 
 ***
 
@@ -654,7 +679,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:482
+packages/quickjs-ffi-types/dist/index.d.ts:495
 
 ***
 
@@ -943,6 +968,30 @@ Bitfield options for QTS_NewContext intrinsices
 #### Source
 
 packages/quickjs-ffi-types/dist/index.d.ts:117
+
+***
+
+### JSPromiseStateEnum
+
+> **JSPromiseStateEnum**: `Object`
+
+#### Type declaration
+
+##### Fulfilled
+
+> **`readonly`** **Fulfilled**: `1`
+
+##### Pending
+
+> **`readonly`** **Pending**: `0`
+
+##### Rejected
+
+> **`readonly`** **Rejected**: `2`
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:140
 
 ## Functions
 

--- a/doc/quickjs-emscripten-core/exports.md
+++ b/doc/quickjs-emscripten-core/exports.md
@@ -406,9 +406,12 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 > **JSPromiseState**: `Object` \| `Object` \| `Object`
 
+A promise state inside QuickJS, which can be pending, fulfilled, or rejected.
+You can unwrap a JSPromiseState with [QuickJSContext#unwrapResult](classes/QuickJSContext.md#unwrapresult).
+
 #### Source
 
-[packages/quickjs-emscripten-core/src/deferred-promise.ts:7](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L7)
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:11](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L11)
 
 ***
 
@@ -669,7 +672,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/context.ts:42](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L42)
+[packages/quickjs-emscripten-core/src/context.ts:43](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/context.ts#L43)
 
 ***
 

--- a/doc/quickjs-emscripten-core/exports.md
+++ b/doc/quickjs-emscripten-core/exports.md
@@ -102,6 +102,9 @@
 - [JSModuleLoaderAsync](interfaces/JSModuleLoaderAsync.md)
 - [JSModuleNormalizer](interfaces/JSModuleNormalizer.md)
 - [JSModuleNormalizerAsync](interfaces/JSModuleNormalizerAsync.md)
+- [JSPromiseStateFulfilled](interfaces/JSPromiseStateFulfilled.md)
+- [JSPromiseStatePending](interfaces/JSPromiseStatePending.md)
+- [JSPromiseStateRejected](interfaces/JSPromiseStateRejected.md)
 - [LowLevelJavascriptVm](interfaces/LowLevelJavascriptVm.md)
 - [ModuleEvalOptions](interfaces/ModuleEvalOptions.md)
 - [QuickJSAsyncEmscriptenModule](interfaces/QuickJSAsyncEmscriptenModule.md)
@@ -404,7 +407,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 ### JSPromiseState
 
-> **JSPromiseState**: `Object` \| `Object` \| `Object`
+> **JSPromiseState**: [`JSPromiseStatePending`](interfaces/JSPromiseStatePending.md) \| [`JSPromiseStateFulfilled`](interfaces/JSPromiseStateFulfilled.md) \| [`JSPromiseStateRejected`](interfaces/JSPromiseStateRejected.md)
 
 A promise state inside QuickJS, which can be pending, fulfilled, or rejected.
 You can unwrap a JSPromiseState with [QuickJSContext#unwrapResult](classes/QuickJSContext.md#unwrapresult).

--- a/doc/quickjs-emscripten-core/interfaces/ContextEvalOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/ContextEvalOptions.md
@@ -25,7 +25,7 @@ don't include the stack frames before this eval in the Error() backtraces
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:257](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L257)
+[packages/quickjs-emscripten-core/src/types.ts:262](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L262)
 
 ***
 
@@ -39,7 +39,7 @@ with JS_EvalFunction().
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:255](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L255)
+[packages/quickjs-emscripten-core/src/types.ts:260](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L260)
 
 ***
 
@@ -51,7 +51,7 @@ Force "strict" mode
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:247](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L247)
+[packages/quickjs-emscripten-core/src/types.ts:252](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L252)
 
 ***
 
@@ -63,7 +63,7 @@ Force "strip" mode
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:249](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L249)
+[packages/quickjs-emscripten-core/src/types.ts:254](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L254)
 
 ***
 
@@ -71,11 +71,14 @@ Force "strip" mode
 
 > **type**?: `"global"` \| `"module"`
 
-Global code (default)
+Global code (default), or "module" code?
+
+- When type is `"global"`, the code is evaluated in the global scope of the QuickJSContext, and the return value is the result of the last expression.
+- When type is `"module"`, the code is evaluated is a module scope, may use `import`, `export`, and top-level `await`. The return value is the module's exports, or a promise for the module's exports.
 
 #### Source
 
-[packages/quickjs-emscripten-core/src/types.ts:245](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L245)
+[packages/quickjs-emscripten-core/src/types.ts:250](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/types.ts#L250)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModule.md
@@ -49,7 +49,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:252
+packages/quickjs-ffi-types/dist/index.d.ts:261
 
 ***
 
@@ -59,7 +59,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:252
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:243
+packages/quickjs-ffi-types/dist/index.d.ts:252
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:243
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:244
+packages/quickjs-ffi-types/dist/index.d.ts:253
 
 ***
 
@@ -79,7 +79,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:244
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:242
+packages/quickjs-ffi-types/dist/index.d.ts:251
 
 ***
 
@@ -89,7 +89,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:242
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:248
+packages/quickjs-ffi-types/dist/index.d.ts:257
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:248
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:249
+packages/quickjs-ffi-types/dist/index.d.ts:258
 
 ***
 
@@ -109,7 +109,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:249
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:246
+packages/quickjs-ffi-types/dist/index.d.ts:255
 
 ***
 
@@ -119,7 +119,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:246
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:247
+packages/quickjs-ffi-types/dist/index.d.ts:256
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:247
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:245
+packages/quickjs-ffi-types/dist/index.d.ts:254
 
 ***
 
@@ -139,7 +139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:245
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:251
+packages/quickjs-ffi-types/dist/index.d.ts:260
 
 ***
 
@@ -149,7 +149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:251
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:250
+packages/quickjs-ffi-types/dist/index.d.ts:259
 
 ***
 
@@ -165,7 +165,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -181,7 +181,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -204,7 +204,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:237
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -222,7 +222,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:237
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:240
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -240,7 +240,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:240
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:239
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -273,7 +273,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:239
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:241
+packages/quickjs-ffi-types/dist/index.d.ts:250
 
 ***
 
@@ -299,7 +299,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -317,7 +317,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:238
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -361,7 +361,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -385,7 +385,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 
@@ -410,7 +410,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:232
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoader.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:297
+packages/quickjs-ffi-types/dist/index.d.ts:306
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoaderOptions.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoaderOptions.md
@@ -35,7 +35,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -47,7 +47,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -69,7 +69,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -109,7 +109,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -129,7 +129,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/JSPromiseStateFulfilled.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSPromiseStateFulfilled.md
@@ -1,0 +1,64 @@
+[quickjs-emscripten](../../packages.md) • **quickjs-emscripten-core** • [Readme](../README.md) \| [Exports](../exports.md)
+
+***
+
+[quickjs-emscripten](../../packages.md) / [quickjs-emscripten-core](../exports.md) / JSPromiseStateFulfilled
+
+# Interface: JSPromiseStateFulfilled
+
+Fulfilled promise state.
+See [JSPromiseState](../exports.md#jspromisestate).
+
+## Contents
+
+- [Properties](JSPromiseStateFulfilled.md#properties)
+  - [error?](JSPromiseStateFulfilled.md#error)
+  - [notAPromise?](JSPromiseStateFulfilled.md#notapromise)
+  - [type](JSPromiseStateFulfilled.md#type)
+  - [value](JSPromiseStateFulfilled.md#value)
+
+## Properties
+
+### error?
+
+> **error**?: `undefined`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:36](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L36)
+
+***
+
+### notAPromise?
+
+> **notAPromise**?: `boolean`
+
+Trying to get the promise state of a non-Promise value returns a fulfilled state with the original value, and `notAPromise: true`.
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:38](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L38)
+
+***
+
+### type
+
+> **type**: `"fulfilled"`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:34](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L34)
+
+***
+
+### value
+
+> **value**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:35](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L35)
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten-core/interfaces/JSPromiseStatePending.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSPromiseStatePending.md
@@ -1,0 +1,48 @@
+[quickjs-emscripten](../../packages.md) • **quickjs-emscripten-core** • [Readme](../README.md) \| [Exports](../exports.md)
+
+***
+
+[quickjs-emscripten](../../packages.md) / [quickjs-emscripten-core](../exports.md) / JSPromiseStatePending
+
+# Interface: JSPromiseStatePending
+
+Pending promise state.
+See [JSPromiseState](../exports.md#jspromisestate).
+
+## Contents
+
+- [Properties](JSPromiseStatePending.md#properties)
+  - [type](JSPromiseStatePending.md#type)
+- [Accessors](JSPromiseStatePending.md#accessors)
+  - [error](JSPromiseStatePending.md#error)
+
+## Properties
+
+### type
+
+> **type**: `"pending"`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:21](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L21)
+
+## Accessors
+
+### error
+
+> **`get`** **error**(): `Error`
+
+The error property here allows unwrapping a JSPromiseState with [QuickJSContext#unwrapResult](../classes/QuickJSContext.md#unwrapresult).
+Unwrapping a pending promise will throw a QuickJSPromisePending error.
+
+#### Returns
+
+`Error`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:26](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L26)
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten-core/interfaces/JSPromiseStateRejected.md
+++ b/doc/quickjs-emscripten-core/interfaces/JSPromiseStateRejected.md
@@ -1,0 +1,40 @@
+[quickjs-emscripten](../../packages.md) • **quickjs-emscripten-core** • [Readme](../README.md) \| [Exports](../exports.md)
+
+***
+
+[quickjs-emscripten](../../packages.md) / [quickjs-emscripten-core](../exports.md) / JSPromiseStateRejected
+
+# Interface: JSPromiseStateRejected
+
+Rejected promise state.
+See [JSPromiseState](../exports.md#jspromisestate).
+
+## Contents
+
+- [Properties](JSPromiseStateRejected.md#properties)
+  - [error](JSPromiseStateRejected.md#error)
+  - [type](JSPromiseStateRejected.md#type)
+
+## Properties
+
+### error
+
+> **error**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:47](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L47)
+
+***
+
+### type
+
+> **type**: `"rejected"`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/deferred-promise.ts:46](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/deferred-promise.ts#L46)
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -55,7 +55,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:252
+packages/quickjs-ffi-types/dist/index.d.ts:261
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:252
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:243
+packages/quickjs-ffi-types/dist/index.d.ts:252
 
 ***
 
@@ -83,7 +83,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:243
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:244
+packages/quickjs-ffi-types/dist/index.d.ts:253
 
 ***
 
@@ -97,7 +97,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:244
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:242
+packages/quickjs-ffi-types/dist/index.d.ts:251
 
 ***
 
@@ -111,7 +111,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:242
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:248
+packages/quickjs-ffi-types/dist/index.d.ts:257
 
 ***
 
@@ -125,7 +125,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:248
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:249
+packages/quickjs-ffi-types/dist/index.d.ts:258
 
 ***
 
@@ -139,7 +139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:249
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:246
+packages/quickjs-ffi-types/dist/index.d.ts:255
 
 ***
 
@@ -153,7 +153,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:246
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:247
+packages/quickjs-ffi-types/dist/index.d.ts:256
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:247
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:245
+packages/quickjs-ffi-types/dist/index.d.ts:254
 
 ***
 
@@ -181,7 +181,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:245
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:251
+packages/quickjs-ffi-types/dist/index.d.ts:260
 
 ***
 
@@ -195,7 +195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:251
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:250
+packages/quickjs-ffi-types/dist/index.d.ts:259
 
 ***
 
@@ -205,7 +205,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:250
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
+packages/quickjs-ffi-types/dist/index.d.ts:302
 
 ***
 
@@ -219,7 +219,7 @@ Implement this field
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:301
 
 ***
 
@@ -235,7 +235,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -251,7 +251,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -278,7 +278,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:237
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -300,7 +300,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:237
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:240
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -322,7 +322,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:240
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:239
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -359,7 +359,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:239
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:241
+packages/quickjs-ffi-types/dist/index.d.ts:250
 
 ***
 
@@ -385,7 +385,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -407,7 +407,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:238
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -451,7 +451,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -475,7 +475,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 
@@ -504,7 +504,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:232
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncFFI.md
@@ -63,6 +63,8 @@ library.
   - [QTS\_NewRuntime](QuickJSAsyncFFI.md#qts-newruntime)
   - [QTS\_NewString](QuickJSAsyncFFI.md#qts-newstring)
   - [QTS\_NewSymbol](QuickJSAsyncFFI.md#qts-newsymbol)
+  - [QTS\_PromiseResult](QuickJSAsyncFFI.md#qts-promiseresult)
+  - [QTS\_PromiseState](QuickJSAsyncFFI.md#qts-promisestate)
   - [QTS\_RecoverableLeakCheck](QuickJSAsyncFFI.md#qts-recoverableleakcheck)
   - [QTS\_ResolveException](QuickJSAsyncFFI.md#qts-resolveexception)
   - [QTS\_RuntimeComputeMemoryUsage](QuickJSAsyncFFI.md#qts-runtimecomputememoryusage)
@@ -95,7 +97,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -115,7 +117,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:451
 
 ***
 
@@ -129,7 +131,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:449
 
 ***
 
@@ -143,7 +145,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:436
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:435
+packages/quickjs-ffi-types/dist/index.d.ts:448
 
 ***
 
@@ -157,7 +159,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:435
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -183,7 +185,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:423
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -209,7 +211,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:423
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:424
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -243,7 +245,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:424
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:422
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -263,7 +265,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:422
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:426
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -283,7 +285,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:426
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:427
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 
@@ -303,7 +305,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:427
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 
@@ -331,7 +333,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:428
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -359,7 +361,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:428
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:429
+packages/quickjs-ffi-types/dist/index.d.ts:440
 
 ***
 
@@ -381,7 +383,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:429
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -403,7 +405,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:417
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
@@ -423,7 +425,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -441,7 +443,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -459,7 +461,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -479,7 +481,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -499,7 +501,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -519,7 +521,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -539,7 +541,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:420
 
 ***
 
@@ -559,7 +561,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:421
 
 ***
 
@@ -573,7 +575,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -593,7 +595,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:417
 
 ***
 
@@ -611,7 +613,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:432
+packages/quickjs-ffi-types/dist/index.d.ts:443
 
 ***
 
@@ -631,7 +633,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:432
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:430
+packages/quickjs-ffi-types/dist/index.d.ts:441
 
 ***
 
@@ -645,7 +647,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:430
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
@@ -667,7 +669,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:418
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -689,7 +691,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:419
+packages/quickjs-ffi-types/dist/index.d.ts:430
 
 ***
 
@@ -709,7 +711,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:419
 
 ***
 
@@ -729,7 +731,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:423
 
 ***
 
@@ -749,7 +751,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -763,7 +765,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -777,7 +779,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -797,7 +799,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -815,7 +817,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -833,7 +835,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:414
 
 ***
 
@@ -855,7 +857,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:415
 
 ***
 
@@ -875,7 +877,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -893,7 +895,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -913,7 +915,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:416
 
 ***
 
@@ -935,7 +937,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:450
 
 ***
 
@@ -953,7 +955,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -973,7 +975,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:413
 
 ***
 
@@ -993,7 +995,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:433
+packages/quickjs-ffi-types/dist/index.d.ts:444
 
 ***
 
@@ -1007,7 +1009,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:433
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -1027,7 +1029,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:418
 
 ***
 
@@ -1049,7 +1051,47 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:422
+
+***
+
+### QTS\_PromiseResult
+
+> **QTS\_PromiseResult**: (`ctx`, `promise`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:446
+
+***
+
+### QTS\_PromiseState
+
+> **QTS\_PromiseState**: (`ctx`, `promise`) => [`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:445
 
 ***
 
@@ -1063,7 +1105,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -1083,7 +1125,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:425
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -1103,7 +1145,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:425
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -1121,7 +1163,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:440
+packages/quickjs-ffi-types/dist/index.d.ts:453
 
 ***
 
@@ -1139,7 +1181,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:440
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:442
+packages/quickjs-ffi-types/dist/index.d.ts:455
 
 ***
 
@@ -1157,7 +1199,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:442
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -1175,7 +1217,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:439
+packages/quickjs-ffi-types/dist/index.d.ts:452
 
 ***
 
@@ -1195,7 +1237,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:439
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:441
+packages/quickjs-ffi-types/dist/index.d.ts:454
 
 ***
 
@@ -1215,7 +1257,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:441
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -1235,7 +1277,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -1259,7 +1301,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:420
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -1283,7 +1325,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:421
+packages/quickjs-ffi-types/dist/index.d.ts:432
 
 ***
 
@@ -1301,7 +1343,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:434
+packages/quickjs-ffi-types/dist/index.d.ts:447
 
 ***
 
@@ -1321,7 +1363,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:434
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -1341,7 +1383,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:431
+packages/quickjs-ffi-types/dist/index.d.ts:442
 
 ***
 
@@ -1361,7 +1403,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:431
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:444
+packages/quickjs-ffi-types/dist/index.d.ts:457
 
 ***
 
@@ -1381,7 +1423,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:444
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:443
+packages/quickjs-ffi-types/dist/index.d.ts:456
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncFFI.md
@@ -40,6 +40,7 @@ library.
   - [QTS\_GetFalse](QuickJSAsyncFFI.md#qts-getfalse)
   - [QTS\_GetFloat64](QuickJSAsyncFFI.md#qts-getfloat64)
   - [QTS\_GetGlobalObject](QuickJSAsyncFFI.md#qts-getglobalobject)
+  - [QTS\_GetModuleNamespace](QuickJSAsyncFFI.md#qts-getmodulenamespace)
   - [QTS\_GetNull](QuickJSAsyncFFI.md#qts-getnull)
   - [QTS\_GetProp](QuickJSAsyncFFI.md#qts-getprop)
   - [QTS\_GetProp\_MaybeAsync](QuickJSAsyncFFI.md#qts-getprop-maybeasync)
@@ -94,7 +95,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:378
+packages/quickjs-ffi-types/dist/index.d.ts:379
 
 ***
 
@@ -114,7 +115,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:378
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 
@@ -128,7 +129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:436
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:434
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -142,7 +143,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:434
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:433
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -156,7 +157,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:433
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:386
 
 ***
 
@@ -182,7 +183,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:422
+packages/quickjs-ffi-types/dist/index.d.ts:423
 
 ***
 
@@ -208,7 +209,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:422
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:423
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -242,7 +243,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:423
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:421
+packages/quickjs-ffi-types/dist/index.d.ts:422
 
 ***
 
@@ -262,7 +263,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:425
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -282,7 +283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:425
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:426
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -302,19 +303,21 @@ packages/quickjs-ffi-types/dist/index.d.ts:426
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
 ### QTS\_Eval
 
-> **QTS\_Eval**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+> **QTS\_Eval**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -328,19 +331,21 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:427
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
 ### QTS\_Eval\_MaybeAsync
 
-> **QTS\_Eval\_MaybeAsync**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer) \| `Promise`\<[`JSValuePointer`](../exports.md#jsvaluepointer)\>
+> **QTS\_Eval\_MaybeAsync**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer) \| `Promise`\<[`JSValuePointer`](../exports.md#jsvaluepointer)\>
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -354,7 +359,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:427
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:428
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -376,7 +381,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:428
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:416
 
 ***
 
@@ -398,7 +403,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:417
 
 ***
 
@@ -418,7 +423,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -436,7 +441,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -454,7 +459,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -474,7 +479,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -494,7 +499,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -514,7 +519,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -534,7 +539,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -554,7 +559,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -568,7 +573,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -588,7 +593,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -599,6 +604,26 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:432
+
+***
+
+### QTS\_GetModuleNamespace
+
+> **QTS\_GetModuleNamespace**: (`ctx`, `module_func_obj`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **module\_func\_obj**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Returns
 
@@ -620,7 +645,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:430
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:389
 
 ***
 
@@ -642,7 +667,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:417
+packages/quickjs-ffi-types/dist/index.d.ts:418
 
 ***
 
@@ -664,7 +689,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:418
+packages/quickjs-ffi-types/dist/index.d.ts:419
 
 ***
 
@@ -684,7 +709,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -704,7 +729,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -724,7 +749,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:413
 
 ***
 
@@ -738,7 +763,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -752,7 +777,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:388
 
 ***
 
@@ -772,7 +797,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:414
 
 ***
 
@@ -790,7 +815,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:415
 
 ***
 
@@ -808,7 +833,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -830,7 +855,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -850,7 +875,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -868,7 +893,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:381
 
 ***
 
@@ -888,7 +913,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -910,7 +935,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:435
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -928,7 +953,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:435
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -948,7 +973,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -968,7 +993,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:431
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -982,7 +1007,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:431
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -1002,7 +1027,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -1024,7 +1049,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 
@@ -1038,7 +1063,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:385
 
 ***
 
@@ -1058,7 +1083,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:424
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -1078,7 +1103,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:424
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:383
 
 ***
 
@@ -1096,7 +1121,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:440
 
 ***
 
@@ -1114,7 +1139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:440
+packages/quickjs-ffi-types/dist/index.d.ts:442
 
 ***
 
@@ -1132,7 +1157,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:440
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:384
 
 ***
 
@@ -1150,7 +1175,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -1170,7 +1195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:439
+packages/quickjs-ffi-types/dist/index.d.ts:441
 
 ***
 
@@ -1190,7 +1215,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:439
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:387
 
 ***
 
@@ -1210,7 +1235,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:382
 
 ***
 
@@ -1234,7 +1259,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:419
+packages/quickjs-ffi-types/dist/index.d.ts:420
 
 ***
 
@@ -1258,7 +1283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:420
+packages/quickjs-ffi-types/dist/index.d.ts:421
 
 ***
 
@@ -1276,7 +1301,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:432
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -1296,7 +1321,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:432
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:380
 
 ***
 
@@ -1316,7 +1341,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:429
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -1336,7 +1361,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:429
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:442
+packages/quickjs-ffi-types/dist/index.d.ts:444
 
 ***
 
@@ -1356,7 +1381,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:442
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:441
+packages/quickjs-ffi-types/dist/index.d.ts:443
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to newQuickJSWASMModule or newQuickJSAsyncWASMModule.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:477
+packages/quickjs-ffi-types/dist/index.d.ts:479
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:477
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:478
+packages/quickjs-ffi-types/dist/index.d.ts:480
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:478
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:476
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to newQuickJSWASMModule or newQuickJSAsyncWASMModule.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:479
+packages/quickjs-ffi-types/dist/index.d.ts:492
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:479
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:480
+packages/quickjs-ffi-types/dist/index.d.ts:493
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:480
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:478
+packages/quickjs-ffi-types/dist/index.d.ts:491
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSEmscriptenModule.md
@@ -55,7 +55,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:252
+packages/quickjs-ffi-types/dist/index.d.ts:261
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:252
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:243
+packages/quickjs-ffi-types/dist/index.d.ts:252
 
 ***
 
@@ -83,7 +83,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:243
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:244
+packages/quickjs-ffi-types/dist/index.d.ts:253
 
 ***
 
@@ -97,7 +97,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:244
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:242
+packages/quickjs-ffi-types/dist/index.d.ts:251
 
 ***
 
@@ -111,7 +111,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:242
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:248
+packages/quickjs-ffi-types/dist/index.d.ts:257
 
 ***
 
@@ -125,7 +125,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:248
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:249
+packages/quickjs-ffi-types/dist/index.d.ts:258
 
 ***
 
@@ -139,7 +139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:249
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:246
+packages/quickjs-ffi-types/dist/index.d.ts:255
 
 ***
 
@@ -153,7 +153,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:246
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:247
+packages/quickjs-ffi-types/dist/index.d.ts:256
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:247
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:245
+packages/quickjs-ffi-types/dist/index.d.ts:254
 
 ***
 
@@ -181,7 +181,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:245
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:251
+packages/quickjs-ffi-types/dist/index.d.ts:260
 
 ***
 
@@ -195,7 +195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:251
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:250
+packages/quickjs-ffi-types/dist/index.d.ts:259
 
 ***
 
@@ -205,7 +205,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:250
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:297
 
 ***
 
@@ -215,7 +215,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:287
+packages/quickjs-ffi-types/dist/index.d.ts:296
 
 ***
 
@@ -231,7 +231,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -247,7 +247,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -274,7 +274,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:237
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -296,7 +296,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:237
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:240
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -318,7 +318,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:240
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:239
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -355,7 +355,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:239
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:241
+packages/quickjs-ffi-types/dist/index.d.ts:250
 
 ***
 
@@ -381,7 +381,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -403,7 +403,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:238
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -447,7 +447,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -471,7 +471,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 
@@ -500,7 +500,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:232
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSFFI.md
@@ -57,6 +57,8 @@ library.
   - [QTS\_NewRuntime](QuickJSFFI.md#qts-newruntime)
   - [QTS\_NewString](QuickJSFFI.md#qts-newstring)
   - [QTS\_NewSymbol](QuickJSFFI.md#qts-newsymbol)
+  - [QTS\_PromiseResult](QuickJSFFI.md#qts-promiseresult)
+  - [QTS\_PromiseState](QuickJSFFI.md#qts-promisestate)
   - [QTS\_RecoverableLeakCheck](QuickJSFFI.md#qts-recoverableleakcheck)
   - [QTS\_ResolveException](QuickJSFFI.md#qts-resolveexception)
   - [QTS\_RuntimeComputeMemoryUsage](QuickJSFFI.md#qts-runtimecomputememoryusage)
@@ -88,7 +90,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:309
+packages/quickjs-ffi-types/dist/index.d.ts:318
 
 ***
 
@@ -108,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:309
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:372
 
 ***
 
@@ -122,7 +124,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:370
 
 ***
 
@@ -136,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:359
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:369
 
 ***
 
@@ -150,7 +152,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:316
+packages/quickjs-ffi-types/dist/index.d.ts:325
 
 ***
 
@@ -176,7 +178,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:316
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:349
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -210,7 +212,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:349
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:348
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -230,7 +232,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:348
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:351
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -250,7 +252,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:351
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:330
+packages/quickjs-ffi-types/dist/index.d.ts:339
 
 ***
 
@@ -278,7 +280,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:352
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -300,7 +302,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:352
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:345
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -320,7 +322,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:345
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:329
+packages/quickjs-ffi-types/dist/index.d.ts:338
 
 ***
 
@@ -338,7 +340,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:329
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:325
+packages/quickjs-ffi-types/dist/index.d.ts:334
 
 ***
 
@@ -356,7 +358,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:325
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:323
+packages/quickjs-ffi-types/dist/index.d.ts:332
 
 ***
 
@@ -376,7 +378,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:323
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:326
+packages/quickjs-ffi-types/dist/index.d.ts:335
 
 ***
 
@@ -396,7 +398,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:326
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:327
+packages/quickjs-ffi-types/dist/index.d.ts:336
 
 ***
 
@@ -416,7 +418,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:327
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:328
+packages/quickjs-ffi-types/dist/index.d.ts:337
 
 ***
 
@@ -436,7 +438,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:328
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:339
+packages/quickjs-ffi-types/dist/index.d.ts:348
 
 ***
 
@@ -456,7 +458,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:339
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:340
+packages/quickjs-ffi-types/dist/index.d.ts:349
 
 ***
 
@@ -470,7 +472,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:340
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:320
+packages/quickjs-ffi-types/dist/index.d.ts:329
 
 ***
 
@@ -490,7 +492,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:320
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:336
+packages/quickjs-ffi-types/dist/index.d.ts:345
 
 ***
 
@@ -508,7 +510,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:336
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:364
 
 ***
 
@@ -528,7 +530,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:355
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 
@@ -542,7 +544,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:319
+packages/quickjs-ffi-types/dist/index.d.ts:328
 
 ***
 
@@ -564,7 +566,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:319
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:346
+packages/quickjs-ffi-types/dist/index.d.ts:355
 
 ***
 
@@ -584,7 +586,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:346
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:338
+packages/quickjs-ffi-types/dist/index.d.ts:347
 
 ***
 
@@ -604,7 +606,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:338
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:342
+packages/quickjs-ffi-types/dist/index.d.ts:351
 
 ***
 
@@ -618,7 +620,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:342
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:321
+packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ***
 
@@ -632,7 +634,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:321
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:318
+packages/quickjs-ffi-types/dist/index.d.ts:327
 
 ***
 
@@ -652,7 +654,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:318
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:343
+packages/quickjs-ffi-types/dist/index.d.ts:352
 
 ***
 
@@ -670,7 +672,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:343
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:344
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -688,7 +690,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:344
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:333
+packages/quickjs-ffi-types/dist/index.d.ts:342
 
 ***
 
@@ -710,7 +712,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:333
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:334
+packages/quickjs-ffi-types/dist/index.d.ts:343
 
 ***
 
@@ -730,7 +732,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:334
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:324
+packages/quickjs-ffi-types/dist/index.d.ts:333
 
 ***
 
@@ -748,7 +750,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:324
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:311
+packages/quickjs-ffi-types/dist/index.d.ts:320
 
 ***
 
@@ -768,7 +770,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:311
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:335
+packages/quickjs-ffi-types/dist/index.d.ts:344
 
 ***
 
@@ -790,7 +792,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:335
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:371
 
 ***
 
@@ -808,7 +810,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:331
+packages/quickjs-ffi-types/dist/index.d.ts:340
 
 ***
 
@@ -828,7 +830,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:331
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:332
+packages/quickjs-ffi-types/dist/index.d.ts:341
 
 ***
 
@@ -848,7 +850,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:332
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:365
 
 ***
 
@@ -862,7 +864,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:356
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:322
+packages/quickjs-ffi-types/dist/index.d.ts:331
 
 ***
 
@@ -882,7 +884,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:322
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:337
+packages/quickjs-ffi-types/dist/index.d.ts:346
 
 ***
 
@@ -904,7 +906,47 @@ packages/quickjs-ffi-types/dist/index.d.ts:337
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:341
+packages/quickjs-ffi-types/dist/index.d.ts:350
+
+***
+
+### QTS\_PromiseResult
+
+> **QTS\_PromiseResult**: (`ctx`, `promise`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:367
+
+***
+
+### QTS\_PromiseState
+
+> **QTS\_PromiseState**: (`ctx`, `promise`) => [`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:366
 
 ***
 
@@ -918,7 +960,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:341
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:315
+packages/quickjs-ffi-types/dist/index.d.ts:324
 
 ***
 
@@ -938,7 +980,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:315
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:350
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -958,7 +1000,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:350
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:313
+packages/quickjs-ffi-types/dist/index.d.ts:322
 
 ***
 
@@ -976,7 +1018,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:313
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:374
 
 ***
 
@@ -994,7 +1036,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:363
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:376
 
 ***
 
@@ -1012,7 +1054,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:365
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:314
+packages/quickjs-ffi-types/dist/index.d.ts:323
 
 ***
 
@@ -1030,7 +1072,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:314
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:373
 
 ***
 
@@ -1050,7 +1092,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:375
 
 ***
 
@@ -1070,7 +1112,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:364
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:317
+packages/quickjs-ffi-types/dist/index.d.ts:326
 
 ***
 
@@ -1090,7 +1132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:317
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:312
+packages/quickjs-ffi-types/dist/index.d.ts:321
 
 ***
 
@@ -1114,7 +1156,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:312
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:347
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -1132,7 +1174,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:347
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:368
 
 ***
 
@@ -1152,7 +1194,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:357
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:310
+packages/quickjs-ffi-types/dist/index.d.ts:319
 
 ***
 
@@ -1172,7 +1214,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:310
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -1192,7 +1234,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:354
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:367
+packages/quickjs-ffi-types/dist/index.d.ts:378
 
 ***
 
@@ -1212,7 +1254,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:367
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:377
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSFFI.md
@@ -36,6 +36,7 @@ library.
   - [QTS\_GetFalse](QuickJSFFI.md#qts-getfalse)
   - [QTS\_GetFloat64](QuickJSFFI.md#qts-getfloat64)
   - [QTS\_GetGlobalObject](QuickJSFFI.md#qts-getglobalobject)
+  - [QTS\_GetModuleNamespace](QuickJSFFI.md#qts-getmodulenamespace)
   - [QTS\_GetNull](QuickJSFFI.md#qts-getnull)
   - [QTS\_GetProp](QuickJSFFI.md#qts-getprop)
   - [QTS\_GetString](QuickJSFFI.md#qts-getstring)
@@ -107,7 +108,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:309
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -121,7 +122,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -135,7 +136,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -255,13 +256,15 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ### QTS\_Eval
 
-> **QTS\_Eval**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+> **QTS\_Eval**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -505,7 +508,27 @@ packages/quickjs-ffi-types/dist/index.d.ts:336
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:355
+
+***
+
+### QTS\_GetModuleNamespace
+
+> **QTS\_GetModuleNamespace**: (`ctx`, `module_func_obj`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **module\_func\_obj**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -767,7 +790,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:335
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -825,7 +848,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:332
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -953,7 +976,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:313
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -971,7 +994,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:365
 
 ***
 
@@ -1007,7 +1030,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:314
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 
@@ -1027,7 +1050,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:364
 
 ***
 
@@ -1109,7 +1132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:347
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -1149,7 +1172,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:310
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -1169,7 +1192,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:367
 
 ***
 
@@ -1189,7 +1212,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:366
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:366
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to newQuickJSWASMModule or newQuickJSAsyncWASMModule.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:463
+packages/quickjs-ffi-types/dist/index.d.ts:465
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:463
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:464
+packages/quickjs-ffi-types/dist/index.d.ts:466
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:464
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:462
+packages/quickjs-ffi-types/dist/index.d.ts:464
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to newQuickJSWASMModule or newQuickJSAsyncWASMModule.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:465
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:465
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:466
+packages/quickjs-ffi-types/dist/index.d.ts:479
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:466
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:464
+packages/quickjs-ffi-types/dist/index.d.ts:477
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/SourceMapData.md
+++ b/doc/quickjs-emscripten-core/interfaces/SourceMapData.md
@@ -22,7 +22,7 @@
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:168
+packages/quickjs-ffi-types/dist/index.d.ts:177
 
 ***
 
@@ -32,7 +32,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:168
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:167
+packages/quickjs-ffi-types/dist/index.d.ts:176
 
 ***
 
@@ -42,7 +42,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:167
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:166
+packages/quickjs-ffi-types/dist/index.d.ts:175
 
 ***
 
@@ -52,7 +52,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:166
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:165
+packages/quickjs-ffi-types/dist/index.d.ts:174
 
 ***
 

--- a/doc/quickjs-emscripten-core/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten-core/namespaces/errors/README.md
@@ -17,6 +17,7 @@ Collects the informative errors this library may throw.
 - [QuickJSEmscriptenModuleError](classes/QuickJSEmscriptenModuleError.md)
 - [QuickJSMemoryLeakDetected](classes/QuickJSMemoryLeakDetected.md)
 - [QuickJSNotImplemented](classes/QuickJSNotImplemented.md)
+- [QuickJSPromisePending](classes/QuickJSPromisePending.md)
 - [QuickJSUnknownIntrinsic](classes/QuickJSUnknownIntrinsic.md)
 - [QuickJSUnwrapError](classes/QuickJSUnwrapError.md)
 - [QuickJSUseAfterFree](classes/QuickJSUseAfterFree.md)

--- a/doc/quickjs-emscripten-core/namespaces/errors/classes/QuickJSPromisePending.md
+++ b/doc/quickjs-emscripten-core/namespaces/errors/classes/QuickJSPromisePending.md
@@ -1,0 +1,59 @@
+[quickjs-emscripten](../../../../packages.md) • **quickjs-emscripten-core** • [Readme](../../../README.md) \| [Exports](../../../exports.md)
+
+***
+
+[quickjs-emscripten](../../../../packages.md) / [quickjs-emscripten-core](../../../exports.md) / [errors](../README.md) / QuickJSPromisePending
+
+# Class: QuickJSPromisePending
+
+## Contents
+
+- [Extends](QuickJSPromisePending.md#extends)
+- [Constructors](QuickJSPromisePending.md#constructors)
+  - [new QuickJSPromisePending(message)](QuickJSPromisePending.md#new-quickjspromisependingmessage)
+- [Properties](QuickJSPromisePending.md#properties)
+  - [name](QuickJSPromisePending.md#name)
+
+## Extends
+
+- `Error`
+
+## Constructors
+
+### new QuickJSPromisePending(message)
+
+> **new QuickJSPromisePending**(`message`?): [`QuickJSPromisePending`](QuickJSPromisePending.md)
+
+#### Parameters
+
+• **message?**: `string`
+
+#### Returns
+
+[`QuickJSPromisePending`](QuickJSPromisePending.md)
+
+#### Inherited from
+
+`Error.constructor`
+
+#### Source
+
+node\_modules/typescript/lib/lib.es5.d.ts:1081
+
+## Properties
+
+### name
+
+> **name**: `string` = `"QuickJSPromisePending"`
+
+#### Overrides
+
+`Error.name`
+
+#### Source
+
+[packages/quickjs-emscripten-core/src/errors.ts:49](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-emscripten-core/src/errors.ts#L49)
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten/classes/Lifetime.md
+++ b/doc/quickjs-emscripten/classes/Lifetime.md
@@ -85,7 +85,7 @@ the creator.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:584
+packages/quickjs-emscripten-core/dist/index.d.ts:592
 
 ## Properties
 
@@ -95,7 +95,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:584
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:574
+packages/quickjs-emscripten-core/dist/index.d.ts:582
 
 ***
 
@@ -105,7 +105,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:575
+packages/quickjs-emscripten-core/dist/index.d.ts:583
 
 ***
 
@@ -115,7 +115,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:573
+packages/quickjs-emscripten-core/dist/index.d.ts:581
 
 ***
 
@@ -125,7 +125,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:573
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:570
+packages/quickjs-emscripten-core/dist/index.d.ts:578
 
 ***
 
@@ -143,7 +143,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:570
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:571
+packages/quickjs-emscripten-core/dist/index.d.ts:579
 
 ***
 
@@ -161,7 +161,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:571
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:572
+packages/quickjs-emscripten-core/dist/index.d.ts:580
 
 ## Accessors
 
@@ -179,7 +179,7 @@ false after the object has been [dispose](Lifetime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:585
+packages/quickjs-emscripten-core/dist/index.d.ts:593
 
 ***
 
@@ -193,7 +193,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:585
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:594
+packages/quickjs-emscripten-core/dist/index.d.ts:602
 
 ***
 
@@ -207,7 +207,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:594
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:593
+packages/quickjs-emscripten-core/dist/index.d.ts:601
 
 ***
 
@@ -228,7 +228,7 @@ If the lifetime has been [dispose](Lifetime.md#dispose-1)d already.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:592
+packages/quickjs-emscripten-core/dist/index.d.ts:600
 
 ## Methods
 
@@ -252,7 +252,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -280,7 +280,7 @@ the result of `map(this)`.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:603
+packages/quickjs-emscripten-core/dist/index.d.ts:611
 
 #### consume(map)
 
@@ -300,7 +300,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:603
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:604
+packages/quickjs-emscripten-core/dist/index.d.ts:612
 
 ***
 
@@ -324,7 +324,7 @@ Dispose of [value](Lifetime.md#value-1) and perform cleanup.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:608
+packages/quickjs-emscripten-core/dist/index.d.ts:616
 
 ***
 
@@ -340,7 +340,7 @@ Create a new handle pointing to the same [value](Lifetime.md#value-1).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:598
+packages/quickjs-emscripten-core/dist/index.d.ts:606
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
@@ -101,7 +101,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:830
+packages/quickjs-emscripten-core/dist/index.d.ts:838
 
 ## Properties
 
@@ -117,7 +117,7 @@ The runtime that created this context.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:319
+packages/quickjs-emscripten-core/dist/index.d.ts:322
 
 ## Accessors
 
@@ -135,7 +135,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:839
+packages/quickjs-emscripten-core/dist/index.d.ts:847
 
 ***
 
@@ -151,7 +151,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:839
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:862
+packages/quickjs-emscripten-core/dist/index.d.ts:870
 
 ***
 
@@ -169,7 +169,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:868
+packages/quickjs-emscripten-core/dist/index.d.ts:876
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:854
+packages/quickjs-emscripten-core/dist/index.d.ts:862
 
 ***
 
@@ -201,7 +201,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:854
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:858
+packages/quickjs-emscripten-core/dist/index.d.ts:866
 
 ***
 
@@ -217,7 +217,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:850
+packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 ## Methods
 
@@ -237,7 +237,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -275,7 +275,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1110
+packages/quickjs-emscripten-core/dist/index.d.ts:1118
 
 ***
 
@@ -308,7 +308,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1203
+packages/quickjs-emscripten-core/dist/index.d.ts:1224
 
 ***
 
@@ -339,7 +339,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1096
+packages/quickjs-emscripten-core/dist/index.d.ts:1104
 
 ***
 
@@ -364,7 +364,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:846
+packages/quickjs-emscripten-core/dist/index.d.ts:854
 
 ***
 
@@ -389,7 +389,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1156
+packages/quickjs-emscripten-core/dist/index.d.ts:1177
 
 ***
 
@@ -423,7 +423,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1190
+packages/quickjs-emscripten-core/dist/index.d.ts:1211
 
 ***
 
@@ -432,7 +432,20 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1190
 > **evalCode**(`code`, `filename`?, `options`?): [`VmCallResult`](../exports.md#vmcallresultvmhandle)\<[`QuickJSHandle`](../exports.md#quickjshandle)\>
 
 Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
-Evaluates the Javascript source `code` in the global scope of this VM.
+
+Evaluates `code`, as though it's in a file named `filename`, with options `options`.
+
+- When `options.type` is `"global"`, the code is evaluated in the global
+  scope of the QuickJSContext, and the return value is the result of the last
+  expression.
+- When `options.type` is `"module"`, the code is evaluated is a module scope.
+  It may use `import` and `export` if [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#setModuleLoader](QuickJSRuntime.md#setmoduleloader) was called.
+  It may use top-level await if supported by the underlying QuickJS library.
+  The return value is the module's exports, or a promise for the module's exports.
+- When `options.type` is unset, the code is evaluated as a module if it
+  contains an `import` or `export` statement, otherwise it is evaluated in
+  the global scope.
+
 When working with async code, you many need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#executePendingJobs](QuickJSRuntime.md#executependingjobs)
 to execute callbacks pending after synchronous evaluation returns.
 
@@ -473,7 +486,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1131
+packages/quickjs-emscripten-core/dist/index.d.ts:1152
 
 ***
 
@@ -499,7 +512,7 @@ See [EvalFlags](../exports.md#evalflags) for number semantics
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:331
+packages/quickjs-emscripten-core/dist/index.d.ts:334
 
 ***
 
@@ -523,7 +536,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1058
+packages/quickjs-emscripten-core/dist/index.d.ts:1066
 
 ***
 
@@ -547,7 +560,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1054
+packages/quickjs-emscripten-core/dist/index.d.ts:1062
 
 ***
 
@@ -573,7 +586,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1041
+packages/quickjs-emscripten-core/dist/index.d.ts:1049
 
 ***
 
@@ -603,7 +616,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1077
+packages/quickjs-emscripten-core/dist/index.d.ts:1085
 
 ***
 
@@ -627,7 +640,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1045
+packages/quickjs-emscripten-core/dist/index.d.ts:1053
 
 ***
 
@@ -652,7 +665,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1050
+packages/quickjs-emscripten-core/dist/index.d.ts:1058
 
 ***
 
@@ -673,7 +686,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:902
+packages/quickjs-emscripten-core/dist/index.d.ts:910
 
 ***
 
@@ -697,7 +710,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:906
+packages/quickjs-emscripten-core/dist/index.d.ts:914
 
 ***
 
@@ -729,7 +742,7 @@ See [Emscripten's docs on Asyncify](https://emscripten.org/docs/porting/asyncify
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:347
+packages/quickjs-emscripten-core/dist/index.d.ts:350
 
 ***
 
@@ -753,7 +766,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:890
+packages/quickjs-emscripten-core/dist/index.d.ts:898
 
 ***
 
@@ -781,7 +794,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:890
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1024
+packages/quickjs-emscripten-core/dist/index.d.ts:1032
 
 #### newError(message)
 
@@ -801,7 +814,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1024
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1028
+packages/quickjs-emscripten-core/dist/index.d.ts:1036
 
 #### newError(undefined)
 
@@ -817,7 +830,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1028
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1029
+packages/quickjs-emscripten-core/dist/index.d.ts:1037
 
 ***
 
@@ -934,7 +947,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1023
+packages/quickjs-emscripten-core/dist/index.d.ts:1031
 
 ***
 
@@ -958,7 +971,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:872
+packages/quickjs-emscripten-core/dist/index.d.ts:880
 
 ***
 
@@ -985,7 +998,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:897
+packages/quickjs-emscripten-core/dist/index.d.ts:905
 
 ***
 
@@ -1010,7 +1023,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:913
+packages/quickjs-emscripten-core/dist/index.d.ts:921
 
 #### newPromise(promise)
 
@@ -1036,7 +1049,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:921
+packages/quickjs-emscripten-core/dist/index.d.ts:929
 
 #### newPromise(newPromiseFn)
 
@@ -1061,7 +1074,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:928
+packages/quickjs-emscripten-core/dist/index.d.ts:936
 
 ***
 
@@ -1085,7 +1098,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:876
+packages/quickjs-emscripten-core/dist/index.d.ts:884
 
 ***
 
@@ -1110,7 +1123,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:886
+packages/quickjs-emscripten-core/dist/index.d.ts:894
 
 ***
 
@@ -1135,7 +1148,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:881
+packages/quickjs-emscripten-core/dist/index.d.ts:889
 
 ***
 
@@ -1167,7 +1180,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1069
+packages/quickjs-emscripten-core/dist/index.d.ts:1077
 
 ***
 
@@ -1204,7 +1217,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1089
+packages/quickjs-emscripten-core/dist/index.d.ts:1097
 
 ***
 
@@ -1228,7 +1241,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1143
+packages/quickjs-emscripten-core/dist/index.d.ts:1164
 
 ***
 
@@ -1256,7 +1269,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1036
+packages/quickjs-emscripten-core/dist/index.d.ts:1044
 
 ***
 
@@ -1287,7 +1300,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1163
+packages/quickjs-emscripten-core/dist/index.d.ts:1184
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
@@ -39,6 +39,7 @@ host functions as though they were synchronous.
   - [getArrayBuffer()](QuickJSAsyncContext.md#getarraybuffer)
   - [getBigInt()](QuickJSAsyncContext.md#getbigint)
   - [getNumber()](QuickJSAsyncContext.md#getnumber)
+  - [getPromiseState()](QuickJSAsyncContext.md#getpromisestate)
   - [getProp()](QuickJSAsyncContext.md#getprop)
   - [getString()](QuickJSAsyncContext.md#getstring)
   - [getSymbol()](QuickJSAsyncContext.md#getsymbol)
@@ -101,7 +102,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:838
+packages/quickjs-emscripten-core/dist/index.d.ts:849
 
 ## Properties
 
@@ -135,7 +136,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:847
+packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 ***
 
@@ -151,7 +152,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:847
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:870
+packages/quickjs-emscripten-core/dist/index.d.ts:881
 
 ***
 
@@ -169,7 +170,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:876
+packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 ***
 
@@ -185,7 +186,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:876
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:862
+packages/quickjs-emscripten-core/dist/index.d.ts:873
 
 ***
 
@@ -201,7 +202,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:862
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:866
+packages/quickjs-emscripten-core/dist/index.d.ts:877
 
 ***
 
@@ -217,7 +218,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:866
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:858
+packages/quickjs-emscripten-core/dist/index.d.ts:869
 
 ## Methods
 
@@ -275,7 +276,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1118
+packages/quickjs-emscripten-core/dist/index.d.ts:1130
 
 ***
 
@@ -308,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1224
+packages/quickjs-emscripten-core/dist/index.d.ts:1236
 
 ***
 
@@ -339,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1104
+packages/quickjs-emscripten-core/dist/index.d.ts:1116
 
 ***
 
@@ -364,7 +365,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:854
+packages/quickjs-emscripten-core/dist/index.d.ts:865
 
 ***
 
@@ -389,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1177
+packages/quickjs-emscripten-core/dist/index.d.ts:1189
 
 ***
 
@@ -423,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1211
+packages/quickjs-emscripten-core/dist/index.d.ts:1223
 
 ***
 
@@ -486,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1152
+packages/quickjs-emscripten-core/dist/index.d.ts:1164
 
 ***
 
@@ -536,7 +537,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1066
+packages/quickjs-emscripten-core/dist/index.d.ts:1077
 
 ***
 
@@ -560,7 +561,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1062
+packages/quickjs-emscripten-core/dist/index.d.ts:1073
 
 ***
 
@@ -586,7 +587,29 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1049
+packages/quickjs-emscripten-core/dist/index.d.ts:1060
+
+***
+
+### getPromiseState()
+
+> **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Parameters
+
+• **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Returns
+
+[`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Inherited from
+
+[`quickjs-emscripten.QuickJSContext.getPromiseState`](QuickJSContext.md#getpromisestate)
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:1078
 
 ***
 
@@ -616,7 +639,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1085
+packages/quickjs-emscripten-core/dist/index.d.ts:1097
 
 ***
 
@@ -640,7 +663,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1053
+packages/quickjs-emscripten-core/dist/index.d.ts:1064
 
 ***
 
@@ -665,7 +688,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1058
+packages/quickjs-emscripten-core/dist/index.d.ts:1069
 
 ***
 
@@ -686,7 +709,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:910
+packages/quickjs-emscripten-core/dist/index.d.ts:921
 
 ***
 
@@ -710,7 +733,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:914
+packages/quickjs-emscripten-core/dist/index.d.ts:925
 
 ***
 
@@ -766,7 +789,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:898
+packages/quickjs-emscripten-core/dist/index.d.ts:909
 
 ***
 
@@ -794,7 +817,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:898
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1032
+packages/quickjs-emscripten-core/dist/index.d.ts:1043
 
 #### newError(message)
 
@@ -814,7 +837,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1032
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1036
+packages/quickjs-emscripten-core/dist/index.d.ts:1047
 
 #### newError(undefined)
 
@@ -830,7 +853,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1036
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1037
+packages/quickjs-emscripten-core/dist/index.d.ts:1048
 
 ***
 
@@ -947,7 +970,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1031
+packages/quickjs-emscripten-core/dist/index.d.ts:1042
 
 ***
 
@@ -971,7 +994,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:880
+packages/quickjs-emscripten-core/dist/index.d.ts:891
 
 ***
 
@@ -998,7 +1021,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:905
+packages/quickjs-emscripten-core/dist/index.d.ts:916
 
 ***
 
@@ -1023,7 +1046,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:921
+packages/quickjs-emscripten-core/dist/index.d.ts:932
 
 #### newPromise(promise)
 
@@ -1049,7 +1072,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:929
+packages/quickjs-emscripten-core/dist/index.d.ts:940
 
 #### newPromise(newPromiseFn)
 
@@ -1074,7 +1097,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:936
+packages/quickjs-emscripten-core/dist/index.d.ts:947
 
 ***
 
@@ -1098,7 +1121,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:884
+packages/quickjs-emscripten-core/dist/index.d.ts:895
 
 ***
 
@@ -1123,7 +1146,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:894
+packages/quickjs-emscripten-core/dist/index.d.ts:905
 
 ***
 
@@ -1148,7 +1171,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:889
+packages/quickjs-emscripten-core/dist/index.d.ts:900
 
 ***
 
@@ -1180,7 +1203,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1077
+packages/quickjs-emscripten-core/dist/index.d.ts:1089
 
 ***
 
@@ -1217,7 +1240,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1097
+packages/quickjs-emscripten-core/dist/index.d.ts:1109
 
 ***
 
@@ -1241,7 +1264,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1164
+packages/quickjs-emscripten-core/dist/index.d.ts:1176
 
 ***
 
@@ -1269,7 +1292,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1044
+packages/quickjs-emscripten-core/dist/index.d.ts:1055
 
 ***
 
@@ -1300,7 +1323,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1184
+packages/quickjs-emscripten-core/dist/index.d.ts:1196
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
@@ -102,7 +102,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:859
+packages/quickjs-emscripten-core/dist/index.d.ts:874
 
 ## Properties
 
@@ -136,7 +136,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:868
+packages/quickjs-emscripten-core/dist/index.d.ts:883
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:891
+packages/quickjs-emscripten-core/dist/index.d.ts:906
 
 ***
 
@@ -170,7 +170,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:897
+packages/quickjs-emscripten-core/dist/index.d.ts:912
 
 ***
 
@@ -186,7 +186,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:897
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:883
+packages/quickjs-emscripten-core/dist/index.d.ts:898
 
 ***
 
@@ -202,7 +202,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:883
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:887
+packages/quickjs-emscripten-core/dist/index.d.ts:902
 
 ***
 
@@ -218,7 +218,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:879
+packages/quickjs-emscripten-core/dist/index.d.ts:894
 
 ## Methods
 
@@ -276,7 +276,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1153
+packages/quickjs-emscripten-core/dist/index.d.ts:1168
 
 ***
 
@@ -309,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1259
+packages/quickjs-emscripten-core/dist/index.d.ts:1274
 
 ***
 
@@ -340,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1139
+packages/quickjs-emscripten-core/dist/index.d.ts:1154
 
 ***
 
@@ -365,7 +365,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:875
+packages/quickjs-emscripten-core/dist/index.d.ts:890
 
 ***
 
@@ -390,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1212
+packages/quickjs-emscripten-core/dist/index.d.ts:1227
 
 ***
 
@@ -424,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1246
+packages/quickjs-emscripten-core/dist/index.d.ts:1261
 
 ***
 
@@ -487,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1187
+packages/quickjs-emscripten-core/dist/index.d.ts:1202
 
 ***
 
@@ -537,7 +537,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1087
+packages/quickjs-emscripten-core/dist/index.d.ts:1102
 
 ***
 
@@ -561,7 +561,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1083
+packages/quickjs-emscripten-core/dist/index.d.ts:1098
 
 ***
 
@@ -587,7 +587,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1070
+packages/quickjs-emscripten-core/dist/index.d.ts:1085
 
 ***
 
@@ -621,7 +621,7 @@ resultHandle.dispose();
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1101
+packages/quickjs-emscripten-core/dist/index.d.ts:1116
 
 ***
 
@@ -651,7 +651,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1120
+packages/quickjs-emscripten-core/dist/index.d.ts:1135
 
 ***
 
@@ -675,7 +675,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1074
+packages/quickjs-emscripten-core/dist/index.d.ts:1089
 
 ***
 
@@ -700,7 +700,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1079
+packages/quickjs-emscripten-core/dist/index.d.ts:1094
 
 ***
 
@@ -721,7 +721,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:931
+packages/quickjs-emscripten-core/dist/index.d.ts:946
 
 ***
 
@@ -745,7 +745,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:935
+packages/quickjs-emscripten-core/dist/index.d.ts:950
 
 ***
 
@@ -801,7 +801,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:919
+packages/quickjs-emscripten-core/dist/index.d.ts:934
 
 ***
 
@@ -829,7 +829,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:919
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1053
+packages/quickjs-emscripten-core/dist/index.d.ts:1068
 
 #### newError(message)
 
@@ -849,7 +849,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1053
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1057
+packages/quickjs-emscripten-core/dist/index.d.ts:1072
 
 #### newError(undefined)
 
@@ -865,7 +865,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1057
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1058
+packages/quickjs-emscripten-core/dist/index.d.ts:1073
 
 ***
 
@@ -982,7 +982,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1052
+packages/quickjs-emscripten-core/dist/index.d.ts:1067
 
 ***
 
@@ -1006,7 +1006,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:901
+packages/quickjs-emscripten-core/dist/index.d.ts:916
 
 ***
 
@@ -1033,7 +1033,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:926
+packages/quickjs-emscripten-core/dist/index.d.ts:941
 
 ***
 
@@ -1058,7 +1058,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:942
+packages/quickjs-emscripten-core/dist/index.d.ts:957
 
 #### newPromise(promise)
 
@@ -1084,7 +1084,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:950
+packages/quickjs-emscripten-core/dist/index.d.ts:965
 
 #### newPromise(newPromiseFn)
 
@@ -1109,7 +1109,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:957
+packages/quickjs-emscripten-core/dist/index.d.ts:972
 
 ***
 
@@ -1133,7 +1133,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:905
+packages/quickjs-emscripten-core/dist/index.d.ts:920
 
 ***
 
@@ -1158,7 +1158,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:915
+packages/quickjs-emscripten-core/dist/index.d.ts:930
 
 ***
 
@@ -1183,7 +1183,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:910
+packages/quickjs-emscripten-core/dist/index.d.ts:925
 
 ***
 
@@ -1215,7 +1215,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1112
+packages/quickjs-emscripten-core/dist/index.d.ts:1127
 
 ***
 
@@ -1252,7 +1252,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1132
+packages/quickjs-emscripten-core/dist/index.d.ts:1147
 
 ***
 
@@ -1276,7 +1276,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1199
+packages/quickjs-emscripten-core/dist/index.d.ts:1214
 
 ***
 
@@ -1304,7 +1304,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1065
+packages/quickjs-emscripten-core/dist/index.d.ts:1080
 
 ***
 
@@ -1335,7 +1335,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1219
+packages/quickjs-emscripten-core/dist/index.d.ts:1234
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
@@ -276,7 +276,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1140
+packages/quickjs-emscripten-core/dist/index.d.ts:1153
 
 ***
 
@@ -309,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1246
+packages/quickjs-emscripten-core/dist/index.d.ts:1259
 
 ***
 
@@ -340,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1126
+packages/quickjs-emscripten-core/dist/index.d.ts:1139
 
 ***
 
@@ -390,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1199
+packages/quickjs-emscripten-core/dist/index.d.ts:1212
 
 ***
 
@@ -424,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1233
+packages/quickjs-emscripten-core/dist/index.d.ts:1246
 
 ***
 
@@ -487,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1174
+packages/quickjs-emscripten-core/dist/index.d.ts:1187
 
 ***
 
@@ -595,6 +595,18 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1070
 
 > **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
 
+Get the current state of a QuickJS promise, see [JSPromiseState](../exports.md#jspromisestate) for the possible states.
+This can be used to expect a promise to be fulfilled when combined with [unwrapResult](QuickJSAsyncContext.md#unwrapresult):
+
+```typescript
+const promiseHandle = context.evalCode(`Promise.resolve(42)`);
+const resultHandle = context.unwrapResult(
+ context.getPromiseState(promiseHandle)
+);
+context.getNumber(resultHandle) === 42; // true
+resultHandle.dispose();
+```
+
 #### Parameters
 
 • **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
@@ -609,7 +621,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1070
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1088
+packages/quickjs-emscripten-core/dist/index.d.ts:1101
 
 ***
 
@@ -639,7 +651,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1107
+packages/quickjs-emscripten-core/dist/index.d.ts:1120
 
 ***
 
@@ -1203,7 +1215,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1099
+packages/quickjs-emscripten-core/dist/index.d.ts:1112
 
 ***
 
@@ -1240,7 +1252,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1119
+packages/quickjs-emscripten-core/dist/index.d.ts:1132
 
 ***
 
@@ -1264,7 +1276,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1186
+packages/quickjs-emscripten-core/dist/index.d.ts:1199
 
 ***
 
@@ -1323,7 +1335,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1206
+packages/quickjs-emscripten-core/dist/index.d.ts:1219
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncContext.md
@@ -102,7 +102,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:849
+packages/quickjs-emscripten-core/dist/index.d.ts:859
 
 ## Properties
 
@@ -136,7 +136,7 @@ false after the object has been [dispose](QuickJSAsyncContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:858
+packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:881
+packages/quickjs-emscripten-core/dist/index.d.ts:891
 
 ***
 
@@ -170,7 +170,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:887
+packages/quickjs-emscripten-core/dist/index.d.ts:897
 
 ***
 
@@ -186,7 +186,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:873
+packages/quickjs-emscripten-core/dist/index.d.ts:883
 
 ***
 
@@ -202,7 +202,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:873
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:877
+packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 ***
 
@@ -218,7 +218,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:877
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:869
+packages/quickjs-emscripten-core/dist/index.d.ts:879
 
 ## Methods
 
@@ -276,7 +276,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1130
+packages/quickjs-emscripten-core/dist/index.d.ts:1140
 
 ***
 
@@ -309,7 +309,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1236
+packages/quickjs-emscripten-core/dist/index.d.ts:1246
 
 ***
 
@@ -340,7 +340,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1116
+packages/quickjs-emscripten-core/dist/index.d.ts:1126
 
 ***
 
@@ -365,7 +365,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:865
+packages/quickjs-emscripten-core/dist/index.d.ts:875
 
 ***
 
@@ -390,7 +390,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1189
+packages/quickjs-emscripten-core/dist/index.d.ts:1199
 
 ***
 
@@ -424,7 +424,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1223
+packages/quickjs-emscripten-core/dist/index.d.ts:1233
 
 ***
 
@@ -487,7 +487,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1164
+packages/quickjs-emscripten-core/dist/index.d.ts:1174
 
 ***
 
@@ -537,7 +537,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1077
+packages/quickjs-emscripten-core/dist/index.d.ts:1087
 
 ***
 
@@ -561,7 +561,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1073
+packages/quickjs-emscripten-core/dist/index.d.ts:1083
 
 ***
 
@@ -587,7 +587,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1060
+packages/quickjs-emscripten-core/dist/index.d.ts:1070
 
 ***
 
@@ -609,7 +609,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1060
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1078
+packages/quickjs-emscripten-core/dist/index.d.ts:1088
 
 ***
 
@@ -639,7 +639,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1097
+packages/quickjs-emscripten-core/dist/index.d.ts:1107
 
 ***
 
@@ -663,7 +663,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1064
+packages/quickjs-emscripten-core/dist/index.d.ts:1074
 
 ***
 
@@ -688,7 +688,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1069
+packages/quickjs-emscripten-core/dist/index.d.ts:1079
 
 ***
 
@@ -709,7 +709,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:921
+packages/quickjs-emscripten-core/dist/index.d.ts:931
 
 ***
 
@@ -733,7 +733,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:925
+packages/quickjs-emscripten-core/dist/index.d.ts:935
 
 ***
 
@@ -789,7 +789,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:909
+packages/quickjs-emscripten-core/dist/index.d.ts:919
 
 ***
 
@@ -817,7 +817,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:909
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1043
+packages/quickjs-emscripten-core/dist/index.d.ts:1053
 
 #### newError(message)
 
@@ -837,7 +837,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1043
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1047
+packages/quickjs-emscripten-core/dist/index.d.ts:1057
 
 #### newError(undefined)
 
@@ -853,7 +853,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1047
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1048
+packages/quickjs-emscripten-core/dist/index.d.ts:1058
 
 ***
 
@@ -970,7 +970,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1042
+packages/quickjs-emscripten-core/dist/index.d.ts:1052
 
 ***
 
@@ -994,7 +994,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:891
+packages/quickjs-emscripten-core/dist/index.d.ts:901
 
 ***
 
@@ -1021,7 +1021,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:916
+packages/quickjs-emscripten-core/dist/index.d.ts:926
 
 ***
 
@@ -1046,7 +1046,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:932
+packages/quickjs-emscripten-core/dist/index.d.ts:942
 
 #### newPromise(promise)
 
@@ -1072,7 +1072,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:940
+packages/quickjs-emscripten-core/dist/index.d.ts:950
 
 #### newPromise(newPromiseFn)
 
@@ -1097,7 +1097,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:947
+packages/quickjs-emscripten-core/dist/index.d.ts:957
 
 ***
 
@@ -1121,7 +1121,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:895
+packages/quickjs-emscripten-core/dist/index.d.ts:905
 
 ***
 
@@ -1146,7 +1146,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:905
+packages/quickjs-emscripten-core/dist/index.d.ts:915
 
 ***
 
@@ -1171,7 +1171,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:900
+packages/quickjs-emscripten-core/dist/index.d.ts:910
 
 ***
 
@@ -1203,7 +1203,7 @@ You may need to call [runtime](QuickJSAsyncContext.md#runtime).[QuickJSRuntime#e
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1089
+packages/quickjs-emscripten-core/dist/index.d.ts:1099
 
 ***
 
@@ -1240,7 +1240,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1109
+packages/quickjs-emscripten-core/dist/index.d.ts:1119
 
 ***
 
@@ -1264,7 +1264,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1176
+packages/quickjs-emscripten-core/dist/index.d.ts:1186
 
 ***
 
@@ -1292,7 +1292,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1055
+packages/quickjs-emscripten-core/dist/index.d.ts:1065
 
 ***
 
@@ -1323,7 +1323,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1196
+packages/quickjs-emscripten-core/dist/index.d.ts:1206
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncRuntime.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncRuntime.md
@@ -75,7 +75,7 @@ A context here may be allocated if one is needed by the runtime, eg for [compute
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:280
+packages/quickjs-emscripten-core/dist/index.d.ts:283
 
 ## Accessors
 
@@ -93,7 +93,7 @@ false after the object has been [dispose](QuickJSAsyncRuntime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:187
+packages/quickjs-emscripten-core/dist/index.d.ts:190
 
 ## Methods
 
@@ -113,7 +113,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -141,7 +141,7 @@ QuickJSWrongOwner if owned by a different runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:274
+packages/quickjs-emscripten-core/dist/index.d.ts:277
 
 ***
 
@@ -165,7 +165,7 @@ For a human-digestible representation, see [dumpMemoryUsage](QuickJSAsyncRuntime
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:259
+packages/quickjs-emscripten-core/dist/index.d.ts:262
 
 ***
 
@@ -185,7 +185,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:188
+packages/quickjs-emscripten-core/dist/index.d.ts:191
 
 ***
 
@@ -206,7 +206,7 @@ For programmatic access to this information, see [computeMemoryUsage](QuickJSAsy
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:264
+packages/quickjs-emscripten-core/dist/index.d.ts:267
 
 ***
 
@@ -244,7 +244,7 @@ functions or rejected promises. Those errors are available by calling
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:246
+packages/quickjs-emscripten-core/dist/index.d.ts:249
 
 ***
 
@@ -267,7 +267,7 @@ true if there is at least one pendingJob queued up.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:214
+packages/quickjs-emscripten-core/dist/index.d.ts:217
 
 ***
 
@@ -295,7 +295,7 @@ You should dispose a created context before disposing this runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:298
+packages/quickjs-emscripten-core/dist/index.d.ts:301
 
 ***
 
@@ -316,7 +316,7 @@ See [setInterruptHandler](QuickJSAsyncRuntime.md#setinterrupthandler).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:228
+packages/quickjs-emscripten-core/dist/index.d.ts:231
 
 ***
 
@@ -336,7 +336,7 @@ Remove the the loader set by [setModuleLoader](QuickJSAsyncRuntime.md#setmodulel
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:207
+packages/quickjs-emscripten-core/dist/index.d.ts:210
 
 ***
 
@@ -364,7 +364,7 @@ The interrupt handler can be removed with [removeInterruptHandler](QuickJSAsyncR
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:223
+packages/quickjs-emscripten-core/dist/index.d.ts:226
 
 ***
 
@@ -392,7 +392,7 @@ See the [pull request](https://github.com/justjake/quickjs-emscripten/pull/114) 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:307
+packages/quickjs-emscripten-core/dist/index.d.ts:310
 
 ***
 
@@ -417,7 +417,7 @@ To remove the limit, set to `-1`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:251
+packages/quickjs-emscripten-core/dist/index.d.ts:254
 
 ***
 
@@ -446,7 +446,7 @@ The loader can be removed with [removeModuleLoader](QuickJSAsyncRuntime.md#remov
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:299
+packages/quickjs-emscripten-core/dist/index.d.ts:302
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
@@ -50,7 +50,7 @@ Synchronous evalCode is not supported.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1429
+packages/quickjs-emscripten-core/dist/index.d.ts:1442
 
 ***
 
@@ -80,7 +80,7 @@ See the documentation for [QuickJSWASMModule#evalCode](QuickJSWASMModule.md#eval
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1441
+packages/quickjs-emscripten-core/dist/index.d.ts:1454
 
 ***
 
@@ -104,7 +104,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1385
+packages/quickjs-emscripten-core/dist/index.d.ts:1398
 
 ***
 
@@ -130,7 +130,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1427
+packages/quickjs-emscripten-core/dist/index.d.ts:1440
 
 ***
 
@@ -156,7 +156,7 @@ concurrent async actions, create multiple WebAssembly modules.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1421
+packages/quickjs-emscripten-core/dist/index.d.ts:1434
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
@@ -50,7 +50,7 @@ Synchronous evalCode is not supported.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1386
+packages/quickjs-emscripten-core/dist/index.d.ts:1407
 
 ***
 
@@ -80,7 +80,7 @@ See the documentation for [QuickJSWASMModule#evalCode](QuickJSWASMModule.md#eval
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1398
+packages/quickjs-emscripten-core/dist/index.d.ts:1419
 
 ***
 
@@ -104,7 +104,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1342
+packages/quickjs-emscripten-core/dist/index.d.ts:1363
 
 ***
 
@@ -130,7 +130,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1384
+packages/quickjs-emscripten-core/dist/index.d.ts:1405
 
 ***
 
@@ -156,7 +156,7 @@ concurrent async actions, create multiple WebAssembly modules.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1378
+packages/quickjs-emscripten-core/dist/index.d.ts:1399
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
@@ -50,7 +50,7 @@ Synchronous evalCode is not supported.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1419
+packages/quickjs-emscripten-core/dist/index.d.ts:1429
 
 ***
 
@@ -80,7 +80,7 @@ See the documentation for [QuickJSWASMModule#evalCode](QuickJSWASMModule.md#eval
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1431
+packages/quickjs-emscripten-core/dist/index.d.ts:1441
 
 ***
 
@@ -104,7 +104,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1375
+packages/quickjs-emscripten-core/dist/index.d.ts:1385
 
 ***
 
@@ -130,7 +130,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1417
+packages/quickjs-emscripten-core/dist/index.d.ts:1427
 
 ***
 
@@ -156,7 +156,7 @@ concurrent async actions, create multiple WebAssembly modules.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1411
+packages/quickjs-emscripten-core/dist/index.d.ts:1421
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
@@ -50,7 +50,7 @@ Synchronous evalCode is not supported.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1442
+packages/quickjs-emscripten-core/dist/index.d.ts:1457
 
 ***
 
@@ -80,7 +80,7 @@ See the documentation for [QuickJSWASMModule#evalCode](QuickJSWASMModule.md#eval
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1454
+packages/quickjs-emscripten-core/dist/index.d.ts:1469
 
 ***
 
@@ -104,7 +104,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1398
+packages/quickjs-emscripten-core/dist/index.d.ts:1413
 
 ***
 
@@ -130,7 +130,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1440
+packages/quickjs-emscripten-core/dist/index.d.ts:1455
 
 ***
 
@@ -156,7 +156,7 @@ concurrent async actions, create multiple WebAssembly modules.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1434
+packages/quickjs-emscripten-core/dist/index.d.ts:1449
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSAsyncWASMModule.md
@@ -50,7 +50,7 @@ Synchronous evalCode is not supported.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1407
+packages/quickjs-emscripten-core/dist/index.d.ts:1419
 
 ***
 
@@ -80,7 +80,7 @@ See the documentation for [QuickJSWASMModule#evalCode](QuickJSWASMModule.md#eval
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1419
+packages/quickjs-emscripten-core/dist/index.d.ts:1431
 
 ***
 
@@ -104,7 +104,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1363
+packages/quickjs-emscripten-core/dist/index.d.ts:1375
 
 ***
 
@@ -130,7 +130,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1405
+packages/quickjs-emscripten-core/dist/index.d.ts:1417
 
 ***
 
@@ -156,7 +156,7 @@ concurrent async actions, create multiple WebAssembly modules.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1399
+packages/quickjs-emscripten-core/dist/index.d.ts:1411
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSContext.md
@@ -130,7 +130,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:849
+packages/quickjs-emscripten-core/dist/index.d.ts:859
 
 ## Properties
 
@@ -142,7 +142,7 @@ The runtime that created this context.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:822
+packages/quickjs-emscripten-core/dist/index.d.ts:832
 
 ## Accessors
 
@@ -160,7 +160,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:858
+packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 ***
 
@@ -176,7 +176,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:881
+packages/quickjs-emscripten-core/dist/index.d.ts:891
 
 ***
 
@@ -194,7 +194,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:887
+packages/quickjs-emscripten-core/dist/index.d.ts:897
 
 ***
 
@@ -210,7 +210,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:873
+packages/quickjs-emscripten-core/dist/index.d.ts:883
 
 ***
 
@@ -226,7 +226,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:873
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:877
+packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 ***
 
@@ -242,7 +242,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:877
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:869
+packages/quickjs-emscripten-core/dist/index.d.ts:879
 
 ## Methods
 
@@ -304,7 +304,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1130
+packages/quickjs-emscripten-core/dist/index.d.ts:1140
 
 ***
 
@@ -333,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1236
+packages/quickjs-emscripten-core/dist/index.d.ts:1246
 
 ***
 
@@ -364,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1116
+packages/quickjs-emscripten-core/dist/index.d.ts:1126
 
 ***
 
@@ -393,7 +393,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:865
+packages/quickjs-emscripten-core/dist/index.d.ts:875
 
 ***
 
@@ -414,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1189
+packages/quickjs-emscripten-core/dist/index.d.ts:1199
 
 ***
 
@@ -444,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1223
+packages/quickjs-emscripten-core/dist/index.d.ts:1233
 
 ***
 
@@ -507,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1164
+packages/quickjs-emscripten-core/dist/index.d.ts:1174
 
 ***
 
@@ -527,7 +527,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1077
+packages/quickjs-emscripten-core/dist/index.d.ts:1087
 
 ***
 
@@ -547,7 +547,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1073
+packages/quickjs-emscripten-core/dist/index.d.ts:1083
 
 ***
 
@@ -573,7 +573,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1060
+packages/quickjs-emscripten-core/dist/index.d.ts:1070
 
 ***
 
@@ -591,7 +591,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1060
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1078
+packages/quickjs-emscripten-core/dist/index.d.ts:1088
 
 ***
 
@@ -621,7 +621,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1097
+packages/quickjs-emscripten-core/dist/index.d.ts:1107
 
 ***
 
@@ -645,7 +645,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1064
+packages/quickjs-emscripten-core/dist/index.d.ts:1074
 
 ***
 
@@ -666,7 +666,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1069
+packages/quickjs-emscripten-core/dist/index.d.ts:1079
 
 ***
 
@@ -683,7 +683,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:921
+packages/quickjs-emscripten-core/dist/index.d.ts:931
 
 ***
 
@@ -703,7 +703,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:925
+packages/quickjs-emscripten-core/dist/index.d.ts:935
 
 ***
 
@@ -723,7 +723,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:909
+packages/quickjs-emscripten-core/dist/index.d.ts:919
 
 ***
 
@@ -747,7 +747,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:909
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1043
+packages/quickjs-emscripten-core/dist/index.d.ts:1053
 
 #### newError(message)
 
@@ -763,7 +763,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1043
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1047
+packages/quickjs-emscripten-core/dist/index.d.ts:1057
 
 #### newError(undefined)
 
@@ -775,7 +775,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1047
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1048
+packages/quickjs-emscripten-core/dist/index.d.ts:1058
 
 ***
 
@@ -892,7 +892,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1042
+packages/quickjs-emscripten-core/dist/index.d.ts:1052
 
 ***
 
@@ -916,7 +916,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:891
+packages/quickjs-emscripten-core/dist/index.d.ts:901
 
 ***
 
@@ -943,7 +943,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:916
+packages/quickjs-emscripten-core/dist/index.d.ts:926
 
 ***
 
@@ -964,7 +964,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:932
+packages/quickjs-emscripten-core/dist/index.d.ts:942
 
 #### newPromise(promise)
 
@@ -986,7 +986,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:940
+packages/quickjs-emscripten-core/dist/index.d.ts:950
 
 #### newPromise(newPromiseFn)
 
@@ -1007,7 +1007,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:947
+packages/quickjs-emscripten-core/dist/index.d.ts:957
 
 ***
 
@@ -1031,7 +1031,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:895
+packages/quickjs-emscripten-core/dist/index.d.ts:905
 
 ***
 
@@ -1052,7 +1052,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:905
+packages/quickjs-emscripten-core/dist/index.d.ts:915
 
 ***
 
@@ -1073,7 +1073,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:900
+packages/quickjs-emscripten-core/dist/index.d.ts:910
 
 ***
 
@@ -1101,7 +1101,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1089
+packages/quickjs-emscripten-core/dist/index.d.ts:1099
 
 ***
 
@@ -1138,7 +1138,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1109
+packages/quickjs-emscripten-core/dist/index.d.ts:1119
 
 ***
 
@@ -1158,7 +1158,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1176
+packages/quickjs-emscripten-core/dist/index.d.ts:1186
 
 ***
 
@@ -1186,7 +1186,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1055
+packages/quickjs-emscripten-core/dist/index.d.ts:1065
 
 ***
 
@@ -1213,7 +1213,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1196
+packages/quickjs-emscripten-core/dist/index.d.ts:1206
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSContext.md
@@ -304,7 +304,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1140
+packages/quickjs-emscripten-core/dist/index.d.ts:1153
 
 ***
 
@@ -333,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1246
+packages/quickjs-emscripten-core/dist/index.d.ts:1259
 
 ***
 
@@ -364,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1126
+packages/quickjs-emscripten-core/dist/index.d.ts:1139
 
 ***
 
@@ -414,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1199
+packages/quickjs-emscripten-core/dist/index.d.ts:1212
 
 ***
 
@@ -444,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1233
+packages/quickjs-emscripten-core/dist/index.d.ts:1246
 
 ***
 
@@ -507,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1174
+packages/quickjs-emscripten-core/dist/index.d.ts:1187
 
 ***
 
@@ -581,6 +581,18 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1070
 
 > **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
 
+Get the current state of a QuickJS promise, see [JSPromiseState](../exports.md#jspromisestate) for the possible states.
+This can be used to expect a promise to be fulfilled when combined with [unwrapResult](QuickJSContext.md#unwrapresult):
+
+```typescript
+const promiseHandle = context.evalCode(`Promise.resolve(42)`);
+const resultHandle = context.unwrapResult(
+ context.getPromiseState(promiseHandle)
+);
+context.getNumber(resultHandle) === 42; // true
+resultHandle.dispose();
+```
+
 #### Parameters
 
 • **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
@@ -591,7 +603,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1070
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1088
+packages/quickjs-emscripten-core/dist/index.d.ts:1101
 
 ***
 
@@ -621,7 +633,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1107
+packages/quickjs-emscripten-core/dist/index.d.ts:1120
 
 ***
 
@@ -1101,7 +1113,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1099
+packages/quickjs-emscripten-core/dist/index.d.ts:1112
 
 ***
 
@@ -1138,7 +1150,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1119
+packages/quickjs-emscripten-core/dist/index.d.ts:1132
 
 ***
 
@@ -1158,7 +1170,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1186
+packages/quickjs-emscripten-core/dist/index.d.ts:1199
 
 ***
 
@@ -1213,7 +1225,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1206
+packages/quickjs-emscripten-core/dist/index.d.ts:1219
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSContext.md
@@ -130,7 +130,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:859
+packages/quickjs-emscripten-core/dist/index.d.ts:874
 
 ## Properties
 
@@ -142,7 +142,7 @@ The runtime that created this context.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:832
+packages/quickjs-emscripten-core/dist/index.d.ts:847
 
 ## Accessors
 
@@ -160,7 +160,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:868
+packages/quickjs-emscripten-core/dist/index.d.ts:883
 
 ***
 
@@ -176,7 +176,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:891
+packages/quickjs-emscripten-core/dist/index.d.ts:906
 
 ***
 
@@ -194,7 +194,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:897
+packages/quickjs-emscripten-core/dist/index.d.ts:912
 
 ***
 
@@ -210,7 +210,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:897
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:883
+packages/quickjs-emscripten-core/dist/index.d.ts:898
 
 ***
 
@@ -226,7 +226,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:883
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:887
+packages/quickjs-emscripten-core/dist/index.d.ts:902
 
 ***
 
@@ -242,7 +242,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:879
+packages/quickjs-emscripten-core/dist/index.d.ts:894
 
 ## Methods
 
@@ -304,7 +304,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1153
+packages/quickjs-emscripten-core/dist/index.d.ts:1168
 
 ***
 
@@ -333,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1259
+packages/quickjs-emscripten-core/dist/index.d.ts:1274
 
 ***
 
@@ -364,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1139
+packages/quickjs-emscripten-core/dist/index.d.ts:1154
 
 ***
 
@@ -393,7 +393,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:875
+packages/quickjs-emscripten-core/dist/index.d.ts:890
 
 ***
 
@@ -414,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1212
+packages/quickjs-emscripten-core/dist/index.d.ts:1227
 
 ***
 
@@ -444,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1246
+packages/quickjs-emscripten-core/dist/index.d.ts:1261
 
 ***
 
@@ -507,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1187
+packages/quickjs-emscripten-core/dist/index.d.ts:1202
 
 ***
 
@@ -527,7 +527,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1087
+packages/quickjs-emscripten-core/dist/index.d.ts:1102
 
 ***
 
@@ -547,7 +547,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1083
+packages/quickjs-emscripten-core/dist/index.d.ts:1098
 
 ***
 
@@ -573,7 +573,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1070
+packages/quickjs-emscripten-core/dist/index.d.ts:1085
 
 ***
 
@@ -603,7 +603,7 @@ resultHandle.dispose();
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1101
+packages/quickjs-emscripten-core/dist/index.d.ts:1116
 
 ***
 
@@ -633,7 +633,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1120
+packages/quickjs-emscripten-core/dist/index.d.ts:1135
 
 ***
 
@@ -657,7 +657,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1074
+packages/quickjs-emscripten-core/dist/index.d.ts:1089
 
 ***
 
@@ -678,7 +678,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1079
+packages/quickjs-emscripten-core/dist/index.d.ts:1094
 
 ***
 
@@ -695,7 +695,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:931
+packages/quickjs-emscripten-core/dist/index.d.ts:946
 
 ***
 
@@ -715,7 +715,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:935
+packages/quickjs-emscripten-core/dist/index.d.ts:950
 
 ***
 
@@ -735,7 +735,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:919
+packages/quickjs-emscripten-core/dist/index.d.ts:934
 
 ***
 
@@ -759,7 +759,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:919
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1053
+packages/quickjs-emscripten-core/dist/index.d.ts:1068
 
 #### newError(message)
 
@@ -775,7 +775,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1053
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1057
+packages/quickjs-emscripten-core/dist/index.d.ts:1072
 
 #### newError(undefined)
 
@@ -787,7 +787,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1057
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1058
+packages/quickjs-emscripten-core/dist/index.d.ts:1073
 
 ***
 
@@ -904,7 +904,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1052
+packages/quickjs-emscripten-core/dist/index.d.ts:1067
 
 ***
 
@@ -928,7 +928,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:901
+packages/quickjs-emscripten-core/dist/index.d.ts:916
 
 ***
 
@@ -955,7 +955,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:926
+packages/quickjs-emscripten-core/dist/index.d.ts:941
 
 ***
 
@@ -976,7 +976,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:942
+packages/quickjs-emscripten-core/dist/index.d.ts:957
 
 #### newPromise(promise)
 
@@ -998,7 +998,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:950
+packages/quickjs-emscripten-core/dist/index.d.ts:965
 
 #### newPromise(newPromiseFn)
 
@@ -1019,7 +1019,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:957
+packages/quickjs-emscripten-core/dist/index.d.ts:972
 
 ***
 
@@ -1043,7 +1043,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:905
+packages/quickjs-emscripten-core/dist/index.d.ts:920
 
 ***
 
@@ -1064,7 +1064,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:915
+packages/quickjs-emscripten-core/dist/index.d.ts:930
 
 ***
 
@@ -1085,7 +1085,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:910
+packages/quickjs-emscripten-core/dist/index.d.ts:925
 
 ***
 
@@ -1113,7 +1113,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1112
+packages/quickjs-emscripten-core/dist/index.d.ts:1127
 
 ***
 
@@ -1150,7 +1150,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1132
+packages/quickjs-emscripten-core/dist/index.d.ts:1147
 
 ***
 
@@ -1170,7 +1170,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1199
+packages/quickjs-emscripten-core/dist/index.d.ts:1214
 
 ***
 
@@ -1198,7 +1198,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1065
+packages/quickjs-emscripten-core/dist/index.d.ts:1080
 
 ***
 
@@ -1225,7 +1225,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1219
+packages/quickjs-emscripten-core/dist/index.d.ts:1234
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSContext.md
@@ -63,6 +63,7 @@ See [QuickJSRuntime](QuickJSRuntime.md) for more information.
   - [getArrayBuffer()](QuickJSContext.md#getarraybuffer)
   - [getBigInt()](QuickJSContext.md#getbigint)
   - [getNumber()](QuickJSContext.md#getnumber)
+  - [getPromiseState()](QuickJSContext.md#getpromisestate)
   - [getProp()](QuickJSContext.md#getprop)
   - [getString()](QuickJSContext.md#getstring)
   - [getSymbol()](QuickJSContext.md#getsymbol)
@@ -129,7 +130,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:838
+packages/quickjs-emscripten-core/dist/index.d.ts:849
 
 ## Properties
 
@@ -141,7 +142,7 @@ The runtime that created this context.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:811
+packages/quickjs-emscripten-core/dist/index.d.ts:822
 
 ## Accessors
 
@@ -159,7 +160,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:847
+packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 ***
 
@@ -175,7 +176,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:847
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:870
+packages/quickjs-emscripten-core/dist/index.d.ts:881
 
 ***
 
@@ -193,7 +194,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:876
+packages/quickjs-emscripten-core/dist/index.d.ts:887
 
 ***
 
@@ -209,7 +210,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:876
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:862
+packages/quickjs-emscripten-core/dist/index.d.ts:873
 
 ***
 
@@ -225,7 +226,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:862
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:866
+packages/quickjs-emscripten-core/dist/index.d.ts:877
 
 ***
 
@@ -241,7 +242,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:866
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:858
+packages/quickjs-emscripten-core/dist/index.d.ts:869
 
 ## Methods
 
@@ -303,7 +304,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1118
+packages/quickjs-emscripten-core/dist/index.d.ts:1130
 
 ***
 
@@ -332,7 +333,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1224
+packages/quickjs-emscripten-core/dist/index.d.ts:1236
 
 ***
 
@@ -363,7 +364,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1104
+packages/quickjs-emscripten-core/dist/index.d.ts:1116
 
 ***
 
@@ -392,7 +393,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:854
+packages/quickjs-emscripten-core/dist/index.d.ts:865
 
 ***
 
@@ -413,7 +414,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1177
+packages/quickjs-emscripten-core/dist/index.d.ts:1189
 
 ***
 
@@ -443,7 +444,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1211
+packages/quickjs-emscripten-core/dist/index.d.ts:1223
 
 ***
 
@@ -506,7 +507,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1152
+packages/quickjs-emscripten-core/dist/index.d.ts:1164
 
 ***
 
@@ -526,7 +527,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1066
+packages/quickjs-emscripten-core/dist/index.d.ts:1077
 
 ***
 
@@ -546,7 +547,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1062
+packages/quickjs-emscripten-core/dist/index.d.ts:1073
 
 ***
 
@@ -572,7 +573,25 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1049
+packages/quickjs-emscripten-core/dist/index.d.ts:1060
+
+***
+
+### getPromiseState()
+
+> **getPromiseState**(`handle`): [`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Parameters
+
+• **handle**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Returns
+
+[`JSPromiseState`](../exports.md#jspromisestate)
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:1078
 
 ***
 
@@ -602,7 +621,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1085
+packages/quickjs-emscripten-core/dist/index.d.ts:1097
 
 ***
 
@@ -626,7 +645,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1053
+packages/quickjs-emscripten-core/dist/index.d.ts:1064
 
 ***
 
@@ -647,7 +666,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1058
+packages/quickjs-emscripten-core/dist/index.d.ts:1069
 
 ***
 
@@ -664,7 +683,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:910
+packages/quickjs-emscripten-core/dist/index.d.ts:921
 
 ***
 
@@ -684,7 +703,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:914
+packages/quickjs-emscripten-core/dist/index.d.ts:925
 
 ***
 
@@ -704,7 +723,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:898
+packages/quickjs-emscripten-core/dist/index.d.ts:909
 
 ***
 
@@ -728,7 +747,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:898
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1032
+packages/quickjs-emscripten-core/dist/index.d.ts:1043
 
 #### newError(message)
 
@@ -744,7 +763,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1032
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1036
+packages/quickjs-emscripten-core/dist/index.d.ts:1047
 
 #### newError(undefined)
 
@@ -756,7 +775,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1036
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1037
+packages/quickjs-emscripten-core/dist/index.d.ts:1048
 
 ***
 
@@ -873,7 +892,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1031
+packages/quickjs-emscripten-core/dist/index.d.ts:1042
 
 ***
 
@@ -897,7 +916,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:880
+packages/quickjs-emscripten-core/dist/index.d.ts:891
 
 ***
 
@@ -924,7 +943,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:905
+packages/quickjs-emscripten-core/dist/index.d.ts:916
 
 ***
 
@@ -945,7 +964,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:921
+packages/quickjs-emscripten-core/dist/index.d.ts:932
 
 #### newPromise(promise)
 
@@ -967,7 +986,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:929
+packages/quickjs-emscripten-core/dist/index.d.ts:940
 
 #### newPromise(newPromiseFn)
 
@@ -988,7 +1007,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:936
+packages/quickjs-emscripten-core/dist/index.d.ts:947
 
 ***
 
@@ -1012,7 +1031,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:884
+packages/quickjs-emscripten-core/dist/index.d.ts:895
 
 ***
 
@@ -1033,7 +1052,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:894
+packages/quickjs-emscripten-core/dist/index.d.ts:905
 
 ***
 
@@ -1054,7 +1073,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:889
+packages/quickjs-emscripten-core/dist/index.d.ts:900
 
 ***
 
@@ -1082,7 +1101,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1077
+packages/quickjs-emscripten-core/dist/index.d.ts:1089
 
 ***
 
@@ -1119,7 +1138,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1097
+packages/quickjs-emscripten-core/dist/index.d.ts:1109
 
 ***
 
@@ -1139,7 +1158,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1164
+packages/quickjs-emscripten-core/dist/index.d.ts:1176
 
 ***
 
@@ -1167,7 +1186,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1044
+packages/quickjs-emscripten-core/dist/index.d.ts:1055
 
 ***
 
@@ -1194,7 +1213,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1184
+packages/quickjs-emscripten-core/dist/index.d.ts:1196
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSContext.md
+++ b/doc/quickjs-emscripten/classes/QuickJSContext.md
@@ -129,7 +129,7 @@ to create a new QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:830
+packages/quickjs-emscripten-core/dist/index.d.ts:838
 
 ## Properties
 
@@ -141,7 +141,7 @@ The runtime that created this context.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:803
+packages/quickjs-emscripten-core/dist/index.d.ts:811
 
 ## Accessors
 
@@ -159,7 +159,7 @@ false after the object has been [dispose](QuickJSContext.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:839
+packages/quickjs-emscripten-core/dist/index.d.ts:847
 
 ***
 
@@ -175,7 +175,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:839
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:862
+packages/quickjs-emscripten-core/dist/index.d.ts:870
 
 ***
 
@@ -193,7 +193,7 @@ You can set properties to create global variables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:868
+packages/quickjs-emscripten-core/dist/index.d.ts:876
 
 ***
 
@@ -209,7 +209,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:868
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:854
+packages/quickjs-emscripten-core/dist/index.d.ts:862
 
 ***
 
@@ -225,7 +225,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:854
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:858
+packages/quickjs-emscripten-core/dist/index.d.ts:866
 
 ***
 
@@ -241,7 +241,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:850
+packages/quickjs-emscripten-core/dist/index.d.ts:858
 
 ## Methods
 
@@ -265,7 +265,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -303,7 +303,7 @@ value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1110
+packages/quickjs-emscripten-core/dist/index.d.ts:1118
 
 ***
 
@@ -332,7 +332,7 @@ socket.on("data", chunk => {
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1203
+packages/quickjs-emscripten-core/dist/index.d.ts:1224
 
 ***
 
@@ -363,7 +363,7 @@ Javascript string or number (which will be converted automatically to a JSValue)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1096
+packages/quickjs-emscripten-core/dist/index.d.ts:1104
 
 ***
 
@@ -392,7 +392,7 @@ will result in an error.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:846
+packages/quickjs-emscripten-core/dist/index.d.ts:854
 
 ***
 
@@ -413,7 +413,7 @@ Returns `handle.toString()` if it cannot be serialized to JSON.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1156
+packages/quickjs-emscripten-core/dist/index.d.ts:1177
 
 ***
 
@@ -443,7 +443,7 @@ socket.write(dataLifetime?.value)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1190
+packages/quickjs-emscripten-core/dist/index.d.ts:1211
 
 ***
 
@@ -452,7 +452,20 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1190
 > **evalCode**(`code`, `filename`?, `options`?): [`VmCallResult`](../exports.md#vmcallresultvmhandle)\<[`QuickJSHandle`](../exports.md#quickjshandle)\>
 
 Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
-Evaluates the Javascript source `code` in the global scope of this VM.
+
+Evaluates `code`, as though it's in a file named `filename`, with options `options`.
+
+- When `options.type` is `"global"`, the code is evaluated in the global
+  scope of the QuickJSContext, and the return value is the result of the last
+  expression.
+- When `options.type` is `"module"`, the code is evaluated is a module scope.
+  It may use `import` and `export` if [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#setModuleLoader](QuickJSRuntime.md#setmoduleloader) was called.
+  It may use top-level await if supported by the underlying QuickJS library.
+  The return value is the module's exports, or a promise for the module's exports.
+- When `options.type` is unset, the code is evaluated as a module if it
+  contains an `import` or `export` statement, otherwise it is evaluated in
+  the global scope.
+
 When working with async code, you many need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#executePendingJobs](QuickJSRuntime.md#executependingjobs)
 to execute callbacks pending after synchronous evaluation returns.
 
@@ -493,7 +506,7 @@ interrupted, the error will have name `InternalError` and message
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1131
+packages/quickjs-emscripten-core/dist/index.d.ts:1152
 
 ***
 
@@ -513,7 +526,7 @@ Coverts `handle` to a JavaScript ArrayBuffer
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1058
+packages/quickjs-emscripten-core/dist/index.d.ts:1066
 
 ***
 
@@ -533,7 +546,7 @@ Converts `handle` to a Javascript bigint.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1054
+packages/quickjs-emscripten-core/dist/index.d.ts:1062
 
 ***
 
@@ -559,7 +572,7 @@ Converts `handle` into a Javascript number.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1041
+packages/quickjs-emscripten-core/dist/index.d.ts:1049
 
 ***
 
@@ -589,7 +602,7 @@ Javascript string (which will be converted automatically).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1077
+packages/quickjs-emscripten-core/dist/index.d.ts:1085
 
 ***
 
@@ -613,7 +626,7 @@ Converts `handle` to a Javascript string.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1045
+packages/quickjs-emscripten-core/dist/index.d.ts:1053
 
 ***
 
@@ -634,7 +647,7 @@ registry in the guest, it will be created with Symbol.for on the host.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1050
+packages/quickjs-emscripten-core/dist/index.d.ts:1058
 
 ***
 
@@ -651,7 +664,7 @@ Create a new QuickJS [array](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:902
+packages/quickjs-emscripten-core/dist/index.d.ts:910
 
 ***
 
@@ -671,7 +684,7 @@ Create a new QuickJS [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:906
+packages/quickjs-emscripten-core/dist/index.d.ts:914
 
 ***
 
@@ -691,7 +704,7 @@ Create a QuickJS [bigint](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:890
+packages/quickjs-emscripten-core/dist/index.d.ts:898
 
 ***
 
@@ -715,7 +728,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:890
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1024
+packages/quickjs-emscripten-core/dist/index.d.ts:1032
 
 #### newError(message)
 
@@ -731,7 +744,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1024
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1028
+packages/quickjs-emscripten-core/dist/index.d.ts:1036
 
 #### newError(undefined)
 
@@ -743,7 +756,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1028
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1029
+packages/quickjs-emscripten-core/dist/index.d.ts:1037
 
 ***
 
@@ -860,7 +873,7 @@ return deferred.handle
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1023
+packages/quickjs-emscripten-core/dist/index.d.ts:1031
 
 ***
 
@@ -884,7 +897,7 @@ Converts a Javascript number into a QuickJS value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:872
+packages/quickjs-emscripten-core/dist/index.d.ts:880
 
 ***
 
@@ -911,7 +924,7 @@ Like [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:897
+packages/quickjs-emscripten-core/dist/index.d.ts:905
 
 ***
 
@@ -932,7 +945,7 @@ resources; see the documentation on [QuickJSDeferredPromise](QuickJSDeferredProm
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:913
+packages/quickjs-emscripten-core/dist/index.d.ts:921
 
 #### newPromise(promise)
 
@@ -954,7 +967,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:921
+packages/quickjs-emscripten-core/dist/index.d.ts:929
 
 #### newPromise(newPromiseFn)
 
@@ -975,7 +988,7 @@ You can still resolve/reject the created promise "early" using its methods.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:928
+packages/quickjs-emscripten-core/dist/index.d.ts:936
 
 ***
 
@@ -999,7 +1012,7 @@ Create a QuickJS [string](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:876
+packages/quickjs-emscripten-core/dist/index.d.ts:884
 
 ***
 
@@ -1020,7 +1033,7 @@ All symbols created with the same key will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:886
+packages/quickjs-emscripten-core/dist/index.d.ts:894
 
 ***
 
@@ -1041,7 +1054,7 @@ No two symbols created with this function will be the same value.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:881
+packages/quickjs-emscripten-core/dist/index.d.ts:889
 
 ***
 
@@ -1069,7 +1082,7 @@ You may need to call [runtime](QuickJSContext.md#runtime).[QuickJSRuntime#execut
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1069
+packages/quickjs-emscripten-core/dist/index.d.ts:1077
 
 ***
 
@@ -1106,7 +1119,7 @@ properties.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1089
+packages/quickjs-emscripten-core/dist/index.d.ts:1097
 
 ***
 
@@ -1126,7 +1139,7 @@ Throw an error in the VM, interrupted whatever current execution is in progress 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1143
+packages/quickjs-emscripten-core/dist/index.d.ts:1164
 
 ***
 
@@ -1154,7 +1167,7 @@ Does not support BigInt values correctly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1036
+packages/quickjs-emscripten-core/dist/index.d.ts:1044
 
 ***
 
@@ -1181,7 +1194,7 @@ If the result is an error, converts the error to a native object and throws the 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1163
+packages/quickjs-emscripten-core/dist/index.d.ts:1184
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:702
+packages/quickjs-emscripten-core/dist/index.d.ts:710
 
 ## Properties
 
@@ -94,7 +94,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:702
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:684
+packages/quickjs-emscripten-core/dist/index.d.ts:692
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:684
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:727
+packages/quickjs-emscripten-core/dist/index.d.ts:735
 
 ***
 
@@ -130,7 +130,7 @@ are finished with it.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:690
+packages/quickjs-emscripten-core/dist/index.d.ts:698
 
 ***
 
@@ -140,7 +140,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:690
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:683
+packages/quickjs-emscripten-core/dist/index.d.ts:691
 
 ***
 
@@ -165,7 +165,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:725
+packages/quickjs-emscripten-core/dist/index.d.ts:733
 
 ***
 
@@ -190,7 +190,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:716
+packages/quickjs-emscripten-core/dist/index.d.ts:724
 
 ***
 
@@ -202,7 +202,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:694
+packages/quickjs-emscripten-core/dist/index.d.ts:702
 
 ## Accessors
 
@@ -220,7 +220,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:726
+packages/quickjs-emscripten-core/dist/index.d.ts:734
 
 ## Methods
 
@@ -244,7 +244,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:721
+packages/quickjs-emscripten-core/dist/index.d.ts:731
 
 ## Properties
 
@@ -94,7 +94,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:721
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:703
+packages/quickjs-emscripten-core/dist/index.d.ts:713
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:703
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:746
+packages/quickjs-emscripten-core/dist/index.d.ts:756
 
 ***
 
@@ -130,7 +130,7 @@ are finished with it.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:709
+packages/quickjs-emscripten-core/dist/index.d.ts:719
 
 ***
 
@@ -140,7 +140,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:709
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:702
+packages/quickjs-emscripten-core/dist/index.d.ts:712
 
 ***
 
@@ -165,7 +165,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:744
+packages/quickjs-emscripten-core/dist/index.d.ts:754
 
 ***
 
@@ -190,7 +190,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:735
+packages/quickjs-emscripten-core/dist/index.d.ts:745
 
 ***
 
@@ -202,7 +202,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:713
+packages/quickjs-emscripten-core/dist/index.d.ts:723
 
 ## Accessors
 
@@ -220,7 +220,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:745
+packages/quickjs-emscripten-core/dist/index.d.ts:755
 
 ## Methods
 

--- a/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:710
+packages/quickjs-emscripten-core/dist/index.d.ts:721
 
 ## Properties
 
@@ -94,7 +94,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:710
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:692
+packages/quickjs-emscripten-core/dist/index.d.ts:703
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:692
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:735
+packages/quickjs-emscripten-core/dist/index.d.ts:746
 
 ***
 
@@ -130,7 +130,7 @@ are finished with it.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:698
+packages/quickjs-emscripten-core/dist/index.d.ts:709
 
 ***
 
@@ -140,7 +140,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:698
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:691
+packages/quickjs-emscripten-core/dist/index.d.ts:702
 
 ***
 
@@ -165,7 +165,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:733
+packages/quickjs-emscripten-core/dist/index.d.ts:744
 
 ***
 
@@ -190,7 +190,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:724
+packages/quickjs-emscripten-core/dist/index.d.ts:735
 
 ***
 
@@ -202,7 +202,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:702
+packages/quickjs-emscripten-core/dist/index.d.ts:713
 
 ## Accessors
 
@@ -220,7 +220,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:734
+packages/quickjs-emscripten-core/dist/index.d.ts:745
 
 ## Methods
 

--- a/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
+++ b/doc/quickjs-emscripten/classes/QuickJSDeferredPromise.md
@@ -84,7 +84,7 @@ this constructor directly.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:731
+packages/quickjs-emscripten-core/dist/index.d.ts:746
 
 ## Properties
 
@@ -94,7 +94,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:731
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:713
+packages/quickjs-emscripten-core/dist/index.d.ts:728
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:713
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:756
+packages/quickjs-emscripten-core/dist/index.d.ts:771
 
 ***
 
@@ -130,7 +130,7 @@ are finished with it.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:719
+packages/quickjs-emscripten-core/dist/index.d.ts:734
 
 ***
 
@@ -140,7 +140,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:719
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:712
+packages/quickjs-emscripten-core/dist/index.d.ts:727
 
 ***
 
@@ -165,7 +165,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:754
+packages/quickjs-emscripten-core/dist/index.d.ts:769
 
 ***
 
@@ -190,7 +190,7 @@ callbacks.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:745
+packages/quickjs-emscripten-core/dist/index.d.ts:760
 
 ***
 
@@ -202,7 +202,7 @@ A native promise that will resolve once this deferred is settled.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:723
+packages/quickjs-emscripten-core/dist/index.d.ts:738
 
 ## Accessors
 
@@ -220,7 +220,7 @@ false after the object has been [dispose](QuickJSDeferredPromise.md#dispose)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:755
+packages/quickjs-emscripten-core/dist/index.d.ts:770
 
 ## Methods
 

--- a/doc/quickjs-emscripten/classes/QuickJSRuntime.md
+++ b/doc/quickjs-emscripten/classes/QuickJSRuntime.md
@@ -76,7 +76,7 @@ A context here may be allocated if one is needed by the runtime, eg for [compute
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:160
+packages/quickjs-emscripten-core/dist/index.d.ts:163
 
 ## Accessors
 
@@ -94,7 +94,7 @@ false after the object has been [dispose](QuickJSRuntime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:187
+packages/quickjs-emscripten-core/dist/index.d.ts:190
 
 ## Methods
 
@@ -118,7 +118,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -142,7 +142,7 @@ QuickJSWrongOwner if owned by a different runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:274
+packages/quickjs-emscripten-core/dist/index.d.ts:277
 
 ***
 
@@ -162,7 +162,7 @@ For a human-digestible representation, see [dumpMemoryUsage](QuickJSRuntime.md#d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:259
+packages/quickjs-emscripten-core/dist/index.d.ts:262
 
 ***
 
@@ -186,7 +186,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:188
+packages/quickjs-emscripten-core/dist/index.d.ts:191
 
 ***
 
@@ -203,7 +203,7 @@ For programmatic access to this information, see [computeMemoryUsage](QuickJSRun
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:264
+packages/quickjs-emscripten-core/dist/index.d.ts:267
 
 ***
 
@@ -237,7 +237,7 @@ functions or rejected promises. Those errors are available by calling
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:246
+packages/quickjs-emscripten-core/dist/index.d.ts:249
 
 ***
 
@@ -256,7 +256,7 @@ true if there is at least one pendingJob queued up.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:214
+packages/quickjs-emscripten-core/dist/index.d.ts:217
 
 ***
 
@@ -280,7 +280,7 @@ You should dispose a created context before disposing this runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:196
+packages/quickjs-emscripten-core/dist/index.d.ts:199
 
 ***
 
@@ -297,7 +297,7 @@ See [setInterruptHandler](QuickJSRuntime.md#setinterrupthandler).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:228
+packages/quickjs-emscripten-core/dist/index.d.ts:231
 
 ***
 
@@ -313,7 +313,7 @@ Remove the the loader set by [setModuleLoader](QuickJSRuntime.md#setmoduleloader
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:207
+packages/quickjs-emscripten-core/dist/index.d.ts:210
 
 ***
 
@@ -337,7 +337,7 @@ The interrupt handler can be removed with [removeInterruptHandler](QuickJSRuntim
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:223
+packages/quickjs-emscripten-core/dist/index.d.ts:226
 
 ***
 
@@ -358,7 +358,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:269
+packages/quickjs-emscripten-core/dist/index.d.ts:272
 
 ***
 
@@ -379,7 +379,7 @@ To remove the limit, set to `-1`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:251
+packages/quickjs-emscripten-core/dist/index.d.ts:254
 
 ***
 
@@ -404,7 +404,7 @@ The loader can be removed with [removeModuleLoader](QuickJSRuntime.md#removemodu
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:203
+packages/quickjs-emscripten-core/dist/index.d.ts:206
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
@@ -81,7 +81,7 @@ with name `"InternalError"` and  message `"interrupted"`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1332
+packages/quickjs-emscripten-core/dist/index.d.ts:1353
 
 ***
 
@@ -101,7 +101,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1342
+packages/quickjs-emscripten-core/dist/index.d.ts:1363
 
 ***
 
@@ -123,7 +123,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1306
+packages/quickjs-emscripten-core/dist/index.d.ts:1327
 
 ***
 
@@ -145,7 +145,7 @@ loading for one or more [QuickJSContext](QuickJSContext.md)s inside the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1300
+packages/quickjs-emscripten-core/dist/index.d.ts:1321
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
@@ -81,7 +81,7 @@ with name `"InternalError"` and  message `"interrupted"`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1353
+packages/quickjs-emscripten-core/dist/index.d.ts:1365
 
 ***
 
@@ -101,7 +101,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1363
+packages/quickjs-emscripten-core/dist/index.d.ts:1375
 
 ***
 
@@ -123,7 +123,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1327
+packages/quickjs-emscripten-core/dist/index.d.ts:1339
 
 ***
 
@@ -145,7 +145,7 @@ loading for one or more [QuickJSContext](QuickJSContext.md)s inside the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1321
+packages/quickjs-emscripten-core/dist/index.d.ts:1333
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
@@ -81,7 +81,7 @@ with name `"InternalError"` and  message `"interrupted"`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1388
+packages/quickjs-emscripten-core/dist/index.d.ts:1403
 
 ***
 
@@ -101,7 +101,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1398
+packages/quickjs-emscripten-core/dist/index.d.ts:1413
 
 ***
 
@@ -123,7 +123,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1362
+packages/quickjs-emscripten-core/dist/index.d.ts:1377
 
 ***
 
@@ -145,7 +145,7 @@ loading for one or more [QuickJSContext](QuickJSContext.md)s inside the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1356
+packages/quickjs-emscripten-core/dist/index.d.ts:1371
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
@@ -81,7 +81,7 @@ with name `"InternalError"` and  message `"interrupted"`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1365
+packages/quickjs-emscripten-core/dist/index.d.ts:1375
 
 ***
 
@@ -101,7 +101,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1375
+packages/quickjs-emscripten-core/dist/index.d.ts:1385
 
 ***
 
@@ -123,7 +123,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1339
+packages/quickjs-emscripten-core/dist/index.d.ts:1349
 
 ***
 
@@ -145,7 +145,7 @@ loading for one or more [QuickJSContext](QuickJSContext.md)s inside the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1333
+packages/quickjs-emscripten-core/dist/index.d.ts:1343
 
 ***
 

--- a/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/QuickJSWASMModule.md
@@ -81,7 +81,7 @@ with name `"InternalError"` and  message `"interrupted"`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1375
+packages/quickjs-emscripten-core/dist/index.d.ts:1388
 
 ***
 
@@ -101,7 +101,7 @@ and provide the [CustomizeVariantOptions#wasmMemory](../interfaces/CustomizeVari
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1385
+packages/quickjs-emscripten-core/dist/index.d.ts:1398
 
 ***
 
@@ -123,7 +123,7 @@ be disposed when the context is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1349
+packages/quickjs-emscripten-core/dist/index.d.ts:1362
 
 ***
 
@@ -145,7 +145,7 @@ loading for one or more [QuickJSContext](QuickJSContext.md)s inside the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1343
+packages/quickjs-emscripten-core/dist/index.d.ts:1356
 
 ***
 

--- a/doc/quickjs-emscripten/classes/Scope.md
+++ b/doc/quickjs-emscripten/classes/Scope.md
@@ -63,7 +63,7 @@ false after the object has been [dispose](Scope.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:657
+packages/quickjs-emscripten-core/dist/index.d.ts:665
 
 ## Methods
 
@@ -87,7 +87,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -111,7 +111,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:658
+packages/quickjs-emscripten-core/dist/index.d.ts:666
 
 ***
 
@@ -135,7 +135,7 @@ Track `lifetime` so that it is disposed when this scope is disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:656
+packages/quickjs-emscripten-core/dist/index.d.ts:664
 
 ***
 
@@ -165,7 +165,7 @@ Do not use with async functions. Instead, use [withScopeAsync](Scope.md#withscop
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:643
+packages/quickjs-emscripten-core/dist/index.d.ts:651
 
 ***
 
@@ -192,7 +192,7 @@ block returns.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:651
+packages/quickjs-emscripten-core/dist/index.d.ts:659
 
 ***
 
@@ -220,7 +220,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:651
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:644
+packages/quickjs-emscripten-core/dist/index.d.ts:652
 
 ***
 

--- a/doc/quickjs-emscripten/classes/StaticLifetime.md
+++ b/doc/quickjs-emscripten/classes/StaticLifetime.md
@@ -64,7 +64,7 @@ A Lifetime that lives forever. Used for constants.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:615
+packages/quickjs-emscripten-core/dist/index.d.ts:623
 
 ## Properties
 
@@ -78,7 +78,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:615
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:574
+packages/quickjs-emscripten-core/dist/index.d.ts:582
 
 ***
 
@@ -92,7 +92,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:575
+packages/quickjs-emscripten-core/dist/index.d.ts:583
 
 ***
 
@@ -106,7 +106,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:573
+packages/quickjs-emscripten-core/dist/index.d.ts:581
 
 ***
 
@@ -120,7 +120,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:573
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:570
+packages/quickjs-emscripten-core/dist/index.d.ts:578
 
 ***
 
@@ -142,7 +142,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:570
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:571
+packages/quickjs-emscripten-core/dist/index.d.ts:579
 
 ***
 
@@ -164,7 +164,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:571
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:572
+packages/quickjs-emscripten-core/dist/index.d.ts:580
 
 ## Accessors
 
@@ -182,7 +182,7 @@ false after the object has been [dispose](StaticLifetime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:585
+packages/quickjs-emscripten-core/dist/index.d.ts:593
 
 ***
 
@@ -196,7 +196,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:585
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:616
+packages/quickjs-emscripten-core/dist/index.d.ts:624
 
 ***
 
@@ -210,7 +210,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:616
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:593
+packages/quickjs-emscripten-core/dist/index.d.ts:601
 
 ***
 
@@ -231,7 +231,7 @@ If the lifetime has been [dispose](StaticLifetime.md#dispose-1)d already.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:592
+packages/quickjs-emscripten-core/dist/index.d.ts:600
 
 ## Methods
 
@@ -251,7 +251,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -283,7 +283,7 @@ the result of `map(this)`.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:603
+packages/quickjs-emscripten-core/dist/index.d.ts:611
 
 #### consume(map)
 
@@ -307,7 +307,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:603
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:604
+packages/quickjs-emscripten-core/dist/index.d.ts:612
 
 ***
 
@@ -327,7 +327,7 @@ Dispose of [value](StaticLifetime.md#value-1) and perform cleanup.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:618
+packages/quickjs-emscripten-core/dist/index.d.ts:626
 
 ***
 
@@ -347,7 +347,7 @@ Create a new handle pointing to the same [value](StaticLifetime.md#value-1).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:617
+packages/quickjs-emscripten-core/dist/index.d.ts:625
 
 ***
 

--- a/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
@@ -51,7 +51,7 @@ freed all the memory you've ever allocated.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1631
+packages/quickjs-emscripten-core/dist/index.d.ts:1644
 
 ## Properties
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1631
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1629
+packages/quickjs-emscripten-core/dist/index.d.ts:1642
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1629
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1630
+packages/quickjs-emscripten-core/dist/index.d.ts:1643
 
 ## Methods
 
@@ -85,7 +85,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1630
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1636
+packages/quickjs-emscripten-core/dist/index.d.ts:1649
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1636
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1635
+packages/quickjs-emscripten-core/dist/index.d.ts:1648
 
 ***
 
@@ -123,7 +123,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1635
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1634
+packages/quickjs-emscripten-core/dist/index.d.ts:1647
 
 ***
 
@@ -141,7 +141,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1634
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1637
+packages/quickjs-emscripten-core/dist/index.d.ts:1650
 
 ***
 
@@ -163,7 +163,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1637
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1633
+packages/quickjs-emscripten-core/dist/index.d.ts:1646
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1633
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1632
+packages/quickjs-emscripten-core/dist/index.d.ts:1645
 
 ***
 

--- a/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
@@ -51,7 +51,7 @@ freed all the memory you've ever allocated.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1616
+packages/quickjs-emscripten-core/dist/index.d.ts:1631
 
 ## Properties
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1616
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1614
+packages/quickjs-emscripten-core/dist/index.d.ts:1629
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1614
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1615
+packages/quickjs-emscripten-core/dist/index.d.ts:1630
 
 ## Methods
 
@@ -85,7 +85,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1615
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1621
+packages/quickjs-emscripten-core/dist/index.d.ts:1636
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1621
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1620
+packages/quickjs-emscripten-core/dist/index.d.ts:1635
 
 ***
 
@@ -123,7 +123,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1620
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1619
+packages/quickjs-emscripten-core/dist/index.d.ts:1634
 
 ***
 
@@ -141,7 +141,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1619
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1622
+packages/quickjs-emscripten-core/dist/index.d.ts:1637
 
 ***
 
@@ -163,7 +163,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1622
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1618
+packages/quickjs-emscripten-core/dist/index.d.ts:1633
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1618
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1617
+packages/quickjs-emscripten-core/dist/index.d.ts:1632
 
 ***
 

--- a/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
@@ -51,7 +51,7 @@ freed all the memory you've ever allocated.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1644
+packages/quickjs-emscripten-core/dist/index.d.ts:1659
 
 ## Properties
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1644
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1642
+packages/quickjs-emscripten-core/dist/index.d.ts:1657
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1642
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1643
+packages/quickjs-emscripten-core/dist/index.d.ts:1658
 
 ## Methods
 
@@ -85,7 +85,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1643
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1649
+packages/quickjs-emscripten-core/dist/index.d.ts:1664
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1649
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1648
+packages/quickjs-emscripten-core/dist/index.d.ts:1663
 
 ***
 
@@ -123,7 +123,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1648
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1647
+packages/quickjs-emscripten-core/dist/index.d.ts:1662
 
 ***
 
@@ -141,7 +141,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1647
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1650
+packages/quickjs-emscripten-core/dist/index.d.ts:1665
 
 ***
 
@@ -163,7 +163,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1650
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1646
+packages/quickjs-emscripten-core/dist/index.d.ts:1661
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1646
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1645
+packages/quickjs-emscripten-core/dist/index.d.ts:1660
 
 ***
 

--- a/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
@@ -51,7 +51,7 @@ freed all the memory you've ever allocated.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1604
+packages/quickjs-emscripten-core/dist/index.d.ts:1616
 
 ## Properties
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1604
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1602
+packages/quickjs-emscripten-core/dist/index.d.ts:1614
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1602
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1603
+packages/quickjs-emscripten-core/dist/index.d.ts:1615
 
 ## Methods
 
@@ -85,7 +85,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1603
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1609
+packages/quickjs-emscripten-core/dist/index.d.ts:1621
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1609
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1608
+packages/quickjs-emscripten-core/dist/index.d.ts:1620
 
 ***
 
@@ -123,7 +123,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1608
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1607
+packages/quickjs-emscripten-core/dist/index.d.ts:1619
 
 ***
 
@@ -141,7 +141,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1607
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1610
+packages/quickjs-emscripten-core/dist/index.d.ts:1622
 
 ***
 
@@ -163,7 +163,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1610
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1606
+packages/quickjs-emscripten-core/dist/index.d.ts:1618
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1606
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1605
+packages/quickjs-emscripten-core/dist/index.d.ts:1617
 
 ***
 

--- a/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
+++ b/doc/quickjs-emscripten/classes/TestQuickJSWASMModule.md
@@ -51,7 +51,7 @@ freed all the memory you've ever allocated.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1583
+packages/quickjs-emscripten-core/dist/index.d.ts:1604
 
 ## Properties
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1583
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1581
+packages/quickjs-emscripten-core/dist/index.d.ts:1602
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1581
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1582
+packages/quickjs-emscripten-core/dist/index.d.ts:1603
 
 ## Methods
 
@@ -85,7 +85,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1588
+packages/quickjs-emscripten-core/dist/index.d.ts:1609
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1588
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1587
+packages/quickjs-emscripten-core/dist/index.d.ts:1608
 
 ***
 
@@ -123,7 +123,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1587
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1586
+packages/quickjs-emscripten-core/dist/index.d.ts:1607
 
 ***
 
@@ -141,7 +141,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1586
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1589
+packages/quickjs-emscripten-core/dist/index.d.ts:1610
 
 ***
 
@@ -163,7 +163,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1589
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1585
+packages/quickjs-emscripten-core/dist/index.d.ts:1606
 
 ***
 
@@ -185,7 +185,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1585
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1584
+packages/quickjs-emscripten-core/dist/index.d.ts:1605
 
 ***
 

--- a/doc/quickjs-emscripten/classes/UsingDisposable.md
+++ b/doc/quickjs-emscripten/classes/UsingDisposable.md
@@ -54,7 +54,7 @@ Base abstract class that helps implement [Disposable](../interfaces/Disposable.m
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:553
+packages/quickjs-emscripten-core/dist/index.d.ts:561
 
 ## Methods
 
@@ -74,7 +74,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -94,7 +94,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:557
+packages/quickjs-emscripten-core/dist/index.d.ts:565
 
 ***
 

--- a/doc/quickjs-emscripten/classes/WeakLifetime.md
+++ b/doc/quickjs-emscripten/classes/WeakLifetime.md
@@ -74,7 +74,7 @@ Used for function arguments.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:628
+packages/quickjs-emscripten-core/dist/index.d.ts:636
 
 ## Properties
 
@@ -88,7 +88,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:628
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:574
+packages/quickjs-emscripten-core/dist/index.d.ts:582
 
 ***
 
@@ -102,7 +102,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:574
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:575
+packages/quickjs-emscripten-core/dist/index.d.ts:583
 
 ***
 
@@ -116,7 +116,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:575
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:573
+packages/quickjs-emscripten-core/dist/index.d.ts:581
 
 ***
 
@@ -130,7 +130,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:573
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:570
+packages/quickjs-emscripten-core/dist/index.d.ts:578
 
 ***
 
@@ -152,7 +152,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:570
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:571
+packages/quickjs-emscripten-core/dist/index.d.ts:579
 
 ***
 
@@ -174,7 +174,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:571
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:572
+packages/quickjs-emscripten-core/dist/index.d.ts:580
 
 ## Accessors
 
@@ -192,7 +192,7 @@ false after the object has been [dispose](WeakLifetime.md#dispose-1)d
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:585
+packages/quickjs-emscripten-core/dist/index.d.ts:593
 
 ***
 
@@ -206,7 +206,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:585
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:594
+packages/quickjs-emscripten-core/dist/index.d.ts:602
 
 ***
 
@@ -220,7 +220,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:594
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:593
+packages/quickjs-emscripten-core/dist/index.d.ts:601
 
 ***
 
@@ -241,7 +241,7 @@ If the lifetime has been [dispose](WeakLifetime.md#dispose-1)d already.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:592
+packages/quickjs-emscripten-core/dist/index.d.ts:600
 
 ## Methods
 
@@ -261,7 +261,7 @@ Just calls the standard .dispose() method of this class.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:561
+packages/quickjs-emscripten-core/dist/index.d.ts:569
 
 ***
 
@@ -293,7 +293,7 @@ the result of `map(this)`.
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:603
+packages/quickjs-emscripten-core/dist/index.d.ts:611
 
 #### consume(map)
 
@@ -317,7 +317,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:603
 
 ##### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:604
+packages/quickjs-emscripten-core/dist/index.d.ts:612
 
 ***
 
@@ -337,7 +337,7 @@ Dispose of [value](WeakLifetime.md#value-1) and perform cleanup.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:629
+packages/quickjs-emscripten-core/dist/index.d.ts:637
 
 ***
 
@@ -357,7 +357,7 @@ Create a new handle pointing to the same [value](WeakLifetime.md#value-1).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:598
+packages/quickjs-emscripten-core/dist/index.d.ts:606
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -144,7 +144,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:310
+packages/quickjs-emscripten-core/dist/index.d.ts:313
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:66
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:481
+packages/quickjs-ffi-types/dist/index.d.ts:483
 
 ***
 
@@ -193,7 +193,7 @@ by the runtime.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:119
+packages/quickjs-emscripten-core/dist/index.d.ts:122
 
 ***
 
@@ -218,7 +218,7 @@ Determines if a VM's execution should be interrupted.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:112
+packages/quickjs-emscripten-core/dist/index.d.ts:115
 
 ***
 
@@ -300,7 +300,7 @@ Language features that can be enabled or disabled in a QuickJSContext.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:440
+packages/quickjs-emscripten-core/dist/index.d.ts:443
 
 ***
 
@@ -359,7 +359,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:28
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:391
+packages/quickjs-emscripten-core/dist/index.d.ts:394
 
 ***
 
@@ -369,7 +369,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:392
+packages/quickjs-emscripten-core/dist/index.d.ts:395
 
 ***
 
@@ -379,7 +379,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:390
+packages/quickjs-emscripten-core/dist/index.d.ts:393
 
 ***
 
@@ -389,7 +389,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:402
+packages/quickjs-emscripten-core/dist/index.d.ts:405
 
 ***
 
@@ -399,7 +399,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:403
+packages/quickjs-emscripten-core/dist/index.d.ts:406
 
 ***
 
@@ -409,7 +409,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:401
+packages/quickjs-emscripten-core/dist/index.d.ts:404
 
 ***
 
@@ -445,7 +445,7 @@ You can do so from Javascript by calling the .dispose() method.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:381
+packages/quickjs-emscripten-core/dist/index.d.ts:384
 
 ***
 
@@ -464,7 +464,7 @@ quickjs-emscripten takes care of disposing JSValueConst references.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:365
+packages/quickjs-emscripten-core/dist/index.d.ts:368
 
 ***
 
@@ -540,7 +540,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:80
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1460
+packages/quickjs-emscripten-core/dist/index.d.ts:1481
 
 ***
 
@@ -579,7 +579,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:71
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:523
+packages/quickjs-emscripten-core/dist/index.d.ts:531
 
 ***
 
@@ -593,7 +593,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:523
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1401
+packages/quickjs-emscripten-core/dist/index.d.ts:1422
 
 ***
 
@@ -645,7 +645,7 @@ You must dispose of any handles you create by calling the `.dispose()` method.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:389
+packages/quickjs-emscripten-core/dist/index.d.ts:392
 
 ***
 
@@ -658,7 +658,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:735
+packages/quickjs-emscripten-core/dist/index.d.ts:743
 
 ***
 
@@ -668,7 +668,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:735
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:480
+packages/quickjs-ffi-types/dist/index.d.ts:482
 
 ***
 
@@ -681,7 +681,7 @@ be disposed.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:354
+packages/quickjs-emscripten-core/dist/index.d.ts:357
 
 ***
 
@@ -856,7 +856,7 @@ The default [Intrinsics](exports.md#intrinsics) language features enabled in a Q
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:462
+packages/quickjs-emscripten-core/dist/index.d.ts:465
 
 ***
 
@@ -1210,7 +1210,7 @@ const getDebugModule = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SY
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1459
+packages/quickjs-emscripten-core/dist/index.d.ts:1480
 
 ***
 
@@ -1339,7 +1339,7 @@ const quickjs = new newQuickJSAsyncWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1448
+packages/quickjs-emscripten-core/dist/index.d.ts:1469
 
 ***
 
@@ -1401,7 +1401,7 @@ const quickjs = new newQuickJSWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1423
+packages/quickjs-emscripten-core/dist/index.d.ts:1444
 
 ***
 
@@ -1428,7 +1428,7 @@ This may be necessary in Cloudflare Workers, which can't compile WebAssembly mod
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1503
+packages/quickjs-emscripten-core/dist/index.d.ts:1524
 
 ***
 
@@ -1451,7 +1451,7 @@ Interrupt execution if it's still running after this time.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1511
+packages/quickjs-emscripten-core/dist/index.d.ts:1532
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -29,6 +29,8 @@
   - [JSModuleNormalizeFailure](exports.md#jsmodulenormalizefailure)
   - [JSModuleNormalizeResult](exports.md#jsmodulenormalizeresult)
   - [JSModuleNormalizeSuccess](exports.md#jsmodulenormalizesuccess)
+  - [JSPromiseState](exports.md#jspromisestate)
+  - [JSPromiseStateEnum](exports.md#jspromisestateenum)
   - [JSRuntimePointer](exports.md#jsruntimepointer)
   - [JSValue](exports.md#jsvalue)
   - [JSValueConst](exports.md#jsvalueconst)
@@ -59,6 +61,7 @@
   - [DefaultIntrinsics](exports.md#defaultintrinsics)
   - [EvalFlags](exports.md#evalflags)
   - [IntrinsicsFlags](exports.md#intrinsicsflags)
+  - [JSPromiseStateEnum](exports.md#jspromisestateenum-1)
   - [RELEASE\_ASYNC](exports.md#release-async)
   - [@jitl/quickjs-wasmfile-release-asyncify](exports.md#jitlquickjs-wasmfile-release-asyncify)
   - [RELEASE\_SYNC](exports.md#release-sync)
@@ -167,7 +170,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:66
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:483
+packages/quickjs-ffi-types/dist/index.d.ts:496
 
 ***
 
@@ -177,7 +180,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:483
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:295
+packages/quickjs-ffi-types/dist/index.d.ts:304
 
 ***
 
@@ -413,6 +416,28 @@ packages/quickjs-emscripten-core/dist/index.d.ts:404
 
 ***
 
+### JSPromiseState
+
+> **JSPromiseState**: `Object` \| `Object` \| `Object`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:669
+
+***
+
+### JSPromiseStateEnum
+
+> **JSPromiseStateEnum**: `Brand`\<*typeof* [`JSPromiseStateEnum`](exports.md#jspromisestateenum-1)\[keyof *typeof* [`JSPromiseStateEnum`](exports.md#jspromisestateenum-1)\], `"JSPromiseStateEnum"`\>
+
+State of a promise.
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:140
+
+***
+
 ### JSRuntimePointer
 
 > **JSRuntimePointer**: `Pointer`\<`"JSRuntime"`\>
@@ -540,7 +565,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:80
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1481
+packages/quickjs-emscripten-core/dist/index.d.ts:1493
 
 ***
 
@@ -593,7 +618,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:531
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1422
+packages/quickjs-emscripten-core/dist/index.d.ts:1434
 
 ***
 
@@ -658,7 +683,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:743
+packages/quickjs-emscripten-core/dist/index.d.ts:754
 
 ***
 
@@ -668,7 +693,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:743
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:482
+packages/quickjs-ffi-types/dist/index.d.ts:495
 
 ***
 
@@ -1006,6 +1031,30 @@ packages/quickjs-ffi-types/dist/index.d.ts:117
 
 ***
 
+### JSPromiseStateEnum
+
+> **JSPromiseStateEnum**: `Object`
+
+#### Type declaration
+
+##### Fulfilled
+
+> **`readonly`** **Fulfilled**: `1`
+
+##### Pending
+
+> **`readonly`** **Pending**: `0`
+
+##### Rejected
+
+> **`readonly`** **Rejected**: `2`
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:140
+
+***
+
 ### RELEASE\_ASYNC
 
 > **`const`** **RELEASE\_ASYNC**: [`QuickJSAsyncVariant`](interfaces/QuickJSAsyncVariant.md)
@@ -1210,7 +1259,7 @@ const getDebugModule = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SY
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1480
+packages/quickjs-emscripten-core/dist/index.d.ts:1492
 
 ***
 
@@ -1339,7 +1388,7 @@ const quickjs = new newQuickJSAsyncWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1469
+packages/quickjs-emscripten-core/dist/index.d.ts:1481
 
 ***
 
@@ -1401,7 +1450,7 @@ const quickjs = new newQuickJSWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1444
+packages/quickjs-emscripten-core/dist/index.d.ts:1456
 
 ***
 
@@ -1428,7 +1477,7 @@ This may be necessary in Cloudflare Workers, which can't compile WebAssembly mod
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1524
+packages/quickjs-emscripten-core/dist/index.d.ts:1536
 
 ***
 
@@ -1451,7 +1500,7 @@ Interrupt execution if it's still running after this time.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1532
+packages/quickjs-emscripten-core/dist/index.d.ts:1544
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -420,9 +420,12 @@ packages/quickjs-emscripten-core/dist/index.d.ts:404
 
 > **JSPromiseState**: `Object` \| `Object` \| `Object`
 
+A promise state inside QuickJS, which can be pending, fulfilled, or rejected.
+You can unwrap a JSPromiseState with [QuickJSContext#unwrapResult](classes/QuickJSContext.md#unwrapresult).
+
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:669
+packages/quickjs-emscripten-core/dist/index.d.ts:673
 
 ***
 
@@ -565,7 +568,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:80
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1493
+packages/quickjs-emscripten-core/dist/index.d.ts:1503
 
 ***
 
@@ -618,7 +621,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:531
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1434
+packages/quickjs-emscripten-core/dist/index.d.ts:1444
 
 ***
 
@@ -683,7 +686,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:754
+packages/quickjs-emscripten-core/dist/index.d.ts:764
 
 ***
 
@@ -1259,7 +1262,7 @@ const getDebugModule = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SY
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1492
+packages/quickjs-emscripten-core/dist/index.d.ts:1502
 
 ***
 
@@ -1388,7 +1391,7 @@ const quickjs = new newQuickJSAsyncWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1481
+packages/quickjs-emscripten-core/dist/index.d.ts:1491
 
 ***
 
@@ -1450,7 +1453,7 @@ const quickjs = new newQuickJSWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1456
+packages/quickjs-emscripten-core/dist/index.d.ts:1466
 
 ***
 
@@ -1477,7 +1480,7 @@ This may be necessary in Cloudflare Workers, which can't compile WebAssembly mod
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1536
+packages/quickjs-emscripten-core/dist/index.d.ts:1546
 
 ***
 
@@ -1500,7 +1503,7 @@ Interrupt execution if it's still running after this time.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1544
+packages/quickjs-emscripten-core/dist/index.d.ts:1554
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -568,7 +568,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:80
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1503
+packages/quickjs-emscripten-core/dist/index.d.ts:1516
 
 ***
 
@@ -621,7 +621,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:531
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1444
+packages/quickjs-emscripten-core/dist/index.d.ts:1457
 
 ***
 
@@ -1262,7 +1262,7 @@ const getDebugModule = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SY
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1502
+packages/quickjs-emscripten-core/dist/index.d.ts:1515
 
 ***
 
@@ -1391,7 +1391,7 @@ const quickjs = new newQuickJSAsyncWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1491
+packages/quickjs-emscripten-core/dist/index.d.ts:1504
 
 ***
 
@@ -1453,7 +1453,7 @@ const quickjs = new newQuickJSWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1466
+packages/quickjs-emscripten-core/dist/index.d.ts:1479
 
 ***
 
@@ -1480,7 +1480,7 @@ This may be necessary in Cloudflare Workers, which can't compile WebAssembly mod
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1546
+packages/quickjs-emscripten-core/dist/index.d.ts:1559
 
 ***
 
@@ -1503,7 +1503,7 @@ Interrupt execution if it's still running after this time.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1554
+packages/quickjs-emscripten-core/dist/index.d.ts:1567
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -116,6 +116,9 @@
 - [JSModuleLoaderAsync](interfaces/JSModuleLoaderAsync.md)
 - [JSModuleNormalizer](interfaces/JSModuleNormalizer.md)
 - [JSModuleNormalizerAsync](interfaces/JSModuleNormalizerAsync.md)
+- [JSPromiseStateFulfilled](interfaces/JSPromiseStateFulfilled.md)
+- [JSPromiseStatePending](interfaces/JSPromiseStatePending.md)
+- [JSPromiseStateRejected](interfaces/JSPromiseStateRejected.md)
 - [LowLevelJavascriptVm](interfaces/LowLevelJavascriptVm.md)
 - [ModuleEvalOptions](interfaces/ModuleEvalOptions.md)
 - [QuickJSAsyncEmscriptenModule](interfaces/QuickJSAsyncEmscriptenModule.md)
@@ -418,7 +421,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:404
 
 ### JSPromiseState
 
-> **JSPromiseState**: `Object` \| `Object` \| `Object`
+> **JSPromiseState**: [`JSPromiseStatePending`](interfaces/JSPromiseStatePending.md) \| [`JSPromiseStateFulfilled`](interfaces/JSPromiseStateFulfilled.md) \| [`JSPromiseStateRejected`](interfaces/JSPromiseStateRejected.md)
 
 A promise state inside QuickJS, which can be pending, fulfilled, or rejected.
 You can unwrap a JSPromiseState with [QuickJSContext#unwrapResult](classes/QuickJSContext.md#unwrapresult).
@@ -568,7 +571,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:80
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1516
+packages/quickjs-emscripten-core/dist/index.d.ts:1531
 
 ***
 
@@ -621,7 +624,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:531
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1457
+packages/quickjs-emscripten-core/dist/index.d.ts:1472
 
 ***
 
@@ -686,7 +689,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:764
+packages/quickjs-emscripten-core/dist/index.d.ts:779
 
 ***
 
@@ -1262,7 +1265,7 @@ const getDebugModule = memoizePromiseFactory(() => newQuickJSWASMModule(DEBUG_SY
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1515
+packages/quickjs-emscripten-core/dist/index.d.ts:1530
 
 ***
 
@@ -1391,7 +1394,7 @@ const quickjs = new newQuickJSAsyncWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1504
+packages/quickjs-emscripten-core/dist/index.d.ts:1519
 
 ***
 
@@ -1453,7 +1456,7 @@ const quickjs = new newQuickJSWASMModuleFromVariant(
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1479
+packages/quickjs-emscripten-core/dist/index.d.ts:1494
 
 ***
 
@@ -1480,7 +1483,7 @@ This may be necessary in Cloudflare Workers, which can't compile WebAssembly mod
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1559
+packages/quickjs-emscripten-core/dist/index.d.ts:1574
 
 ***
 
@@ -1503,7 +1506,7 @@ Interrupt execution if it's still running after this time.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1567
+packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/AsyncRuntimeOptions.md
+++ b/doc/quickjs-emscripten/interfaces/AsyncRuntimeOptions.md
@@ -35,7 +35,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:417
+packages/quickjs-emscripten-core/dist/index.d.ts:420
 
 ***
 
@@ -49,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:412
+packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 ***
 
@@ -63,7 +63,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:413
+packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 ***
 
@@ -77,7 +77,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:414
+packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 ***
 
@@ -87,7 +87,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:434
+packages/quickjs-emscripten-core/dist/index.d.ts:437
 
 ***
 
@@ -101,7 +101,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:434
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:415
+packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 ***
 
@@ -115,7 +115,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:416
+packages/quickjs-emscripten-core/dist/index.d.ts:419
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:418
+packages/quickjs-emscripten-core/dist/index.d.ts:421
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ContextEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ContextEvalOptions.md
@@ -25,7 +25,7 @@ don't include the stack frames before this eval in the Error() backtraces
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:521
+packages/quickjs-emscripten-core/dist/index.d.ts:529
 
 ***
 
@@ -39,7 +39,7 @@ with JS_EvalFunction().
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:519
+packages/quickjs-emscripten-core/dist/index.d.ts:527
 
 ***
 
@@ -51,7 +51,7 @@ Force "strict" mode
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:511
+packages/quickjs-emscripten-core/dist/index.d.ts:519
 
 ***
 
@@ -63,7 +63,7 @@ Force "strip" mode
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:513
+packages/quickjs-emscripten-core/dist/index.d.ts:521
 
 ***
 
@@ -71,11 +71,14 @@ packages/quickjs-emscripten-core/dist/index.d.ts:513
 
 > **type**?: `"global"` \| `"module"`
 
-Global code (default)
+Global code (default), or "module" code?
+
+- When type is `"global"`, the code is evaluated in the global scope of the QuickJSContext, and the return value is the result of the last expression.
+- When type is `"module"`, the code is evaluated is a module scope, may use `import`, `export`, and top-level `await`. The return value is the module's exports, or a promise for the module's exports.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:509
+packages/quickjs-emscripten-core/dist/index.d.ts:517
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ContextOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ContextOptions.md
@@ -37,7 +37,7 @@ const contextWithoutDateOrEval = runtime.newContext({
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:495
+packages/quickjs-emscripten-core/dist/index.d.ts:498
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+++ b/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
@@ -29,7 +29,7 @@ The enumerable properties of this object will be passed verbatim, although they 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1495
+packages/quickjs-emscripten-core/dist/index.d.ts:1516
 
 ***
 
@@ -69,7 +69,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1493
+packages/quickjs-emscripten-core/dist/index.d.ts:1514
 
 ***
 
@@ -101,7 +101,7 @@ Debug logger
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1497
+packages/quickjs-emscripten-core/dist/index.d.ts:1518
 
 ***
 
@@ -113,7 +113,7 @@ If given, Emscripten will compile the WebAssembly.Module from these bytes.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1465
+packages/quickjs-emscripten-core/dist/index.d.ts:1486
 
 ***
 
@@ -125,7 +125,7 @@ If given, Emscripten will try to load the WebAssembly module data from this loca
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1463
+packages/quickjs-emscripten-core/dist/index.d.ts:1484
 
 ***
 
@@ -137,7 +137,7 @@ If given, use the Memory when instantiating the WebAssembly.Instance.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1469
+packages/quickjs-emscripten-core/dist/index.d.ts:1490
 
 ***
 
@@ -149,7 +149,7 @@ If given, Emscripten will instantiate the WebAssembly.Instance from this existin
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1467
+packages/quickjs-emscripten-core/dist/index.d.ts:1488
 
 ***
 
@@ -161,7 +161,7 @@ If given, we will provide the source map to Emscripten directly. This may only b
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1473
+packages/quickjs-emscripten-core/dist/index.d.ts:1494
 
 ***
 
@@ -173,7 +173,7 @@ If given, Emscripten will try to load the source map for the WebAssembly module 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1471
+packages/quickjs-emscripten-core/dist/index.d.ts:1492
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+++ b/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
@@ -29,7 +29,7 @@ The enumerable properties of this object will be passed verbatim, although they 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1528
+packages/quickjs-emscripten-core/dist/index.d.ts:1538
 
 ***
 
@@ -69,7 +69,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1526
+packages/quickjs-emscripten-core/dist/index.d.ts:1536
 
 ***
 
@@ -101,7 +101,7 @@ Debug logger
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1530
+packages/quickjs-emscripten-core/dist/index.d.ts:1540
 
 ***
 
@@ -113,7 +113,7 @@ If given, Emscripten will compile the WebAssembly.Module from these bytes.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1498
+packages/quickjs-emscripten-core/dist/index.d.ts:1508
 
 ***
 
@@ -125,7 +125,7 @@ If given, Emscripten will try to load the WebAssembly module data from this loca
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1496
+packages/quickjs-emscripten-core/dist/index.d.ts:1506
 
 ***
 
@@ -137,7 +137,7 @@ If given, use the Memory when instantiating the WebAssembly.Instance.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1502
+packages/quickjs-emscripten-core/dist/index.d.ts:1512
 
 ***
 
@@ -149,7 +149,7 @@ If given, Emscripten will instantiate the WebAssembly.Instance from this existin
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1500
+packages/quickjs-emscripten-core/dist/index.d.ts:1510
 
 ***
 
@@ -161,7 +161,7 @@ If given, we will provide the source map to Emscripten directly. This may only b
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1506
+packages/quickjs-emscripten-core/dist/index.d.ts:1516
 
 ***
 
@@ -173,7 +173,7 @@ If given, Emscripten will try to load the source map for the WebAssembly module 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1504
+packages/quickjs-emscripten-core/dist/index.d.ts:1514
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+++ b/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
@@ -29,7 +29,7 @@ The enumerable properties of this object will be passed verbatim, although they 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1538
+packages/quickjs-emscripten-core/dist/index.d.ts:1551
 
 ***
 
@@ -69,7 +69,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1536
+packages/quickjs-emscripten-core/dist/index.d.ts:1549
 
 ***
 
@@ -101,7 +101,7 @@ Debug logger
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1540
+packages/quickjs-emscripten-core/dist/index.d.ts:1553
 
 ***
 
@@ -113,7 +113,7 @@ If given, Emscripten will compile the WebAssembly.Module from these bytes.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1508
+packages/quickjs-emscripten-core/dist/index.d.ts:1521
 
 ***
 
@@ -125,7 +125,7 @@ If given, Emscripten will try to load the WebAssembly module data from this loca
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1506
+packages/quickjs-emscripten-core/dist/index.d.ts:1519
 
 ***
 
@@ -137,7 +137,7 @@ If given, use the Memory when instantiating the WebAssembly.Instance.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1512
+packages/quickjs-emscripten-core/dist/index.d.ts:1525
 
 ***
 
@@ -149,7 +149,7 @@ If given, Emscripten will instantiate the WebAssembly.Instance from this existin
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1510
+packages/quickjs-emscripten-core/dist/index.d.ts:1523
 
 ***
 
@@ -161,7 +161,7 @@ If given, we will provide the source map to Emscripten directly. This may only b
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1516
+packages/quickjs-emscripten-core/dist/index.d.ts:1529
 
 ***
 
@@ -173,7 +173,7 @@ If given, Emscripten will try to load the source map for the WebAssembly module 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1514
+packages/quickjs-emscripten-core/dist/index.d.ts:1527
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+++ b/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
@@ -29,7 +29,7 @@ The enumerable properties of this object will be passed verbatim, although they 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1516
+packages/quickjs-emscripten-core/dist/index.d.ts:1528
 
 ***
 
@@ -69,7 +69,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1514
+packages/quickjs-emscripten-core/dist/index.d.ts:1526
 
 ***
 
@@ -101,7 +101,7 @@ Debug logger
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1518
+packages/quickjs-emscripten-core/dist/index.d.ts:1530
 
 ***
 
@@ -113,7 +113,7 @@ If given, Emscripten will compile the WebAssembly.Module from these bytes.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1486
+packages/quickjs-emscripten-core/dist/index.d.ts:1498
 
 ***
 
@@ -125,7 +125,7 @@ If given, Emscripten will try to load the WebAssembly module data from this loca
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1484
+packages/quickjs-emscripten-core/dist/index.d.ts:1496
 
 ***
 
@@ -137,7 +137,7 @@ If given, use the Memory when instantiating the WebAssembly.Instance.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1490
+packages/quickjs-emscripten-core/dist/index.d.ts:1502
 
 ***
 
@@ -149,7 +149,7 @@ If given, Emscripten will instantiate the WebAssembly.Instance from this existin
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1488
+packages/quickjs-emscripten-core/dist/index.d.ts:1500
 
 ***
 
@@ -161,7 +161,7 @@ If given, we will provide the source map to Emscripten directly. This may only b
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1494
+packages/quickjs-emscripten-core/dist/index.d.ts:1506
 
 ***
 
@@ -173,7 +173,7 @@ If given, Emscripten will try to load the source map for the WebAssembly module 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1492
+packages/quickjs-emscripten-core/dist/index.d.ts:1504
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
+++ b/doc/quickjs-emscripten/interfaces/CustomizeVariantOptions.md
@@ -29,7 +29,7 @@ The enumerable properties of this object will be passed verbatim, although they 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1551
+packages/quickjs-emscripten-core/dist/index.d.ts:1566
 
 ***
 
@@ -69,7 +69,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1549
+packages/quickjs-emscripten-core/dist/index.d.ts:1564
 
 ***
 
@@ -101,7 +101,7 @@ Debug logger
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1553
+packages/quickjs-emscripten-core/dist/index.d.ts:1568
 
 ***
 
@@ -113,7 +113,7 @@ If given, Emscripten will compile the WebAssembly.Module from these bytes.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1521
+packages/quickjs-emscripten-core/dist/index.d.ts:1536
 
 ***
 
@@ -125,7 +125,7 @@ If given, Emscripten will try to load the WebAssembly module data from this loca
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1519
+packages/quickjs-emscripten-core/dist/index.d.ts:1534
 
 ***
 
@@ -137,7 +137,7 @@ If given, use the Memory when instantiating the WebAssembly.Instance.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1525
+packages/quickjs-emscripten-core/dist/index.d.ts:1540
 
 ***
 
@@ -149,7 +149,7 @@ If given, Emscripten will instantiate the WebAssembly.Instance from this existin
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1523
+packages/quickjs-emscripten-core/dist/index.d.ts:1538
 
 ***
 
@@ -161,7 +161,7 @@ If given, we will provide the source map to Emscripten directly. This may only b
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1529
+packages/quickjs-emscripten-core/dist/index.d.ts:1544
 
 ***
 
@@ -173,7 +173,7 @@ If given, Emscripten will try to load the source map for the WebAssembly module 
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1527
+packages/quickjs-emscripten-core/dist/index.d.ts:1542
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/Disposable.md
+++ b/doc/quickjs-emscripten/interfaces/Disposable.md
@@ -26,7 +26,7 @@ Use [Scope](../classes/Scope.md) to manage cleaning up multiple disposables.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:539
+packages/quickjs-emscripten-core/dist/index.d.ts:547
 
 ## Methods
 
@@ -42,7 +42,7 @@ A method that is used to release resources held by an object. Called by the sema
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:543
+packages/quickjs-emscripten-core/dist/index.d.ts:551
 
 ***
 
@@ -58,7 +58,7 @@ Dispose of the underlying resources used by this object.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:534
+packages/quickjs-emscripten-core/dist/index.d.ts:542
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModule.md
@@ -49,7 +49,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:252
+packages/quickjs-ffi-types/dist/index.d.ts:261
 
 ***
 
@@ -59,7 +59,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:252
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:243
+packages/quickjs-ffi-types/dist/index.d.ts:252
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:243
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:244
+packages/quickjs-ffi-types/dist/index.d.ts:253
 
 ***
 
@@ -79,7 +79,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:244
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:242
+packages/quickjs-ffi-types/dist/index.d.ts:251
 
 ***
 
@@ -89,7 +89,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:242
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:248
+packages/quickjs-ffi-types/dist/index.d.ts:257
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:248
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:249
+packages/quickjs-ffi-types/dist/index.d.ts:258
 
 ***
 
@@ -109,7 +109,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:249
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:246
+packages/quickjs-ffi-types/dist/index.d.ts:255
 
 ***
 
@@ -119,7 +119,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:246
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:247
+packages/quickjs-ffi-types/dist/index.d.ts:256
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:247
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:245
+packages/quickjs-ffi-types/dist/index.d.ts:254
 
 ***
 
@@ -139,7 +139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:245
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:251
+packages/quickjs-ffi-types/dist/index.d.ts:260
 
 ***
 
@@ -149,7 +149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:251
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:250
+packages/quickjs-ffi-types/dist/index.d.ts:259
 
 ***
 
@@ -165,7 +165,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -181,7 +181,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -204,7 +204,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:237
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -222,7 +222,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:237
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:240
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -240,7 +240,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:240
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:239
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -273,7 +273,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:239
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:241
+packages/quickjs-ffi-types/dist/index.d.ts:250
 
 ***
 
@@ -299,7 +299,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -317,7 +317,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:238
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -361,7 +361,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -385,7 +385,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 
@@ -410,7 +410,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:232
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoader.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:297
+packages/quickjs-ffi-types/dist/index.d.ts:306
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoaderOptions.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoaderOptions.md
@@ -35,7 +35,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -47,7 +47,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -69,7 +69,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -109,7 +109,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -129,7 +129,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/JSModuleLoader.md
+++ b/doc/quickjs-emscripten/interfaces/JSModuleLoader.md
@@ -22,7 +22,7 @@ Load module (sync)
 
 ## Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:399
+packages/quickjs-emscripten-core/dist/index.d.ts:402
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/JSModuleLoaderAsync.md
+++ b/doc/quickjs-emscripten/interfaces/JSModuleLoaderAsync.md
@@ -22,7 +22,7 @@ Load module (async)
 
 ## Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:395
+packages/quickjs-emscripten-core/dist/index.d.ts:398
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/JSModuleNormalizer.md
+++ b/doc/quickjs-emscripten/interfaces/JSModuleNormalizer.md
@@ -26,7 +26,7 @@
 
 ## Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:408
+packages/quickjs-emscripten-core/dist/index.d.ts:411
 
 > **JSModuleNormalizer**(`baseModuleName`, `requestedName`, `vm`): [`JSModuleNormalizeResult`](../exports.md#jsmodulenormalizeresult) \| `Promise`\<[`JSModuleNormalizeResult`](../exports.md#jsmodulenormalizeresult)\>
 
@@ -44,7 +44,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:408
 
 ## Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:405
+packages/quickjs-emscripten-core/dist/index.d.ts:408
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/JSModuleNormalizerAsync.md
+++ b/doc/quickjs-emscripten/interfaces/JSModuleNormalizerAsync.md
@@ -26,7 +26,7 @@
 
 ## Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:405
+packages/quickjs-emscripten-core/dist/index.d.ts:408
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/JSPromiseStateFulfilled.md
+++ b/doc/quickjs-emscripten/interfaces/JSPromiseStateFulfilled.md
@@ -1,0 +1,64 @@
+[quickjs-emscripten](../../packages.md) • **quickjs-emscripten** • [Readme](../README.md) \| [Exports](../exports.md)
+
+***
+
+[quickjs-emscripten](../../packages.md) / [quickjs-emscripten](../exports.md) / JSPromiseStateFulfilled
+
+# Interface: JSPromiseStateFulfilled
+
+Fulfilled promise state.
+See [JSPromiseState](../exports.md#jspromisestate).
+
+## Contents
+
+- [Properties](JSPromiseStateFulfilled.md#properties)
+  - [error?](JSPromiseStateFulfilled.md#error)
+  - [notAPromise?](JSPromiseStateFulfilled.md#notapromise)
+  - [type](JSPromiseStateFulfilled.md#type)
+  - [value](JSPromiseStateFulfilled.md#value)
+
+## Properties
+
+### error?
+
+> **error**?: `undefined`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:693
+
+***
+
+### notAPromise?
+
+> **notAPromise**?: `boolean`
+
+Trying to get the promise state of a non-Promise value returns a fulfilled state with the original value, and `notAPromise: true`.
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:695
+
+***
+
+### type
+
+> **type**: `"fulfilled"`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:691
+
+***
+
+### value
+
+> **value**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:692
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten/interfaces/JSPromiseStatePending.md
+++ b/doc/quickjs-emscripten/interfaces/JSPromiseStatePending.md
@@ -1,0 +1,48 @@
+[quickjs-emscripten](../../packages.md) • **quickjs-emscripten** • [Readme](../README.md) \| [Exports](../exports.md)
+
+***
+
+[quickjs-emscripten](../../packages.md) / [quickjs-emscripten](../exports.md) / JSPromiseStatePending
+
+# Interface: JSPromiseStatePending
+
+Pending promise state.
+See [JSPromiseState](../exports.md#jspromisestate).
+
+## Contents
+
+- [Properties](JSPromiseStatePending.md#properties)
+  - [type](JSPromiseStatePending.md#type)
+- [Accessors](JSPromiseStatePending.md#accessors)
+  - [error](JSPromiseStatePending.md#error)
+
+## Properties
+
+### type
+
+> **type**: `"pending"`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:679
+
+## Accessors
+
+### error
+
+> **`get`** **error**(): `Error`
+
+The error property here allows unwrapping a JSPromiseState with [QuickJSContext#unwrapResult](../classes/QuickJSContext.md#unwrapresult).
+Unwrapping a pending promise will throw a [QuickJSPromisePending]([object Object]) error.
+
+#### Returns
+
+`Error`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:684
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten/interfaces/JSPromiseStateRejected.md
+++ b/doc/quickjs-emscripten/interfaces/JSPromiseStateRejected.md
@@ -1,0 +1,40 @@
+[quickjs-emscripten](../../packages.md) • **quickjs-emscripten** • [Readme](../README.md) \| [Exports](../exports.md)
+
+***
+
+[quickjs-emscripten](../../packages.md) / [quickjs-emscripten](../exports.md) / JSPromiseStateRejected
+
+# Interface: JSPromiseStateRejected
+
+Rejected promise state.
+See [JSPromiseState](../exports.md#jspromisestate).
+
+## Contents
+
+- [Properties](JSPromiseStateRejected.md#properties)
+  - [error](JSPromiseStateRejected.md#error)
+  - [type](JSPromiseStateRejected.md#type)
+
+## Properties
+
+### error
+
+> **error**: [`QuickJSHandle`](../exports.md#quickjshandle)
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:703
+
+***
+
+### type
+
+> **type**: `"rejected"`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:702
+
+***
+
+Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
@@ -27,7 +27,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1275
+packages/quickjs-emscripten-core/dist/index.d.ts:1285
 
 ***
 
@@ -39,7 +39,7 @@ Memory limit, in bytes, of WebAssembly heap memory used by the QuickJS VM.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1270
+packages/quickjs-emscripten-core/dist/index.d.ts:1280
 
 ***
 
@@ -51,7 +51,7 @@ Module loader for any `import` statements or expressions.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1279
+packages/quickjs-emscripten-core/dist/index.d.ts:1289
 
 ***
 
@@ -64,7 +64,7 @@ See [shouldInterruptAfterDeadline](../exports.md#shouldinterruptafterdeadline).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1266
+packages/quickjs-emscripten-core/dist/index.d.ts:1276
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
@@ -27,7 +27,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1242
+packages/quickjs-emscripten-core/dist/index.d.ts:1263
 
 ***
 
@@ -39,7 +39,7 @@ Memory limit, in bytes, of WebAssembly heap memory used by the QuickJS VM.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1237
+packages/quickjs-emscripten-core/dist/index.d.ts:1258
 
 ***
 
@@ -51,7 +51,7 @@ Module loader for any `import` statements or expressions.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1246
+packages/quickjs-emscripten-core/dist/index.d.ts:1267
 
 ***
 
@@ -64,7 +64,7 @@ See [shouldInterruptAfterDeadline](../exports.md#shouldinterruptafterdeadline).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1233
+packages/quickjs-emscripten-core/dist/index.d.ts:1254
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
@@ -27,7 +27,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1298
+packages/quickjs-emscripten-core/dist/index.d.ts:1313
 
 ***
 
@@ -39,7 +39,7 @@ Memory limit, in bytes, of WebAssembly heap memory used by the QuickJS VM.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1293
+packages/quickjs-emscripten-core/dist/index.d.ts:1308
 
 ***
 
@@ -51,7 +51,7 @@ Module loader for any `import` statements or expressions.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1302
+packages/quickjs-emscripten-core/dist/index.d.ts:1317
 
 ***
 
@@ -64,7 +64,7 @@ See [shouldInterruptAfterDeadline](../exports.md#shouldinterruptafterdeadline).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1289
+packages/quickjs-emscripten-core/dist/index.d.ts:1304
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
@@ -27,7 +27,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1285
+packages/quickjs-emscripten-core/dist/index.d.ts:1298
 
 ***
 
@@ -39,7 +39,7 @@ Memory limit, in bytes, of WebAssembly heap memory used by the QuickJS VM.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1280
+packages/quickjs-emscripten-core/dist/index.d.ts:1293
 
 ***
 
@@ -51,7 +51,7 @@ Module loader for any `import` statements or expressions.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1289
+packages/quickjs-emscripten-core/dist/index.d.ts:1302
 
 ***
 
@@ -64,7 +64,7 @@ See [shouldInterruptAfterDeadline](../exports.md#shouldinterruptafterdeadline).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1276
+packages/quickjs-emscripten-core/dist/index.d.ts:1289
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
+++ b/doc/quickjs-emscripten/interfaces/ModuleEvalOptions.md
@@ -27,7 +27,7 @@ To remove the limit, set to `0`.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1263
+packages/quickjs-emscripten-core/dist/index.d.ts:1275
 
 ***
 
@@ -39,7 +39,7 @@ Memory limit, in bytes, of WebAssembly heap memory used by the QuickJS VM.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1258
+packages/quickjs-emscripten-core/dist/index.d.ts:1270
 
 ***
 
@@ -51,7 +51,7 @@ Module loader for any `import` statements or expressions.
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1267
+packages/quickjs-emscripten-core/dist/index.d.ts:1279
 
 ***
 
@@ -64,7 +64,7 @@ See [shouldInterruptAfterDeadline](../exports.md#shouldinterruptafterdeadline).
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1254
+packages/quickjs-emscripten-core/dist/index.d.ts:1266
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -55,7 +55,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:252
+packages/quickjs-ffi-types/dist/index.d.ts:261
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:252
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:243
+packages/quickjs-ffi-types/dist/index.d.ts:252
 
 ***
 
@@ -83,7 +83,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:243
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:244
+packages/quickjs-ffi-types/dist/index.d.ts:253
 
 ***
 
@@ -97,7 +97,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:244
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:242
+packages/quickjs-ffi-types/dist/index.d.ts:251
 
 ***
 
@@ -111,7 +111,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:242
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:248
+packages/quickjs-ffi-types/dist/index.d.ts:257
 
 ***
 
@@ -125,7 +125,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:248
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:249
+packages/quickjs-ffi-types/dist/index.d.ts:258
 
 ***
 
@@ -139,7 +139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:249
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:246
+packages/quickjs-ffi-types/dist/index.d.ts:255
 
 ***
 
@@ -153,7 +153,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:246
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:247
+packages/quickjs-ffi-types/dist/index.d.ts:256
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:247
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:245
+packages/quickjs-ffi-types/dist/index.d.ts:254
 
 ***
 
@@ -181,7 +181,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:245
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:251
+packages/quickjs-ffi-types/dist/index.d.ts:260
 
 ***
 
@@ -195,7 +195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:251
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:250
+packages/quickjs-ffi-types/dist/index.d.ts:259
 
 ***
 
@@ -205,7 +205,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:250
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
+packages/quickjs-ffi-types/dist/index.d.ts:302
 
 ***
 
@@ -219,7 +219,7 @@ Implement this field
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:301
 
 ***
 
@@ -235,7 +235,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -251,7 +251,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -278,7 +278,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:237
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -300,7 +300,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:237
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:240
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -322,7 +322,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:240
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:239
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -359,7 +359,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:239
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:241
+packages/quickjs-ffi-types/dist/index.d.ts:250
 
 ***
 
@@ -385,7 +385,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -407,7 +407,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:238
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -451,7 +451,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -475,7 +475,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 
@@ -504,7 +504,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:232
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
@@ -63,6 +63,8 @@ library.
   - [QTS\_NewRuntime](QuickJSAsyncFFI.md#qts-newruntime)
   - [QTS\_NewString](QuickJSAsyncFFI.md#qts-newstring)
   - [QTS\_NewSymbol](QuickJSAsyncFFI.md#qts-newsymbol)
+  - [QTS\_PromiseResult](QuickJSAsyncFFI.md#qts-promiseresult)
+  - [QTS\_PromiseState](QuickJSAsyncFFI.md#qts-promisestate)
   - [QTS\_RecoverableLeakCheck](QuickJSAsyncFFI.md#qts-recoverableleakcheck)
   - [QTS\_ResolveException](QuickJSAsyncFFI.md#qts-resolveexception)
   - [QTS\_RuntimeComputeMemoryUsage](QuickJSAsyncFFI.md#qts-runtimecomputememoryusage)
@@ -95,7 +97,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -115,7 +117,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:451
 
 ***
 
@@ -129,7 +131,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:449
 
 ***
 
@@ -143,7 +145,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:436
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:435
+packages/quickjs-ffi-types/dist/index.d.ts:448
 
 ***
 
@@ -157,7 +159,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:435
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -183,7 +185,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:423
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -209,7 +211,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:423
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:424
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -243,7 +245,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:424
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:422
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -263,7 +265,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:422
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:426
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -283,7 +285,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:426
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:427
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 
@@ -303,7 +305,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:427
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 
@@ -331,7 +333,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:428
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -359,7 +361,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:428
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:429
+packages/quickjs-ffi-types/dist/index.d.ts:440
 
 ***
 
@@ -381,7 +383,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:429
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -403,7 +405,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:417
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
@@ -423,7 +425,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -441,7 +443,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -459,7 +461,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -479,7 +481,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -499,7 +501,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -519,7 +521,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -539,7 +541,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:420
 
 ***
 
@@ -559,7 +561,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:421
 
 ***
 
@@ -573,7 +575,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -593,7 +595,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:417
 
 ***
 
@@ -611,7 +613,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:432
+packages/quickjs-ffi-types/dist/index.d.ts:443
 
 ***
 
@@ -631,7 +633,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:432
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:430
+packages/quickjs-ffi-types/dist/index.d.ts:441
 
 ***
 
@@ -645,7 +647,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:430
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
@@ -667,7 +669,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:418
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -689,7 +691,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:419
+packages/quickjs-ffi-types/dist/index.d.ts:430
 
 ***
 
@@ -709,7 +711,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:419
 
 ***
 
@@ -729,7 +731,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:423
 
 ***
 
@@ -749,7 +751,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -763,7 +765,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -777,7 +779,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -797,7 +799,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -815,7 +817,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -833,7 +835,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:414
 
 ***
 
@@ -855,7 +857,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:415
 
 ***
 
@@ -875,7 +877,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -893,7 +895,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -913,7 +915,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:416
 
 ***
 
@@ -935,7 +937,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:450
 
 ***
 
@@ -953,7 +955,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -973,7 +975,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:413
 
 ***
 
@@ -993,7 +995,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:433
+packages/quickjs-ffi-types/dist/index.d.ts:444
 
 ***
 
@@ -1007,7 +1009,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:433
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -1027,7 +1029,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:418
 
 ***
 
@@ -1049,7 +1051,47 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:422
+
+***
+
+### QTS\_PromiseResult
+
+> **QTS\_PromiseResult**: (`ctx`, `promise`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:446
+
+***
+
+### QTS\_PromiseState
+
+> **QTS\_PromiseState**: (`ctx`, `promise`) => [`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:445
 
 ***
 
@@ -1063,7 +1105,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -1083,7 +1125,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:425
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -1103,7 +1145,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:425
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -1121,7 +1163,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:440
+packages/quickjs-ffi-types/dist/index.d.ts:453
 
 ***
 
@@ -1139,7 +1181,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:440
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:442
+packages/quickjs-ffi-types/dist/index.d.ts:455
 
 ***
 
@@ -1157,7 +1199,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:442
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -1175,7 +1217,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:439
+packages/quickjs-ffi-types/dist/index.d.ts:452
 
 ***
 
@@ -1195,7 +1237,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:439
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:441
+packages/quickjs-ffi-types/dist/index.d.ts:454
 
 ***
 
@@ -1215,7 +1257,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:441
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -1235,7 +1277,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -1259,7 +1301,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:420
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -1283,7 +1325,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:421
+packages/quickjs-ffi-types/dist/index.d.ts:432
 
 ***
 
@@ -1301,7 +1343,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:434
+packages/quickjs-ffi-types/dist/index.d.ts:447
 
 ***
 
@@ -1321,7 +1363,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:434
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -1341,7 +1383,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:431
+packages/quickjs-ffi-types/dist/index.d.ts:442
 
 ***
 
@@ -1361,7 +1403,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:431
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:444
+packages/quickjs-ffi-types/dist/index.d.ts:457
 
 ***
 
@@ -1381,7 +1423,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:444
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:443
+packages/quickjs-ffi-types/dist/index.d.ts:456
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
@@ -40,6 +40,7 @@ library.
   - [QTS\_GetFalse](QuickJSAsyncFFI.md#qts-getfalse)
   - [QTS\_GetFloat64](QuickJSAsyncFFI.md#qts-getfloat64)
   - [QTS\_GetGlobalObject](QuickJSAsyncFFI.md#qts-getglobalobject)
+  - [QTS\_GetModuleNamespace](QuickJSAsyncFFI.md#qts-getmodulenamespace)
   - [QTS\_GetNull](QuickJSAsyncFFI.md#qts-getnull)
   - [QTS\_GetProp](QuickJSAsyncFFI.md#qts-getprop)
   - [QTS\_GetProp\_MaybeAsync](QuickJSAsyncFFI.md#qts-getprop-maybeasync)
@@ -94,7 +95,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:378
+packages/quickjs-ffi-types/dist/index.d.ts:379
 
 ***
 
@@ -114,7 +115,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:378
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 
@@ -128,7 +129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:436
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:434
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -142,7 +143,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:434
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:433
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -156,7 +157,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:433
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:386
 
 ***
 
@@ -182,7 +183,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:422
+packages/quickjs-ffi-types/dist/index.d.ts:423
 
 ***
 
@@ -208,7 +209,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:422
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:423
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -242,7 +243,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:423
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:421
+packages/quickjs-ffi-types/dist/index.d.ts:422
 
 ***
 
@@ -262,7 +263,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:421
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:425
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -282,7 +283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:425
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:426
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -302,19 +303,21 @@ packages/quickjs-ffi-types/dist/index.d.ts:426
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
 ### QTS\_Eval
 
-> **QTS\_Eval**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+> **QTS\_Eval**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -328,19 +331,21 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:427
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
 ### QTS\_Eval\_MaybeAsync
 
-> **QTS\_Eval\_MaybeAsync**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer) \| `Promise`\<[`JSValuePointer`](../exports.md#jsvaluepointer)\>
+> **QTS\_Eval\_MaybeAsync**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer) \| `Promise`\<[`JSValuePointer`](../exports.md#jsvaluepointer)\>
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -354,7 +359,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:427
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:428
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -376,7 +381,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:428
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:416
 
 ***
 
@@ -398,7 +403,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:417
 
 ***
 
@@ -418,7 +423,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -436,7 +441,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -454,7 +459,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -474,7 +479,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -494,7 +499,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -514,7 +519,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -534,7 +539,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -554,7 +559,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -568,7 +573,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -588,7 +593,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -599,6 +604,26 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:432
+
+***
+
+### QTS\_GetModuleNamespace
+
+> **QTS\_GetModuleNamespace**: (`ctx`, `module_func_obj`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **module\_func\_obj**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Returns
 
@@ -620,7 +645,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:430
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:389
 
 ***
 
@@ -642,7 +667,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:417
+packages/quickjs-ffi-types/dist/index.d.ts:418
 
 ***
 
@@ -664,7 +689,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:418
+packages/quickjs-ffi-types/dist/index.d.ts:419
 
 ***
 
@@ -684,7 +709,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:418
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -704,7 +729,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -724,7 +749,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:413
 
 ***
 
@@ -738,7 +763,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -752,7 +777,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:388
 
 ***
 
@@ -772,7 +797,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:414
 
 ***
 
@@ -790,7 +815,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:415
 
 ***
 
@@ -808,7 +833,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -830,7 +855,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -850,7 +875,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -868,7 +893,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:381
 
 ***
 
@@ -888,7 +913,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -910,7 +935,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:435
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -928,7 +953,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:435
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -948,7 +973,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -968,7 +993,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:431
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -982,7 +1007,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:431
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -1002,7 +1027,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -1024,7 +1049,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 
@@ -1038,7 +1063,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:385
 
 ***
 
@@ -1058,7 +1083,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:424
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -1078,7 +1103,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:424
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:383
 
 ***
 
@@ -1096,7 +1121,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:440
 
 ***
 
@@ -1114,7 +1139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:440
+packages/quickjs-ffi-types/dist/index.d.ts:442
 
 ***
 
@@ -1132,7 +1157,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:440
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:384
 
 ***
 
@@ -1150,7 +1175,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -1170,7 +1195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:439
+packages/quickjs-ffi-types/dist/index.d.ts:441
 
 ***
 
@@ -1190,7 +1215,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:439
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:387
 
 ***
 
@@ -1210,7 +1235,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:382
 
 ***
 
@@ -1234,7 +1259,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:419
+packages/quickjs-ffi-types/dist/index.d.ts:420
 
 ***
 
@@ -1258,7 +1283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:420
+packages/quickjs-ffi-types/dist/index.d.ts:421
 
 ***
 
@@ -1276,7 +1301,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:420
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:432
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -1296,7 +1321,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:432
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:380
 
 ***
 
@@ -1316,7 +1341,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:429
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -1336,7 +1361,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:429
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:442
+packages/quickjs-ffi-types/dist/index.d.ts:444
 
 ***
 
@@ -1356,7 +1381,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:442
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:441
+packages/quickjs-ffi-types/dist/index.d.ts:443
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:479
+packages/quickjs-ffi-types/dist/index.d.ts:492
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:479
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:480
+packages/quickjs-ffi-types/dist/index.d.ts:493
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:480
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:478
+packages/quickjs-ffi-types/dist/index.d.ts:491
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:477
+packages/quickjs-ffi-types/dist/index.d.ts:479
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:477
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:478
+packages/quickjs-ffi-types/dist/index.d.ts:480
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:478
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:476
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSEmscriptenModule.md
@@ -55,7 +55,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:252
+packages/quickjs-ffi-types/dist/index.d.ts:261
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:252
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:243
+packages/quickjs-ffi-types/dist/index.d.ts:252
 
 ***
 
@@ -83,7 +83,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:243
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:244
+packages/quickjs-ffi-types/dist/index.d.ts:253
 
 ***
 
@@ -97,7 +97,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:244
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:242
+packages/quickjs-ffi-types/dist/index.d.ts:251
 
 ***
 
@@ -111,7 +111,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:242
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:248
+packages/quickjs-ffi-types/dist/index.d.ts:257
 
 ***
 
@@ -125,7 +125,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:248
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:249
+packages/quickjs-ffi-types/dist/index.d.ts:258
 
 ***
 
@@ -139,7 +139,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:249
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:246
+packages/quickjs-ffi-types/dist/index.d.ts:255
 
 ***
 
@@ -153,7 +153,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:246
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:247
+packages/quickjs-ffi-types/dist/index.d.ts:256
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:247
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:245
+packages/quickjs-ffi-types/dist/index.d.ts:254
 
 ***
 
@@ -181,7 +181,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:245
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:251
+packages/quickjs-ffi-types/dist/index.d.ts:260
 
 ***
 
@@ -195,7 +195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:251
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:250
+packages/quickjs-ffi-types/dist/index.d.ts:259
 
 ***
 
@@ -205,7 +205,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:250
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:297
 
 ***
 
@@ -215,7 +215,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:287
+packages/quickjs-ffi-types/dist/index.d.ts:296
 
 ***
 
@@ -231,7 +231,7 @@ Compile this to WebAssembly.Module
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:209
+packages/quickjs-ffi-types/dist/index.d.ts:218
 
 ***
 
@@ -247,7 +247,7 @@ If provided, use this WebAssembly.Memory instead of an automatically created one
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:211
+packages/quickjs-ffi-types/dist/index.d.ts:220
 
 ## Methods
 
@@ -274,7 +274,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:237
+packages/quickjs-ffi-types/dist/index.d.ts:246
 
 ***
 
@@ -296,7 +296,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:237
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:240
+packages/quickjs-ffi-types/dist/index.d.ts:249
 
 ***
 
@@ -318,7 +318,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:240
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:239
+packages/quickjs-ffi-types/dist/index.d.ts:248
 
 ***
 
@@ -355,7 +355,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:239
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:241
+packages/quickjs-ffi-types/dist/index.d.ts:250
 
 ***
 
@@ -381,7 +381,7 @@ Create an instance of the WASM module, call onSuccess(instance), then return ins
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:213
+packages/quickjs-ffi-types/dist/index.d.ts:222
 
 ***
 
@@ -403,7 +403,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:213
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:238
+packages/quickjs-ffi-types/dist/index.d.ts:247
 
 ***
 
@@ -447,7 +447,7 @@ Often `''` (empty string)
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:205
+packages/quickjs-ffi-types/dist/index.d.ts:214
 
 ***
 
@@ -471,7 +471,7 @@ Called by emscripten as dependencies blocking initialization are added or fulfil
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:215
+packages/quickjs-ffi-types/dist/index.d.ts:224
 
 ***
 
@@ -500,7 +500,7 @@ https://emscripten.org/docs/api_reference/preamble.js.html#stringToUTF8
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:232
+packages/quickjs-ffi-types/dist/index.d.ts:241
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
@@ -57,6 +57,8 @@ library.
   - [QTS\_NewRuntime](QuickJSFFI.md#qts-newruntime)
   - [QTS\_NewString](QuickJSFFI.md#qts-newstring)
   - [QTS\_NewSymbol](QuickJSFFI.md#qts-newsymbol)
+  - [QTS\_PromiseResult](QuickJSFFI.md#qts-promiseresult)
+  - [QTS\_PromiseState](QuickJSFFI.md#qts-promisestate)
   - [QTS\_RecoverableLeakCheck](QuickJSFFI.md#qts-recoverableleakcheck)
   - [QTS\_ResolveException](QuickJSFFI.md#qts-resolveexception)
   - [QTS\_RuntimeComputeMemoryUsage](QuickJSFFI.md#qts-runtimecomputememoryusage)
@@ -88,7 +90,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:309
+packages/quickjs-ffi-types/dist/index.d.ts:318
 
 ***
 
@@ -108,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:309
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:372
 
 ***
 
@@ -122,7 +124,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:370
 
 ***
 
@@ -136,7 +138,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:359
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:369
 
 ***
 
@@ -150,7 +152,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:316
+packages/quickjs-ffi-types/dist/index.d.ts:325
 
 ***
 
@@ -176,7 +178,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:316
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:349
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -210,7 +212,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:349
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:348
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -230,7 +232,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:348
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:351
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -250,7 +252,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:351
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:330
+packages/quickjs-ffi-types/dist/index.d.ts:339
 
 ***
 
@@ -278,7 +280,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:352
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -300,7 +302,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:352
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:345
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -320,7 +322,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:345
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:329
+packages/quickjs-ffi-types/dist/index.d.ts:338
 
 ***
 
@@ -338,7 +340,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:329
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:325
+packages/quickjs-ffi-types/dist/index.d.ts:334
 
 ***
 
@@ -356,7 +358,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:325
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:323
+packages/quickjs-ffi-types/dist/index.d.ts:332
 
 ***
 
@@ -376,7 +378,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:323
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:326
+packages/quickjs-ffi-types/dist/index.d.ts:335
 
 ***
 
@@ -396,7 +398,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:326
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:327
+packages/quickjs-ffi-types/dist/index.d.ts:336
 
 ***
 
@@ -416,7 +418,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:327
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:328
+packages/quickjs-ffi-types/dist/index.d.ts:337
 
 ***
 
@@ -436,7 +438,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:328
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:339
+packages/quickjs-ffi-types/dist/index.d.ts:348
 
 ***
 
@@ -456,7 +458,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:339
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:340
+packages/quickjs-ffi-types/dist/index.d.ts:349
 
 ***
 
@@ -470,7 +472,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:340
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:320
+packages/quickjs-ffi-types/dist/index.d.ts:329
 
 ***
 
@@ -490,7 +492,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:320
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:336
+packages/quickjs-ffi-types/dist/index.d.ts:345
 
 ***
 
@@ -508,7 +510,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:336
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:364
 
 ***
 
@@ -528,7 +530,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:355
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 
@@ -542,7 +544,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:319
+packages/quickjs-ffi-types/dist/index.d.ts:328
 
 ***
 
@@ -564,7 +566,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:319
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:346
+packages/quickjs-ffi-types/dist/index.d.ts:355
 
 ***
 
@@ -584,7 +586,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:346
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:338
+packages/quickjs-ffi-types/dist/index.d.ts:347
 
 ***
 
@@ -604,7 +606,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:338
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:342
+packages/quickjs-ffi-types/dist/index.d.ts:351
 
 ***
 
@@ -618,7 +620,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:342
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:321
+packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ***
 
@@ -632,7 +634,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:321
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:318
+packages/quickjs-ffi-types/dist/index.d.ts:327
 
 ***
 
@@ -652,7 +654,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:318
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:343
+packages/quickjs-ffi-types/dist/index.d.ts:352
 
 ***
 
@@ -670,7 +672,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:343
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:344
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -688,7 +690,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:344
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:333
+packages/quickjs-ffi-types/dist/index.d.ts:342
 
 ***
 
@@ -710,7 +712,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:333
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:334
+packages/quickjs-ffi-types/dist/index.d.ts:343
 
 ***
 
@@ -730,7 +732,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:334
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:324
+packages/quickjs-ffi-types/dist/index.d.ts:333
 
 ***
 
@@ -748,7 +750,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:324
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:311
+packages/quickjs-ffi-types/dist/index.d.ts:320
 
 ***
 
@@ -768,7 +770,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:311
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:335
+packages/quickjs-ffi-types/dist/index.d.ts:344
 
 ***
 
@@ -790,7 +792,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:335
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:371
 
 ***
 
@@ -808,7 +810,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:331
+packages/quickjs-ffi-types/dist/index.d.ts:340
 
 ***
 
@@ -828,7 +830,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:331
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:332
+packages/quickjs-ffi-types/dist/index.d.ts:341
 
 ***
 
@@ -848,7 +850,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:332
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:365
 
 ***
 
@@ -862,7 +864,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:356
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:322
+packages/quickjs-ffi-types/dist/index.d.ts:331
 
 ***
 
@@ -882,7 +884,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:322
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:337
+packages/quickjs-ffi-types/dist/index.d.ts:346
 
 ***
 
@@ -904,7 +906,47 @@ packages/quickjs-ffi-types/dist/index.d.ts:337
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:341
+packages/quickjs-ffi-types/dist/index.d.ts:350
+
+***
+
+### QTS\_PromiseResult
+
+> **QTS\_PromiseResult**: (`ctx`, `promise`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:367
+
+***
+
+### QTS\_PromiseState
+
+> **QTS\_PromiseState**: (`ctx`, `promise`) => [`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **promise**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSPromiseStateEnum`](../exports.md#jspromisestateenum-1)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:366
 
 ***
 
@@ -918,7 +960,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:341
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:315
+packages/quickjs-ffi-types/dist/index.d.ts:324
 
 ***
 
@@ -938,7 +980,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:315
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:350
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -958,7 +1000,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:350
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:313
+packages/quickjs-ffi-types/dist/index.d.ts:322
 
 ***
 
@@ -976,7 +1018,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:313
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:374
 
 ***
 
@@ -994,7 +1036,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:363
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:376
 
 ***
 
@@ -1012,7 +1054,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:365
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:314
+packages/quickjs-ffi-types/dist/index.d.ts:323
 
 ***
 
@@ -1030,7 +1072,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:314
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:373
 
 ***
 
@@ -1050,7 +1092,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:375
 
 ***
 
@@ -1070,7 +1112,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:364
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:317
+packages/quickjs-ffi-types/dist/index.d.ts:326
 
 ***
 
@@ -1090,7 +1132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:317
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:312
+packages/quickjs-ffi-types/dist/index.d.ts:321
 
 ***
 
@@ -1114,7 +1156,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:312
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:347
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -1132,7 +1174,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:347
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:368
 
 ***
 
@@ -1152,7 +1194,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:357
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:310
+packages/quickjs-ffi-types/dist/index.d.ts:319
 
 ***
 
@@ -1172,7 +1214,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:310
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -1192,7 +1234,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:354
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:367
+packages/quickjs-ffi-types/dist/index.d.ts:378
 
 ***
 
@@ -1212,7 +1254,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:367
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:377
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
@@ -36,6 +36,7 @@ library.
   - [QTS\_GetFalse](QuickJSFFI.md#qts-getfalse)
   - [QTS\_GetFloat64](QuickJSFFI.md#qts-getfloat64)
   - [QTS\_GetGlobalObject](QuickJSFFI.md#qts-getglobalobject)
+  - [QTS\_GetModuleNamespace](QuickJSFFI.md#qts-getmodulenamespace)
   - [QTS\_GetNull](QuickJSFFI.md#qts-getnull)
   - [QTS\_GetProp](QuickJSFFI.md#qts-getprop)
   - [QTS\_GetString](QuickJSFFI.md#qts-getstring)
@@ -107,7 +108,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:309
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -121,7 +122,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -135,7 +136,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -255,13 +256,15 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ### QTS\_Eval
 
-> **QTS\_Eval**: (`ctx`, `js_code`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+> **QTS\_Eval**: (`ctx`, `js_code`, `js_code_length`, `filename`, `detectModule`, `evalFlags`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
 
 #### Parameters
 
 • **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
 
 • **js\_code**: [`BorrowedHeapCharPointer`](../exports.md#borrowedheapcharpointer)
+
+• **js\_code\_length**: `number`
 
 • **filename**: `string`
 
@@ -505,7 +508,27 @@ packages/quickjs-ffi-types/dist/index.d.ts:336
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:355
+
+***
+
+### QTS\_GetModuleNamespace
+
+> **QTS\_GetModuleNamespace**: (`ctx`, `module_func_obj`) => [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Parameters
+
+• **ctx**: [`JSContextPointer`](../exports.md#jscontextpointer)
+
+• **module\_func\_obj**: [`JSValueConstPointer`](../exports.md#jsvalueconstpointer) \| [`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Returns
+
+[`JSValuePointer`](../exports.md#jsvaluepointer)
+
+#### Source
+
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -767,7 +790,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:335
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -825,7 +848,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:332
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -953,7 +976,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:313
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -971,7 +994,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:365
 
 ***
 
@@ -1007,7 +1030,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:314
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 
@@ -1027,7 +1050,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:364
 
 ***
 
@@ -1109,7 +1132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:347
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -1149,7 +1172,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:310
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -1169,7 +1192,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:367
 
 ***
 
@@ -1189,7 +1212,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:366
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:366
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:463
+packages/quickjs-ffi-types/dist/index.d.ts:465
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:463
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:464
+packages/quickjs-ffi-types/dist/index.d.ts:466
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:464
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:462
+packages/quickjs-ffi-types/dist/index.d.ts:464
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:465
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:465
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:466
+packages/quickjs-ffi-types/dist/index.d.ts:479
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:466
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:464
+packages/quickjs-ffi-types/dist/index.d.ts:477
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/RuntimeOptions.md
+++ b/doc/quickjs-emscripten/interfaces/RuntimeOptions.md
@@ -35,7 +35,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:417
+packages/quickjs-emscripten-core/dist/index.d.ts:420
 
 ***
 
@@ -49,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:412
+packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 ***
 
@@ -63,7 +63,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:413
+packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 ***
 
@@ -77,7 +77,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:414
+packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 ***
 
@@ -87,7 +87,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:431
+packages/quickjs-emscripten-core/dist/index.d.ts:434
 
 ***
 
@@ -101,7 +101,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:431
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:415
+packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 ***
 
@@ -115,7 +115,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:416
+packages/quickjs-emscripten-core/dist/index.d.ts:419
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:418
+packages/quickjs-emscripten-core/dist/index.d.ts:421
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/RuntimeOptionsBase.md
+++ b/doc/quickjs-emscripten/interfaces/RuntimeOptionsBase.md
@@ -31,7 +31,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:417
+packages/quickjs-emscripten-core/dist/index.d.ts:420
 
 ***
 
@@ -41,7 +41,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:412
+packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 ***
 
@@ -51,7 +51,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:413
+packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 ***
 
@@ -61,7 +61,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:414
+packages/quickjs-emscripten-core/dist/index.d.ts:417
 
 ***
 
@@ -71,7 +71,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:415
+packages/quickjs-emscripten-core/dist/index.d.ts:418
 
 ***
 
@@ -81,7 +81,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:416
+packages/quickjs-emscripten-core/dist/index.d.ts:419
 
 ***
 
@@ -91,7 +91,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:418
+packages/quickjs-emscripten-core/dist/index.d.ts:421
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/SourceMapData.md
+++ b/doc/quickjs-emscripten/interfaces/SourceMapData.md
@@ -22,7 +22,7 @@
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:168
+packages/quickjs-ffi-types/dist/index.d.ts:177
 
 ***
 
@@ -32,7 +32,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:168
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:167
+packages/quickjs-ffi-types/dist/index.d.ts:176
 
 ***
 
@@ -42,7 +42,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:167
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:166
+packages/quickjs-ffi-types/dist/index.d.ts:175
 
 ***
 
@@ -52,7 +52,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:166
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:165
+packages/quickjs-ffi-types/dist/index.d.ts:174
 
 ***
 

--- a/doc/quickjs-emscripten/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten/namespaces/errors/README.md
@@ -39,7 +39,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1606
+packages/quickjs-emscripten-core/dist/index.d.ts:1621
 
 ***
 
@@ -49,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1606
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1608
+packages/quickjs-emscripten-core/dist/index.d.ts:1623
 
 ***
 
@@ -59,7 +59,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1608
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1610
+packages/quickjs-emscripten-core/dist/index.d.ts:1625
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1610
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1612
+packages/quickjs-emscripten-core/dist/index.d.ts:1627
 
 ***
 
@@ -79,7 +79,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1612
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1614
+packages/quickjs-emscripten-core/dist/index.d.ts:1629
 
 ***
 
@@ -89,7 +89,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1614
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1616
+packages/quickjs-emscripten-core/dist/index.d.ts:1631
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1616
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1618
+packages/quickjs-emscripten-core/dist/index.d.ts:1633
 
 ***
 
@@ -109,7 +109,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1618
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1620
+packages/quickjs-emscripten-core/dist/index.d.ts:1635
 
 ***
 
@@ -119,7 +119,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1620
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1622
+packages/quickjs-emscripten-core/dist/index.d.ts:1637
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1622
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1624
+packages/quickjs-emscripten-core/dist/index.d.ts:1639
 
 ## Variables
 
@@ -139,7 +139,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1624
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1606
+packages/quickjs-emscripten-core/dist/index.d.ts:1621
 
 ***
 
@@ -149,7 +149,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1606
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1608
+packages/quickjs-emscripten-core/dist/index.d.ts:1623
 
 ***
 
@@ -159,7 +159,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1608
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1610
+packages/quickjs-emscripten-core/dist/index.d.ts:1625
 
 ***
 
@@ -169,7 +169,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1610
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1612
+packages/quickjs-emscripten-core/dist/index.d.ts:1627
 
 ***
 
@@ -179,7 +179,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1612
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1614
+packages/quickjs-emscripten-core/dist/index.d.ts:1629
 
 ***
 
@@ -189,7 +189,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1614
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1616
+packages/quickjs-emscripten-core/dist/index.d.ts:1631
 
 ***
 
@@ -199,7 +199,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1616
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1618
+packages/quickjs-emscripten-core/dist/index.d.ts:1633
 
 ***
 
@@ -209,7 +209,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1618
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1620
+packages/quickjs-emscripten-core/dist/index.d.ts:1635
 
 ***
 
@@ -219,7 +219,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1620
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1622
+packages/quickjs-emscripten-core/dist/index.d.ts:1637
 
 ***
 
@@ -229,7 +229,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1622
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1624
+packages/quickjs-emscripten-core/dist/index.d.ts:1639
 
 ***
 

--- a/doc/quickjs-emscripten/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten/namespaces/errors/README.md
@@ -39,7 +39,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1593
+packages/quickjs-emscripten-core/dist/index.d.ts:1606
 
 ***
 
@@ -49,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1593
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1595
+packages/quickjs-emscripten-core/dist/index.d.ts:1608
 
 ***
 
@@ -59,7 +59,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1595
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1597
+packages/quickjs-emscripten-core/dist/index.d.ts:1610
 
 ***
 
@@ -69,7 +69,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1597
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1599
+packages/quickjs-emscripten-core/dist/index.d.ts:1612
 
 ***
 
@@ -79,7 +79,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1599
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1601
+packages/quickjs-emscripten-core/dist/index.d.ts:1614
 
 ***
 
@@ -89,7 +89,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1601
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1603
+packages/quickjs-emscripten-core/dist/index.d.ts:1616
 
 ***
 
@@ -99,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1603
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1605
+packages/quickjs-emscripten-core/dist/index.d.ts:1618
 
 ***
 
@@ -109,7 +109,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1605
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1607
+packages/quickjs-emscripten-core/dist/index.d.ts:1620
 
 ***
 
@@ -119,7 +119,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1607
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1609
+packages/quickjs-emscripten-core/dist/index.d.ts:1622
 
 ***
 
@@ -129,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1609
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1611
+packages/quickjs-emscripten-core/dist/index.d.ts:1624
 
 ## Variables
 
@@ -139,7 +139,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1611
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1593
+packages/quickjs-emscripten-core/dist/index.d.ts:1606
 
 ***
 
@@ -149,7 +149,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1593
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1595
+packages/quickjs-emscripten-core/dist/index.d.ts:1608
 
 ***
 
@@ -159,7 +159,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1595
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1597
+packages/quickjs-emscripten-core/dist/index.d.ts:1610
 
 ***
 
@@ -169,7 +169,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1597
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1599
+packages/quickjs-emscripten-core/dist/index.d.ts:1612
 
 ***
 
@@ -179,7 +179,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1599
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1601
+packages/quickjs-emscripten-core/dist/index.d.ts:1614
 
 ***
 
@@ -189,7 +189,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1601
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1603
+packages/quickjs-emscripten-core/dist/index.d.ts:1616
 
 ***
 
@@ -199,7 +199,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1603
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1605
+packages/quickjs-emscripten-core/dist/index.d.ts:1618
 
 ***
 
@@ -209,7 +209,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1605
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1607
+packages/quickjs-emscripten-core/dist/index.d.ts:1620
 
 ***
 
@@ -219,7 +219,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1607
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1609
+packages/quickjs-emscripten-core/dist/index.d.ts:1622
 
 ***
 
@@ -229,7 +229,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1609
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1611
+packages/quickjs-emscripten-core/dist/index.d.ts:1624
 
 ***
 

--- a/doc/quickjs-emscripten/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten/namespaces/errors/README.md
@@ -14,6 +14,7 @@
   - [QuickJSEmscriptenModuleError](README.md#quickjsemscriptenmoduleerror)
   - [QuickJSMemoryLeakDetected](README.md#quickjsmemoryleakdetected)
   - [QuickJSNotImplemented](README.md#quickjsnotimplemented)
+  - [QuickJSPromisePending](README.md#quickjspromisepending)
   - [QuickJSUnknownIntrinsic](README.md#quickjsunknownintrinsic)
   - [QuickJSUnwrapError](README.md#quickjsunwraperror)
   - [QuickJSUseAfterFree](README.md#quickjsuseafterfree)
@@ -24,6 +25,7 @@
   - [QuickJSEmscriptenModuleError](README.md#quickjsemscriptenmoduleerror-1)
   - [QuickJSMemoryLeakDetected](README.md#quickjsmemoryleakdetected-1)
   - [QuickJSNotImplemented](README.md#quickjsnotimplemented-1)
+  - [QuickJSPromisePending](README.md#quickjspromisepending-1)
   - [QuickJSUnknownIntrinsic](README.md#quickjsunknownintrinsic-1)
   - [QuickJSUnwrapError](README.md#quickjsunwraperror-1)
   - [QuickJSUseAfterFree](README.md#quickjsuseafterfree-1)
@@ -37,7 +39,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1580
+packages/quickjs-emscripten-core/dist/index.d.ts:1593
 
 ***
 
@@ -47,7 +49,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1582
+packages/quickjs-emscripten-core/dist/index.d.ts:1595
 
 ***
 
@@ -57,7 +59,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1584
+packages/quickjs-emscripten-core/dist/index.d.ts:1597
 
 ***
 
@@ -67,7 +69,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1586
+packages/quickjs-emscripten-core/dist/index.d.ts:1599
 
 ***
 
@@ -77,7 +79,17 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1586
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1588
+packages/quickjs-emscripten-core/dist/index.d.ts:1601
+
+***
+
+### QuickJSPromisePending
+
+> **QuickJSPromisePending**: `QuickJSPromisePending`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:1603
 
 ***
 
@@ -87,7 +99,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1588
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1590
+packages/quickjs-emscripten-core/dist/index.d.ts:1605
 
 ***
 
@@ -97,7 +109,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1590
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1592
+packages/quickjs-emscripten-core/dist/index.d.ts:1607
 
 ***
 
@@ -107,7 +119,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1592
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1594
+packages/quickjs-emscripten-core/dist/index.d.ts:1609
 
 ***
 
@@ -117,7 +129,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1594
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1596
+packages/quickjs-emscripten-core/dist/index.d.ts:1611
 
 ## Variables
 
@@ -127,7 +139,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1596
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1580
+packages/quickjs-emscripten-core/dist/index.d.ts:1593
 
 ***
 
@@ -137,7 +149,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1582
+packages/quickjs-emscripten-core/dist/index.d.ts:1595
 
 ***
 
@@ -147,7 +159,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1584
+packages/quickjs-emscripten-core/dist/index.d.ts:1597
 
 ***
 
@@ -157,7 +169,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1586
+packages/quickjs-emscripten-core/dist/index.d.ts:1599
 
 ***
 
@@ -167,7 +179,17 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1586
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1588
+packages/quickjs-emscripten-core/dist/index.d.ts:1601
+
+***
+
+### QuickJSPromisePending
+
+> **QuickJSPromisePending**: *typeof* `QuickJSPromisePending`
+
+#### Source
+
+packages/quickjs-emscripten-core/dist/index.d.ts:1603
 
 ***
 
@@ -177,7 +199,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1588
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1590
+packages/quickjs-emscripten-core/dist/index.d.ts:1605
 
 ***
 
@@ -187,7 +209,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1590
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1592
+packages/quickjs-emscripten-core/dist/index.d.ts:1607
 
 ***
 
@@ -197,7 +219,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1592
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1594
+packages/quickjs-emscripten-core/dist/index.d.ts:1609
 
 ***
 
@@ -207,7 +229,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1594
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1596
+packages/quickjs-emscripten-core/dist/index.d.ts:1611
 
 ***
 

--- a/doc/quickjs-emscripten/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten/namespaces/errors/README.md
@@ -37,7 +37,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1568
+packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 ***
 
@@ -47,7 +47,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1568
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1570
+packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 ***
 
@@ -57,7 +57,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1570
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1572
+packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 ***
 
@@ -67,7 +67,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1572
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1574
+packages/quickjs-emscripten-core/dist/index.d.ts:1586
 
 ***
 
@@ -77,7 +77,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1574
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1576
+packages/quickjs-emscripten-core/dist/index.d.ts:1588
 
 ***
 
@@ -87,7 +87,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1576
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1578
+packages/quickjs-emscripten-core/dist/index.d.ts:1590
 
 ***
 
@@ -97,7 +97,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1578
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1580
+packages/quickjs-emscripten-core/dist/index.d.ts:1592
 
 ***
 
@@ -107,7 +107,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1582
+packages/quickjs-emscripten-core/dist/index.d.ts:1594
 
 ***
 
@@ -117,7 +117,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1584
+packages/quickjs-emscripten-core/dist/index.d.ts:1596
 
 ## Variables
 
@@ -127,7 +127,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1568
+packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 ***
 
@@ -137,7 +137,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1568
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1570
+packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 ***
 
@@ -147,7 +147,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1570
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1572
+packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 ***
 
@@ -157,7 +157,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1572
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1574
+packages/quickjs-emscripten-core/dist/index.d.ts:1586
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1574
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1576
+packages/quickjs-emscripten-core/dist/index.d.ts:1588
 
 ***
 
@@ -177,7 +177,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1576
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1578
+packages/quickjs-emscripten-core/dist/index.d.ts:1590
 
 ***
 
@@ -187,7 +187,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1578
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1580
+packages/quickjs-emscripten-core/dist/index.d.ts:1592
 
 ***
 
@@ -197,7 +197,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1582
+packages/quickjs-emscripten-core/dist/index.d.ts:1594
 
 ***
 
@@ -207,7 +207,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1584
+packages/quickjs-emscripten-core/dist/index.d.ts:1596
 
 ***
 

--- a/doc/quickjs-emscripten/namespaces/errors/README.md
+++ b/doc/quickjs-emscripten/namespaces/errors/README.md
@@ -37,7 +37,7 @@
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1547
+packages/quickjs-emscripten-core/dist/index.d.ts:1568
 
 ***
 
@@ -47,7 +47,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1547
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1549
+packages/quickjs-emscripten-core/dist/index.d.ts:1570
 
 ***
 
@@ -57,7 +57,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1549
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1551
+packages/quickjs-emscripten-core/dist/index.d.ts:1572
 
 ***
 
@@ -67,7 +67,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1551
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1553
+packages/quickjs-emscripten-core/dist/index.d.ts:1574
 
 ***
 
@@ -77,7 +77,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1553
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1555
+packages/quickjs-emscripten-core/dist/index.d.ts:1576
 
 ***
 
@@ -87,7 +87,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1555
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1557
+packages/quickjs-emscripten-core/dist/index.d.ts:1578
 
 ***
 
@@ -97,7 +97,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1557
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1559
+packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 ***
 
@@ -107,7 +107,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1559
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1561
+packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 ***
 
@@ -117,7 +117,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1561
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1563
+packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 ## Variables
 
@@ -127,7 +127,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1563
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1547
+packages/quickjs-emscripten-core/dist/index.d.ts:1568
 
 ***
 
@@ -137,7 +137,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1547
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1549
+packages/quickjs-emscripten-core/dist/index.d.ts:1570
 
 ***
 
@@ -147,7 +147,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1549
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1551
+packages/quickjs-emscripten-core/dist/index.d.ts:1572
 
 ***
 
@@ -157,7 +157,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1551
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1553
+packages/quickjs-emscripten-core/dist/index.d.ts:1574
 
 ***
 
@@ -167,7 +167,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1553
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1555
+packages/quickjs-emscripten-core/dist/index.d.ts:1576
 
 ***
 
@@ -177,7 +177,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1555
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1557
+packages/quickjs-emscripten-core/dist/index.d.ts:1578
 
 ***
 
@@ -187,7 +187,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1557
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1559
+packages/quickjs-emscripten-core/dist/index.d.ts:1580
 
 ***
 
@@ -197,7 +197,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1559
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1561
+packages/quickjs-emscripten-core/dist/index.d.ts:1582
 
 ***
 
@@ -207,7 +207,7 @@ packages/quickjs-emscripten-core/dist/index.d.ts:1561
 
 #### Source
 
-packages/quickjs-emscripten-core/dist/index.d.ts:1563
+packages/quickjs-emscripten-core/dist/index.d.ts:1584
 
 ***
 

--- a/packages/quickjs-emscripten-core/src/context-asyncify.ts
+++ b/packages/quickjs-emscripten-core/src/context-asyncify.ts
@@ -56,7 +56,8 @@ export class QuickJSAsyncContext extends QuickJSContext {
         .consume((charHandle) =>
           this.ffi.QTS_Eval_MaybeAsync(
             this.ctx.value,
-            charHandle.value,
+            charHandle.value.ptr,
+            charHandle.value.strlen,
             filename,
             detectModule,
             flags,

--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -651,6 +651,19 @@ export class QuickJSContext
     )
   }
 
+  /**
+   * Get the current state of a QuickJS promise, see {@link JSPromiseState} for the possible states.
+   * This can be used to expect a promise to be fulfilled when combined with {@link unwrapResult}:
+   *
+   * ```typescript
+   * const promiseHandle = context.evalCode(`Promise.resolve(42)`);
+   * const resultHandle = context.unwrapResult(
+   *  context.getPromiseState(promiseHandle)
+   * );
+   * context.getNumber(resultHandle) === 42; // true
+   * resultHandle.dispose();
+   * ```
+   */
   getPromiseState(handle: QuickJSHandle): JSPromiseState {
     this.runtime.assertOwned(handle)
     const state = this.ffi.QTS_PromiseState(this.ctx.value, handle.value)

--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -816,7 +816,20 @@ export class QuickJSContext
 
   /**
    * Like [`eval(code)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description).
-   * Evaluates the Javascript source `code` in the global scope of this VM.
+   *
+   * Evaluates `code`, as though it's in a file named `filename`, with options `options`.
+   *
+   * - When `options.type` is `"global"`, the code is evaluated in the global
+   *   scope of the QuickJSContext, and the return value is the result of the last
+   *   expression.
+   * - When `options.type` is `"module"`, the code is evaluated is a module scope.
+   *   It may use `import` and `export` if {@link runtime}.{@link QuickJSRuntime#setModuleLoader} was called.
+   *   It may use top-level await if supported by the underlying QuickJS library.
+   *   The return value is the module's exports, or a promise for the module's exports.
+   * - When `options.type` is unset, the code is evaluated as a module if it
+   *   contains an `import` or `export` statement, otherwise it is evaluated in
+   *   the global scope.
+   *
    * When working with async code, you many need to call {@link runtime}.{@link QuickJSRuntime#executePendingJobs}
    * to execute callbacks pending after synchronous evaluation returns.
    *

--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -312,7 +312,7 @@ export class QuickJSContext
   newString(str: string): QuickJSHandle {
     const ptr = this.memory
       .newHeapCharPointer(str)
-      .consume((charHandle) => this.ffi.QTS_NewString(this.ctx.value, charHandle.value))
+      .consume((charHandle) => this.ffi.QTS_NewString(this.ctx.value, charHandle.value.ptr))
     return this.memory.heapValueHandle(ptr)
   }
 
@@ -324,7 +324,7 @@ export class QuickJSContext
     const key = (typeof description === "symbol" ? description.description : description) ?? ""
     const ptr = this.memory
       .newHeapCharPointer(key)
-      .consume((charHandle) => this.ffi.QTS_NewSymbol(this.ctx.value, charHandle.value, 0))
+      .consume((charHandle) => this.ffi.QTS_NewSymbol(this.ctx.value, charHandle.value.ptr, 0))
     return this.memory.heapValueHandle(ptr)
   }
 
@@ -336,7 +336,7 @@ export class QuickJSContext
     const description = (typeof key === "symbol" ? key.description : key) ?? ""
     const ptr = this.memory
       .newHeapCharPointer(description)
-      .consume((charHandle) => this.ffi.QTS_NewSymbol(this.ctx.value, charHandle.value, 1))
+      .consume((charHandle) => this.ffi.QTS_NewSymbol(this.ctx.value, charHandle.value.ptr, 1))
     return this.memory.heapValueHandle(ptr)
   }
 
@@ -850,7 +850,14 @@ export class QuickJSContext
     const resultPtr = this.memory
       .newHeapCharPointer(code)
       .consume((charHandle) =>
-        this.ffi.QTS_Eval(this.ctx.value, charHandle.value, filename, detectModule, flags),
+        this.ffi.QTS_Eval(
+          this.ctx.value,
+          charHandle.value.ptr,
+          charHandle.value.strlen,
+          filename,
+          detectModule,
+          flags,
+        ),
       )
     const errorPtr = this.ffi.QTS_ResolveException(this.ctx.value, resultPtr)
     if (errorPtr) {

--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -11,7 +11,8 @@ import type {
   EitherFFI,
 } from "@jitl/quickjs-ffi-types"
 import { debugLog } from "./debug"
-import { JSPromiseState, QuickJSDeferredPromise } from "./deferred-promise"
+import type { JSPromiseState } from "./deferred-promise"
+import { QuickJSDeferredPromise } from "./deferred-promise"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { shouldInterruptAfterDeadline } from "./interrupt-helpers"
 import { QuickJSUnwrapError } from "./errors"

--- a/packages/quickjs-emscripten-core/src/deferred-promise.ts
+++ b/packages/quickjs-emscripten-core/src/deferred-promise.ts
@@ -4,6 +4,11 @@ import type { QuickJSRuntime } from "./runtime"
 import type { QuickJSContext } from "./context"
 export type { PromiseExecutor } from "./types"
 
+export type JSPromiseState =
+  | { type: "pending" }
+  | { type: "fulfilled"; value: QuickJSHandle; error?: undefined; notAPromise?: boolean }
+  | { type: "rejected"; error: QuickJSHandle }
+
 /**
  * QuickJSDeferredPromise wraps a QuickJS promise {@link handle} and allows
  * {@link resolve}ing or {@link reject}ing that promise. Use it to bridge asynchronous

--- a/packages/quickjs-emscripten-core/src/deferred-promise.ts
+++ b/packages/quickjs-emscripten-core/src/deferred-promise.ts
@@ -4,9 +4,26 @@ import type { QuickJSRuntime } from "./runtime"
 import type { QuickJSContext } from "./context"
 export type { PromiseExecutor } from "./types"
 
+/**
+ * A promise state inside QuickJS, which can be pending, fulfilled, or rejected.
+ * You can unwrap a JSPromiseState with {@link QuickJSContext#unwrapResult}.
+ */
 export type JSPromiseState =
-  | { type: "pending" }
-  | { type: "fulfilled"; value: QuickJSHandle; error?: undefined; notAPromise?: boolean }
+  | {
+      type: "pending"
+      /**
+       * The error property here allows unwrapping a JSPromiseState with {@link QuickJSContext#unwrapResult}.
+       * Unwrapping a pending promise will throw a {@link QuickJSPromisePending} error.
+       */
+      get error(): Error
+    }
+  | {
+      type: "fulfilled"
+      value: QuickJSHandle
+      error?: undefined
+      /** Trying to get the promise state of a non-Promise value returns a fulfilled state with the original value, and `notAPromise: true`. */
+      notAPromise?: boolean
+    }
   | { type: "rejected"; error: QuickJSHandle }
 
 /**

--- a/packages/quickjs-emscripten-core/src/deferred-promise.ts
+++ b/packages/quickjs-emscripten-core/src/deferred-promise.ts
@@ -9,22 +9,43 @@ export type { PromiseExecutor } from "./types"
  * You can unwrap a JSPromiseState with {@link QuickJSContext#unwrapResult}.
  */
 export type JSPromiseState =
-  | {
-      type: "pending"
-      /**
-       * The error property here allows unwrapping a JSPromiseState with {@link QuickJSContext#unwrapResult}.
-       * Unwrapping a pending promise will throw a {@link QuickJSPromisePending} error.
-       */
-      get error(): Error
-    }
-  | {
-      type: "fulfilled"
-      value: QuickJSHandle
-      error?: undefined
-      /** Trying to get the promise state of a non-Promise value returns a fulfilled state with the original value, and `notAPromise: true`. */
-      notAPromise?: boolean
-    }
-  | { type: "rejected"; error: QuickJSHandle }
+  | JSPromiseStatePending
+  | JSPromiseStateFulfilled
+  | JSPromiseStateRejected
+
+/**
+ * Pending promise state.
+ * See {@link JSPromiseState}.
+ */
+export interface JSPromiseStatePending {
+  type: "pending"
+  /**
+   * The error property here allows unwrapping a JSPromiseState with {@link QuickJSContext#unwrapResult}.
+   * Unwrapping a pending promise will throw a {@link QuickJSPromisePending} error.
+   */
+  get error(): Error
+}
+
+/**
+ * Fulfilled promise state.
+ * See {@link JSPromiseState}.
+ */
+export interface JSPromiseStateFulfilled {
+  type: "fulfilled"
+  value: QuickJSHandle
+  error?: undefined
+  /** Trying to get the promise state of a non-Promise value returns a fulfilled state with the original value, and `notAPromise: true`. */
+  notAPromise?: boolean
+}
+
+/**
+ * Rejected promise state.
+ * See {@link JSPromiseState}.
+ */
+export interface JSPromiseStateRejected {
+  type: "rejected"
+  error: QuickJSHandle
+}
 
 /**
  * QuickJSDeferredPromise wraps a QuickJS promise {@link handle} and allows

--- a/packages/quickjs-emscripten-core/src/errors.ts
+++ b/packages/quickjs-emscripten-core/src/errors.ts
@@ -44,3 +44,7 @@ export class QuickJSEmscriptenModuleError extends Error {
 export class QuickJSUnknownIntrinsic extends TypeError {
   name = "QuickJSUnknownIntrinsic"
 }
+
+export class QuickJSPromisePending extends Error {
+  name = "QuickJSPromisePending"
+}

--- a/packages/quickjs-emscripten-core/src/memory.ts
+++ b/packages/quickjs-emscripten-core/src/memory.ts
@@ -43,11 +43,12 @@ export class ModuleMemory {
     return new Lifetime({ typedArray, ptr }, undefined, (value) => this.module._free(value.ptr))
   }
 
-  newHeapCharPointer(string: string): Lifetime<OwnedHeapCharPointer> {
-    const numBytes = this.module.lengthBytesUTF8(string) + 1
-    const ptr: OwnedHeapCharPointer = this.module._malloc(numBytes) as OwnedHeapCharPointer
-    this.module.stringToUTF8(string, ptr, numBytes)
-    return new Lifetime(ptr, undefined, (value) => this.module._free(value))
+  newHeapCharPointer(string: string): Lifetime<{ ptr: OwnedHeapCharPointer; strlen: number }> {
+    const strlen = this.module.lengthBytesUTF8(string)
+    const dataBytes = strlen + 1
+    const ptr: OwnedHeapCharPointer = this.module._malloc(dataBytes) as OwnedHeapCharPointer
+    this.module.stringToUTF8(string, ptr, dataBytes)
+    return new Lifetime({ ptr, strlen }, undefined, (value) => this.module._free(value.ptr))
   }
 
   newHeapBufferPointer(buffer: Uint8Array): Lifetime<HeapUint8Array> {

--- a/packages/quickjs-emscripten-core/src/runtime.ts
+++ b/packages/quickjs-emscripten-core/src/runtime.ts
@@ -380,7 +380,7 @@ export class QuickJSRuntime extends UsingDisposable implements Disposable {
         const moduleSource =
           typeof result === "string" ? result : "value" in result ? result.value : result
 
-        return this.memory.newHeapCharPointer(moduleSource).value
+        return this.memory.newHeapCharPointer(moduleSource).value.ptr
       } catch (error) {
         debugLog("cToHostLoadModule: caught error", error)
         context.throw(error as any)
@@ -400,7 +400,7 @@ export class QuickJSRuntime extends UsingDisposable implements Disposable {
           throw new Error("Runtime pointer mismatch")
         }
 
-        const context =
+        const context: QuickJSContext =
           this.contextMap.get(ctx) ??
           this.newContext({
             /* TODO: Does this happen? Are we responsible for disposing? I don't think so */
@@ -418,7 +418,7 @@ export class QuickJSRuntime extends UsingDisposable implements Disposable {
           }
 
           const name = typeof result === "string" ? result : result.value
-          return context.getMemory(this.rt.value).newHeapCharPointer(name).value
+          return context.getMemory(this.rt.value).newHeapCharPointer(name).value.ptr
         } catch (error) {
           debugLog("normalizeModule: caught error", error)
           context.throw(error as any)

--- a/packages/quickjs-emscripten-core/src/types.ts
+++ b/packages/quickjs-emscripten-core/src/types.ts
@@ -241,7 +241,12 @@ export interface ContextOptions {
 }
 
 export interface ContextEvalOptions {
-  /** Global code (default) */
+  /**
+   * Global code (default), or "module" code?
+   *
+   * - When type is `"global"`, the code is evaluated in the global scope of the QuickJSContext, and the return value is the result of the last expression.
+   * - When type is `"module"`, the code is evaluated is a module scope, may use `import`, `export`, and top-level `await`. The return value is the module's exports, or a promise for the module's exports.
+   */
   type?: "global" | "module"
   /** Force "strict" mode */
   strict?: boolean

--- a/packages/quickjs-emscripten/src/quickjs.test.ts
+++ b/packages/quickjs-emscripten/src/quickjs.test.ts
@@ -390,7 +390,7 @@ function contextTests(getContext: GetTestContext, isDebug = false) {
     })
   })
 
-  describe.only(".evalCode", () => {
+  describe(".evalCode", () => {
     it("on success: returns { value: success }", () => {
       const value = vm.unwrapResult(vm.evalCode(`["this", "should", "work"].join(' ')`))
       assert.equal(vm.getString(value), "this should work")

--- a/packages/quickjs-emscripten/src/quickjs.test.ts
+++ b/packages/quickjs-emscripten/src/quickjs.test.ts
@@ -501,7 +501,7 @@ log('exported default');
 
       vm.runtime.executePendingJobs()
       const promiseState = promise.consume((p) => vm.getPromiseState(p))
-      if (promiseState === "pending") {
+      if (promiseState.type === "pending") {
         throw new Error(`By now promise should be resolved.`)
       }
 

--- a/packages/quickjs-emscripten/src/quickjs.test.ts
+++ b/packages/quickjs-emscripten/src/quickjs.test.ts
@@ -67,6 +67,10 @@ function contextTests(getContext: GetTestContext, isDebug = false) {
   })
 
   after(() => {
+    if (!ffi) {
+      return
+    }
+
     if (ffi.QTS_BuildIsAsyncify()) {
       // Asyncify explodes during leak checking.
       return

--- a/packages/quickjs-ffi-types/src/ffi-async.ts
+++ b/packages/quickjs-ffi-types/src/ffi-async.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "."
 
@@ -192,6 +193,14 @@ export interface QuickJSAsyncFFI {
   QTS_NewPromiseCapability: (
     ctx: JSContextPointer,
     resolve_funcs_out: JSValuePointerPointer,
+  ) => JSValuePointer
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
   ) => JSValuePointer
   QTS_TestStringArg: (string: string) => void
   QTS_BuildIsDebug: () => number

--- a/packages/quickjs-ffi-types/src/ffi-async.ts
+++ b/packages/quickjs-ffi-types/src/ffi-async.ts
@@ -167,6 +167,7 @@ export interface QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
@@ -174,10 +175,15 @@ export interface QuickJSAsyncFFI {
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer>
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer
   QTS_Typeof: (
     ctx: JSContextPointer,
     value: JSValuePointer | JSValueConstPointer,

--- a/packages/quickjs-ffi-types/src/ffi-types.ts
+++ b/packages/quickjs-ffi-types/src/ffi-types.ts
@@ -108,6 +108,14 @@ export type IntrinsicsFlags = Brand<number, "IntrinsicsFlags">
  */
 export type EvalDetectModule = Brand<number, "EvalDetectModule">
 
+/**
+ * State of a promise.
+ */
+export type JSPromiseStateEnum = Brand<
+  (typeof JSPromiseStateEnum)[keyof typeof JSPromiseStateEnum],
+  "JSPromiseStateEnum"
+>
+
 export function assertSync<Args extends any[], R>(fn: (...args: Args) => R): (...args: Args) => R {
   return function mustBeSync(...args: Args): R {
     const result = fn(...args)
@@ -161,4 +169,10 @@ export const IntrinsicsFlags = {
   BigDecimal: 1 << 13,
   OperatorOverloading: 1 << 14,
   BignumExt: 1 << 15,
+} as const
+
+export const JSPromiseStateEnum = {
+  Pending: 0,
+  Fulfilled: 1,
+  Rejected: 2,
 } as const

--- a/packages/quickjs-ffi-types/src/ffi.ts
+++ b/packages/quickjs-ffi-types/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "."
 
 /**
@@ -152,6 +153,14 @@ export interface QuickJSFFI {
   QTS_NewPromiseCapability: (
     ctx: JSContextPointer,
     resolve_funcs_out: JSValuePointerPointer,
+  ) => JSValuePointer
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
   ) => JSValuePointer
   QTS_TestStringArg: (string: string) => void
   QTS_BuildIsDebug: () => number

--- a/packages/quickjs-ffi-types/src/ffi.ts
+++ b/packages/quickjs-ffi-types/src/ffi.ts
@@ -135,9 +135,14 @@ export interface QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
+  ) => JSValuePointer
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
   ) => JSValuePointer
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -385,6 +386,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/src/ffi.ts
@@ -333,25 +333,39 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap(
     "QTS_Eval",
     "number",
-    ["number", "number", "string", "number", "number"],
+    ["number", "number", "number", "string", "number", "number"],
     { async: true },
   )
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -384,6 +385,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/src/ffi.ts
@@ -330,26 +330,41 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-ng-wasmfile-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-release-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-ng-wasmfile-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-ng-wasmfile-release-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -385,6 +386,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/src/ffi.ts
@@ -333,25 +333,39 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap(
     "QTS_Eval",
     "number",
-    ["number", "number", "string", "number", "number"],
+    ["number", "number", "number", "string", "number", "number"],
     { async: true },
   )
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -384,6 +385,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/src/ffi.ts
@@ -330,26 +330,41 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-browser-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-release-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-browser-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-browser-release-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -385,6 +386,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/src/ffi.ts
@@ -333,25 +333,39 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap(
     "QTS_Eval",
     "number",
-    ["number", "number", "string", "number", "number"],
+    ["number", "number", "number", "string", "number", "number"],
     { async: true },
   )
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -384,6 +385,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/src/ffi.ts
@@ -330,26 +330,41 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-cjs-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-release-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-cjs-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-cjs-release-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -385,6 +386,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/src/ffi.ts
@@ -333,25 +333,39 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap(
     "QTS_Eval",
     "number",
-    ["number", "number", "string", "number", "number"],
+    ["number", "number", "number", "string", "number", "number"],
     { async: true },
   )
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -384,6 +385,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/src/ffi.ts
@@ -330,26 +330,41 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-mjs-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-release-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-singlefile-mjs-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-singlefile-mjs-release-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -385,6 +386,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/src/ffi.ts
@@ -333,25 +333,39 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap(
     "QTS_Eval",
     "number",
-    ["number", "number", "string", "number", "number"],
+    ["number", "number", "number", "string", "number", "number"],
     { async: true },
   )
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-wasmfile-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-debug-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-wasmfile-debug-sync/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-debug-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-wasmfile-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
   assertSync,
 } from "@jitl/quickjs-ffi-types"
 
@@ -384,6 +385,16 @@ export class QuickJSAsyncFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",

--- a/packages/variant-quickjs-wasmfile-release-asyncify/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/src/ffi.ts
@@ -330,26 +330,41 @@ export class QuickJSAsyncFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = assertSync(
-    this.module.cwrap("QTS_Eval", "number", ["number", "number", "string", "number", "number"]),
+    this.module.cwrap("QTS_Eval", "number", [
+      "number",
+      "number",
+      "number",
+      "string",
+      "number",
+      "number",
+    ]),
   )
 
   QTS_Eval_MaybeAsync: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer | Promise<JSValuePointer> = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-wasmfile-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-release-sync/src/ffi.ts
@@ -266,16 +266,23 @@ export class QuickJSFFI {
   QTS_Eval: (
     ctx: JSContextPointer,
     js_code: BorrowedHeapCharPointer,
+    js_code_length: number,
     filename: string,
     detectModule: EvalDetectModule,
     evalFlags: EvalFlags,
   ) => JSValuePointer = this.module.cwrap("QTS_Eval", "number", [
     "number",
     "number",
+    "number",
     "string",
     "number",
     "number",
   ])
+
+  QTS_GetModuleNamespace: (
+    ctx: JSContextPointer,
+    module_func_obj: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_GetModuleNamespace", "number", ["number", "number"])
 
   QTS_Typeof: (
     ctx: JSContextPointer,

--- a/packages/variant-quickjs-wasmfile-release-sync/src/ffi.ts
+++ b/packages/variant-quickjs-wasmfile-release-sync/src/ffi.ts
@@ -19,6 +19,7 @@ import {
   EvalFlags,
   IntrinsicsFlags,
   EvalDetectModule,
+  JSPromiseStateEnum,
 } from "@jitl/quickjs-ffi-types"
 
 /**
@@ -302,6 +303,16 @@ export class QuickJSFFI {
     "number",
     "number",
   ])
+
+  QTS_PromiseState: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSPromiseStateEnum = this.module.cwrap("QTS_PromiseState", "number", ["number", "number"])
+
+  QTS_PromiseResult: (
+    ctx: JSContextPointer,
+    promise: JSValuePointer | JSValueConstPointer,
+  ) => JSValuePointer = this.module.cwrap("QTS_PromiseResult", "number", ["number", "number"])
 
   QTS_TestStringArg: (string: string) => void = this.module.cwrap("QTS_TestStringArg", null, [
     "string",


### PR DESCRIPTION
Fixes #148

- Evaluating code with `{ mode: 'module' }` now returns the module exports or a promise of the module exports.
- introduce `context.getPromiseState(handle)` for synchronous access to promise contents. This can be used with `context.unwrapResult` to expect a promise to be resolved. Example usage: `context.runtime.executePendingJobs(); resolved = context.unwrapResult(context.getPromiseState(promiseHandle))`