### PR TITLE
quickjs-emscripten-core: export setDebugMode

### DIFF
--- a/packages/quickjs-emscripten-core/src/index.ts
+++ b/packages/quickjs-emscripten-core/src/index.ts
@@ -46,4 +46,4 @@ export type {
 export { DefaultIntrinsics } from "./types"
 export type { ModuleEvalOptions } from "./module"
 export { QuickJSPropertyKey } from "./context"
-export { debugLog } from "./debug"
+export { debugLog, setDebugMode } from "./debug"


### PR DESCRIPTION
Fixes #194 by exporting `setDebugMode` to quickjs-emscripten-core (and thus quickjs-emscripten)