### PR TITLE
Support more ASmJS targets

### DIFF
--- a/scripts/prepareVariants.ts
+++ b/scripts/prepareVariants.ts
@@ -128,9 +128,6 @@ const targets = {
   "asmjs-mjs": makeTarget({
     description: `Compiled to pure Javascript, no WebAssembly required.`,
     emscriptenInclusion: EmscriptenInclusion.AsmJs,
-    releaseMode: ReleaseMode.Release,
-    syncMode: SyncMode.Sync,
-    library: CLibrary.QuickJS,
     exports: {
       import: {
         emscriptenEnvironment: [


### PR DESCRIPTION
Supporting Quickjs-ng and ASyncify may be beneficial for applications and sandboxes using quickjs, even if their environment doesn't support WASM