### PR TITLE
Allow host functions to be treated as constructors

### DIFF
--- a/c/interface.c
+++ b/c/interface.c
@@ -1069,7 +1069,7 @@ JSValue *QTS_NewFunction(JSContext *ctx, uint32_t func_id, const char *name) {
       /* JSCFunctionMagic* */ &qts_call_function,
       /* name */ name,
       /* min argc */ 0,
-      /* function type */ JS_CFUNC_generic_magic,
+      /* function type */ JS_CFUNC_constructor_or_func_magic,
       /* magic: fn id */ func_id);
   return jsvalue_to_heap(func_obj);
 }


### PR DESCRIPTION
When creating new functions on the host side, it's not currently possible to create a constructor that can be called with `new` from within the VM.  The only thing that needs to change to enable this is the function type used when creating the function with `JS_NewCFunctionMagic`.

Example:

Host:
```js
vm.newFunction('Cat', () => {
  const cat = vm.newObject();
  vm.setProp(cat, 'breed', 'calico');
  return cat;
});
```

Script:
```js
const cat = new Cat();
console.log(cat.breed);
// "calico"
```

Without this change the error "not a constructor" is thrown instead.

Creating synthetic constructors is also supported in the `qjs` REPL:

```
qjs > function Cat() { return { breed: 'calico' }; }
qjs > const cat = new Cat()
qjs > console.log(cat.breed)
calico
```