### PR TITLE
Support generator return values in QuickJSIterator

### DIFF
--- a/packages/quickjs-emscripten-core/src/QuickJSIterator.ts
+++ b/packages/quickjs-emscripten-core/src/QuickJSIterator.ts
@@ -128,20 +128,17 @@ export class QuickJSIterator
     }
 
     const done = this.context.getProp(callResult.value, "done").consume((v) => this.context.dump(v))
+    const value = this.context.getProp(callResult.value, "value")
+
+    callResult.value.dispose()
+
     if (done) {
-      callResult.value.dispose()
       this.dispose()
-      return {
-        done,
-        value: undefined,
-      }
     }
 
-    const value = this.context.getProp(callResult.value, "value")
-    callResult.value.dispose()
     return {
       value: DisposableResult.success(value),
-      done: done as false,
+      done: done as boolean,
     }
   }
 }


### PR DESCRIPTION
Currently the quickjs iterator does not support generator function return values, as it assumes when `done === true` then `value === undefined`. 

This is not the case for generator-derived iterators 

```
function* () {
   return "some value"
}
```

[MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#value) are a little vague on this so I can understand the confusion

> Any JavaScript value returned by the iterator. Can be omitted when done is true.

However - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#description:
> A function* declaration creates a [GeneratorFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction) object. Each time a generator function is called, it returns a new [Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) object, which conforms to the [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol).

> A return statement in a generator, when executed, will make the generator finish (i.e. the done property of the object returned by it will be set to true). If a value is returned, it will be set as the value property of the object returned by the generator. 

I guess the key word is "can" be omitted, not "must"