### PR TITLE
Fix emscripten build warnings

### DIFF
--- a/doc/@jitl/quickjs-ffi-types/exports.md
+++ b/doc/@jitl/quickjs-ffi-types/exports.md
@@ -84,7 +84,7 @@ for the Emscripten stack.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:253](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L253)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:245](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L245)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/EmscriptenModule.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/EmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](EmscriptenModule.md#extends)
 - [Properties](EmscriptenModule.md#properties)
   - [FAST\_MEMORY](EmscriptenModule.md#fast-memory)
-  - [HEAP16](EmscriptenModule.md#heap16)
-  - [HEAP32](EmscriptenModule.md#heap32)
-  - [HEAP8](EmscriptenModule.md#heap8)
-  - [HEAPF32](EmscriptenModule.md#heapf32)
-  - [HEAPF64](EmscriptenModule.md#heapf64)
-  - [HEAPU16](EmscriptenModule.md#heapu16)
-  - [HEAPU32](EmscriptenModule.md#heapu32)
   - [HEAPU8](EmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](EmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](EmscriptenModule.md#total-stack)
@@ -49,77 +42,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L169)
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L158)
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L164)
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L165)
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L162)
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L163)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
 
 ***
 
@@ -129,7 +52,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L157)
 
 ***
 
@@ -139,7 +62,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L168)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
 
 ***
 
@@ -149,7 +72,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L167)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/EmscriptenModuleLoader.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:256](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L256)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:248](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L248)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](QuickJSAsyncEmscriptenModule.md#extends)
 - [Properties](QuickJSAsyncEmscriptenModule.md#properties)
   - [FAST\_MEMORY](QuickJSAsyncEmscriptenModule.md#fast-memory)
-  - [HEAP16](QuickJSAsyncEmscriptenModule.md#heap16)
-  - [HEAP32](QuickJSAsyncEmscriptenModule.md#heap32)
-  - [HEAP8](QuickJSAsyncEmscriptenModule.md#heap8)
-  - [HEAPF32](QuickJSAsyncEmscriptenModule.md#heapf32)
-  - [HEAPF64](QuickJSAsyncEmscriptenModule.md#heapf64)
-  - [HEAPU16](QuickJSAsyncEmscriptenModule.md#heapu16)
-  - [HEAPU32](QuickJSAsyncEmscriptenModule.md#heapu32)
   - [HEAPU8](QuickJSAsyncEmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](QuickJSAsyncEmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](QuickJSAsyncEmscriptenModule.md#total-stack)
@@ -55,105 +48,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L169)
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAP16`](EmscriptenModule.md#heap16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAP32`](EmscriptenModule.md#heap32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAP8`](EmscriptenModule.md#heap8)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L158)
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPF32`](EmscriptenModule.md#heapf32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L164)
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPF64`](EmscriptenModule.md#heapf64)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L165)
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPU16`](EmscriptenModule.md#heapu16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L162)
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPU32`](EmscriptenModule.md#heapu32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L163)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
 
 ***
 
@@ -167,7 +62,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L157)
 
 ***
 
@@ -181,7 +76,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L168)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
 
 ***
 
@@ -195,7 +90,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L167)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
 
 ***
 
@@ -205,7 +100,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:250](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L250)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:242](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L242)
 
 ***
 
@@ -219,7 +114,7 @@ Implement this field
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:249](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L249)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:241](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L241)
 
 ***
 

--- a/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/@jitl/quickjs-ffi-types/interfaces/QuickJSEmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](QuickJSEmscriptenModule.md#extends)
 - [Properties](QuickJSEmscriptenModule.md#properties)
   - [FAST\_MEMORY](QuickJSEmscriptenModule.md#fast-memory)
-  - [HEAP16](QuickJSEmscriptenModule.md#heap16)
-  - [HEAP32](QuickJSEmscriptenModule.md#heap32)
-  - [HEAP8](QuickJSEmscriptenModule.md#heap8)
-  - [HEAPF32](QuickJSEmscriptenModule.md#heapf32)
-  - [HEAPF64](QuickJSEmscriptenModule.md#heapf64)
-  - [HEAPU16](QuickJSEmscriptenModule.md#heapu16)
-  - [HEAPU32](QuickJSEmscriptenModule.md#heapu32)
   - [HEAPU8](QuickJSEmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](QuickJSEmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](QuickJSEmscriptenModule.md#total-stack)
@@ -55,105 +48,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L169)
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAP16`](EmscriptenModule.md#heap16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAP32`](EmscriptenModule.md#heap32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAP8`](EmscriptenModule.md#heap8)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L158)
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPF32`](EmscriptenModule.md#heapf32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L164)
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPF64`](EmscriptenModule.md#heapf64)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L165)
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPU16`](EmscriptenModule.md#heapu16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L162)
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Inherited from
-
-[`@jitl/quickjs-ffi-types.EmscriptenModule.HEAPU32`](EmscriptenModule.md#heapu32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L163)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
 
 ***
 
@@ -167,7 +62,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L157)
 
 ***
 
@@ -181,7 +76,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L168)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
 
 ***
 
@@ -195,7 +90,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L167)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
 
 ***
 
@@ -205,7 +100,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:244](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L244)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:236](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L236)
 
 ***
 
@@ -215,7 +110,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:243](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L243)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:235](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L235)
 
 ***
 

--- a/doc/@jitl/quickjs-ng-wasmfile-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-ng-wasmfile-debug-asyncify/README.md
@@ -85,23 +85,23 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-O3"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```
 

--- a/doc/@jitl/quickjs-ng-wasmfile-debug-sync/README.md
+++ b/doc/@jitl/quickjs-ng-wasmfile-debug-sync/README.md
@@ -89,14 +89,14 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```
 

--- a/doc/@jitl/quickjs-ng-wasmfile-release-asyncify/README.md
+++ b/doc/@jitl/quickjs-ng-wasmfile-release-asyncify/README.md
@@ -85,15 +85,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/doc/@jitl/quickjs-singlefile-browser-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-browser-debug-asyncify/README.md
@@ -73,24 +73,24 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-O3"
+  "-s SINGLE_FILE=1"
 ]
 ```
 

--- a/doc/@jitl/quickjs-singlefile-browser-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-browser-debug-asyncify/README.md
@@ -78,7 +78,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-O3",
   "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",

--- a/doc/@jitl/quickjs-singlefile-browser-debug-sync/README.md
+++ b/doc/@jitl/quickjs-singlefile-browser-debug-sync/README.md
@@ -76,7 +76,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-DQTS_SANITIZE_LEAK",
   "-fsanitize=leak",
   "-g2",

--- a/doc/@jitl/quickjs-singlefile-browser-debug-sync/README.md
+++ b/doc/@jitl/quickjs-singlefile-browser-debug-sync/README.md
@@ -77,15 +77,15 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "-s SINGLE_FILE=1"
 ]
 ```
 

--- a/doc/@jitl/quickjs-singlefile-browser-release-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-browser-release-asyncify/README.md
@@ -73,15 +73,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/doc/@jitl/quickjs-singlefile-cjs-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-cjs-debug-asyncify/README.md
@@ -73,24 +73,24 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-O3"
+  "-s SINGLE_FILE=1"
 ]
 ```
 

--- a/doc/@jitl/quickjs-singlefile-cjs-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-cjs-debug-asyncify/README.md
@@ -78,7 +78,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-O3",
   "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",

--- a/doc/@jitl/quickjs-singlefile-cjs-debug-sync/README.md
+++ b/doc/@jitl/quickjs-singlefile-cjs-debug-sync/README.md
@@ -76,7 +76,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-DQTS_SANITIZE_LEAK",
   "-fsanitize=leak",
   "-g2",

--- a/doc/@jitl/quickjs-singlefile-cjs-debug-sync/README.md
+++ b/doc/@jitl/quickjs-singlefile-cjs-debug-sync/README.md
@@ -77,15 +77,15 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "-s SINGLE_FILE=1"
 ]
 ```
 

--- a/doc/@jitl/quickjs-singlefile-cjs-release-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-cjs-release-asyncify/README.md
@@ -73,15 +73,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/doc/@jitl/quickjs-singlefile-mjs-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-mjs-debug-asyncify/README.md
@@ -73,24 +73,24 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-O3"
+  "-s SINGLE_FILE=1"
 ]
 ```
 

--- a/doc/@jitl/quickjs-singlefile-mjs-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-mjs-debug-asyncify/README.md
@@ -78,7 +78,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-O3",
   "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",

--- a/doc/@jitl/quickjs-singlefile-mjs-debug-sync/README.md
+++ b/doc/@jitl/quickjs-singlefile-mjs-debug-sync/README.md
@@ -76,7 +76,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-DQTS_SANITIZE_LEAK",
   "-fsanitize=leak",
   "-g2",

--- a/doc/@jitl/quickjs-singlefile-mjs-debug-sync/README.md
+++ b/doc/@jitl/quickjs-singlefile-mjs-debug-sync/README.md
@@ -77,15 +77,15 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "-s SINGLE_FILE=1"
 ]
 ```
 

--- a/doc/@jitl/quickjs-singlefile-mjs-release-asyncify/README.md
+++ b/doc/@jitl/quickjs-singlefile-mjs-release-asyncify/README.md
@@ -73,15 +73,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/doc/@jitl/quickjs-wasmfile-debug-asyncify/README.md
+++ b/doc/@jitl/quickjs-wasmfile-debug-asyncify/README.md
@@ -85,23 +85,23 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-O3"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```
 

--- a/doc/@jitl/quickjs-wasmfile-debug-sync/README.md
+++ b/doc/@jitl/quickjs-wasmfile-debug-sync/README.md
@@ -89,14 +89,14 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```
 

--- a/doc/@jitl/quickjs-wasmfile-release-asyncify/README.md
+++ b/doc/@jitl/quickjs-wasmfile-release-asyncify/README.md
@@ -85,15 +85,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/doc/quickjs-emscripten-core/exports.md
+++ b/doc/quickjs-emscripten-core/exports.md
@@ -215,7 +215,7 @@ An `Array` that also implements [Disposable](interfaces/Disposable.md):
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:253](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L253)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:245](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L245)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](EmscriptenModule.md#extends)
 - [Properties](EmscriptenModule.md#properties)
   - [FAST\_MEMORY](EmscriptenModule.md#fast-memory)
-  - [HEAP16](EmscriptenModule.md#heap16)
-  - [HEAP32](EmscriptenModule.md#heap32)
-  - [HEAP8](EmscriptenModule.md#heap8)
-  - [HEAPF32](EmscriptenModule.md#heapf32)
-  - [HEAPF64](EmscriptenModule.md#heapf64)
-  - [HEAPU16](EmscriptenModule.md#heapu16)
-  - [HEAPU32](EmscriptenModule.md#heapu32)
   - [HEAPU8](EmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](EmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](EmscriptenModule.md#total-stack)
@@ -49,77 +42,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L169)
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L158)
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L164)
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L165)
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L162)
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L163)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
 
 ***
 
@@ -129,7 +52,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L157)
 
 ***
 
@@ -139,7 +62,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L168)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
 
 ***
 
@@ -149,7 +72,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L167)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoader.md
+++ b/doc/quickjs-emscripten-core/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:256](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L256)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:248](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L248)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](QuickJSAsyncEmscriptenModule.md#extends)
 - [Properties](QuickJSAsyncEmscriptenModule.md#properties)
   - [FAST\_MEMORY](QuickJSAsyncEmscriptenModule.md#fast-memory)
-  - [HEAP16](QuickJSAsyncEmscriptenModule.md#heap16)
-  - [HEAP32](QuickJSAsyncEmscriptenModule.md#heap32)
-  - [HEAP8](QuickJSAsyncEmscriptenModule.md#heap8)
-  - [HEAPF32](QuickJSAsyncEmscriptenModule.md#heapf32)
-  - [HEAPF64](QuickJSAsyncEmscriptenModule.md#heapf64)
-  - [HEAPU16](QuickJSAsyncEmscriptenModule.md#heapu16)
-  - [HEAPU32](QuickJSAsyncEmscriptenModule.md#heapu32)
   - [HEAPU8](QuickJSAsyncEmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](QuickJSAsyncEmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](QuickJSAsyncEmscriptenModule.md#total-stack)
@@ -55,105 +48,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L169)
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAP16`](EmscriptenModule.md#heap16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAP32`](EmscriptenModule.md#heap32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAP8`](EmscriptenModule.md#heap8)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L158)
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPF32`](EmscriptenModule.md#heapf32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L164)
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPF64`](EmscriptenModule.md#heapf64)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L165)
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPU16`](EmscriptenModule.md#heapu16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L162)
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPU32`](EmscriptenModule.md#heapu32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L163)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
 
 ***
 
@@ -167,7 +62,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L157)
 
 ***
 
@@ -181,7 +76,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L168)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
 
 ***
 
@@ -195,7 +90,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L167)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
 
 ***
 
@@ -205,7 +100,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:250](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L250)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:242](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L242)
 
 ***
 
@@ -219,7 +114,7 @@ Implement this field
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:249](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L249)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:241](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L241)
 
 ***
 

--- a/doc/quickjs-emscripten-core/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/quickjs-emscripten-core/interfaces/QuickJSEmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](QuickJSEmscriptenModule.md#extends)
 - [Properties](QuickJSEmscriptenModule.md#properties)
   - [FAST\_MEMORY](QuickJSEmscriptenModule.md#fast-memory)
-  - [HEAP16](QuickJSEmscriptenModule.md#heap16)
-  - [HEAP32](QuickJSEmscriptenModule.md#heap32)
-  - [HEAP8](QuickJSEmscriptenModule.md#heap8)
-  - [HEAPF32](QuickJSEmscriptenModule.md#heapf32)
-  - [HEAPF64](QuickJSEmscriptenModule.md#heapf64)
-  - [HEAPU16](QuickJSEmscriptenModule.md#heapu16)
-  - [HEAPU32](QuickJSEmscriptenModule.md#heapu32)
   - [HEAPU8](QuickJSEmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](QuickJSEmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](QuickJSEmscriptenModule.md#total-stack)
@@ -55,105 +48,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:169](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L169)
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAP16`](EmscriptenModule.md#heap16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAP32`](EmscriptenModule.md#heap32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAP8`](EmscriptenModule.md#heap8)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:158](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L158)
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPF32`](EmscriptenModule.md#heapf32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:164](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L164)
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPF64`](EmscriptenModule.md#heapf64)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:165](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L165)
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPU16`](EmscriptenModule.md#heapu16)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:162](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L162)
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten-core.EmscriptenModule.HEAPU32`](EmscriptenModule.md#heapu32)
-
-#### Source
-
-[packages/quickjs-ffi-types/src/emscripten-types.ts:163](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L163)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
 
 ***
 
@@ -167,7 +62,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:161](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L161)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:157](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L157)
 
 ***
 
@@ -181,7 +76,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:168](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L168)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:160](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L160)
 
 ***
 
@@ -195,7 +90,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:167](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L167)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:159](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L159)
 
 ***
 
@@ -205,7 +100,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:244](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L244)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:236](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L236)
 
 ***
 
@@ -215,7 +110,7 @@ QuickJS.
 
 #### Source
 
-[packages/quickjs-ffi-types/src/emscripten-types.ts:243](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L243)
+[packages/quickjs-ffi-types/src/emscripten-types.ts:235](https://github.com/justjake/quickjs-emscripten/blob/main/packages/quickjs-ffi-types/src/emscripten-types.ts#L235)
 
 ***
 

--- a/doc/quickjs-emscripten/exports.md
+++ b/doc/quickjs-emscripten/exports.md
@@ -219,7 +219,7 @@ An `Array` that also implements [Disposable](interfaces/Disposable.md):
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:547
+packages/quickjs-ffi-types/dist/index.d.ts:540
 
 ***
 
@@ -229,7 +229,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:547
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:337
+packages/quickjs-ffi-types/dist/index.d.ts:330
 
 ***
 
@@ -757,7 +757,7 @@ Property key for getting or setting a property on a handle with
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:546
+packages/quickjs-ffi-types/dist/index.d.ts:539
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](EmscriptenModule.md#extends)
 - [Properties](EmscriptenModule.md#properties)
   - [FAST\_MEMORY](EmscriptenModule.md#fast-memory)
-  - [HEAP16](EmscriptenModule.md#heap16)
-  - [HEAP32](EmscriptenModule.md#heap32)
-  - [HEAP8](EmscriptenModule.md#heap8)
-  - [HEAPF32](EmscriptenModule.md#heapf32)
-  - [HEAPF64](EmscriptenModule.md#heapf64)
-  - [HEAPU16](EmscriptenModule.md#heapu16)
-  - [HEAPU32](EmscriptenModule.md#heapu32)
   - [HEAPU8](EmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](EmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](EmscriptenModule.md#total-stack)
@@ -49,77 +42,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:284
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:285
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:283
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:289
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:290
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:287
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:286
 
 ***
 
@@ -129,7 +52,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:286
+packages/quickjs-ffi-types/dist/index.d.ts:283
 
 ***
 
@@ -139,7 +62,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:286
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:285
 
 ***
 
@@ -149,7 +72,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:292
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:291
+packages/quickjs-ffi-types/dist/index.d.ts:284
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoader.md
+++ b/doc/quickjs-emscripten/interfaces/EmscriptenModuleLoader.md
@@ -22,7 +22,7 @@
 
 ## Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:339
+packages/quickjs-ffi-types/dist/index.d.ts:332
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncEmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncEmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](QuickJSAsyncEmscriptenModule.md#extends)
 - [Properties](QuickJSAsyncEmscriptenModule.md#properties)
   - [FAST\_MEMORY](QuickJSAsyncEmscriptenModule.md#fast-memory)
-  - [HEAP16](QuickJSAsyncEmscriptenModule.md#heap16)
-  - [HEAP32](QuickJSAsyncEmscriptenModule.md#heap32)
-  - [HEAP8](QuickJSAsyncEmscriptenModule.md#heap8)
-  - [HEAPF32](QuickJSAsyncEmscriptenModule.md#heapf32)
-  - [HEAPF64](QuickJSAsyncEmscriptenModule.md#heapf64)
-  - [HEAPU16](QuickJSAsyncEmscriptenModule.md#heapu16)
-  - [HEAPU32](QuickJSAsyncEmscriptenModule.md#heapu32)
   - [HEAPU8](QuickJSAsyncEmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](QuickJSAsyncEmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](QuickJSAsyncEmscriptenModule.md#total-stack)
@@ -55,105 +48,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAP16`](EmscriptenModule.md#heap16)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:284
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAP32`](EmscriptenModule.md#heap32)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:285
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAP8`](EmscriptenModule.md#heap8)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:283
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPF32`](EmscriptenModule.md#heapf32)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:289
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPF64`](EmscriptenModule.md#heapf64)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:290
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPU16`](EmscriptenModule.md#heapu16)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:287
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPU32`](EmscriptenModule.md#heapu32)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:286
 
 ***
 
@@ -167,7 +62,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:286
+packages/quickjs-ffi-types/dist/index.d.ts:283
 
 ***
 
@@ -181,7 +76,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:286
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:285
 
 ***
 
@@ -195,7 +90,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:292
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:291
+packages/quickjs-ffi-types/dist/index.d.ts:284
 
 ***
 
@@ -205,7 +100,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:291
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:335
+packages/quickjs-ffi-types/dist/index.d.ts:328
 
 ***
 
@@ -219,7 +114,7 @@ Implement this field
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:334
+packages/quickjs-ffi-types/dist/index.d.ts:327
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncFFI.md
@@ -107,7 +107,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:431
+packages/quickjs-ffi-types/dist/index.d.ts:424
 
 ***
 
@@ -127,7 +127,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:431
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:502
+packages/quickjs-ffi-types/dist/index.d.ts:495
 
 ***
 
@@ -141,7 +141,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:502
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:500
+packages/quickjs-ffi-types/dist/index.d.ts:493
 
 ***
 
@@ -155,7 +155,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:500
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:499
+packages/quickjs-ffi-types/dist/index.d.ts:492
 
 ***
 
@@ -169,7 +169,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:499
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:438
+packages/quickjs-ffi-types/dist/index.d.ts:431
 
 ***
 
@@ -195,7 +195,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:438
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:481
+packages/quickjs-ffi-types/dist/index.d.ts:474
 
 ***
 
@@ -221,7 +221,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:481
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:482
+packages/quickjs-ffi-types/dist/index.d.ts:475
 
 ***
 
@@ -255,7 +255,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:482
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:478
+packages/quickjs-ffi-types/dist/index.d.ts:471
 
 ***
 
@@ -275,7 +275,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:478
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:484
+packages/quickjs-ffi-types/dist/index.d.ts:477
 
 ***
 
@@ -295,7 +295,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:484
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:485
+packages/quickjs-ffi-types/dist/index.d.ts:478
 
 ***
 
@@ -315,7 +315,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:485
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:454
+packages/quickjs-ffi-types/dist/index.d.ts:447
 
 ***
 
@@ -343,7 +343,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:454
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:486
+packages/quickjs-ffi-types/dist/index.d.ts:479
 
 ***
 
@@ -371,7 +371,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:486
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:487
+packages/quickjs-ffi-types/dist/index.d.ts:480
 
 ***
 
@@ -393,7 +393,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:487
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:470
+packages/quickjs-ffi-types/dist/index.d.ts:463
 
 ***
 
@@ -415,7 +415,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:470
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:471
+packages/quickjs-ffi-types/dist/index.d.ts:464
 
 ***
 
@@ -435,7 +435,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:471
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:453
+packages/quickjs-ffi-types/dist/index.d.ts:446
 
 ***
 
@@ -453,7 +453,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:453
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:449
+packages/quickjs-ffi-types/dist/index.d.ts:442
 
 ***
 
@@ -471,7 +471,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:449
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:447
+packages/quickjs-ffi-types/dist/index.d.ts:440
 
 ***
 
@@ -491,7 +491,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:447
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:450
+packages/quickjs-ffi-types/dist/index.d.ts:443
 
 ***
 
@@ -511,7 +511,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:450
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:451
+packages/quickjs-ffi-types/dist/index.d.ts:444
 
 ***
 
@@ -531,7 +531,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:451
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:452
+packages/quickjs-ffi-types/dist/index.d.ts:445
 
 ***
 
@@ -551,7 +551,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:452
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:463
+packages/quickjs-ffi-types/dist/index.d.ts:456
 
 ***
 
@@ -571,7 +571,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:463
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:464
+packages/quickjs-ffi-types/dist/index.d.ts:457
 
 ***
 
@@ -589,7 +589,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:464
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:497
+packages/quickjs-ffi-types/dist/index.d.ts:490
 
 ***
 
@@ -603,7 +603,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:497
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:442
+packages/quickjs-ffi-types/dist/index.d.ts:435
 
 ***
 
@@ -623,7 +623,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:442
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:460
+packages/quickjs-ffi-types/dist/index.d.ts:453
 
 ***
 
@@ -641,7 +641,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:460
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:492
+packages/quickjs-ffi-types/dist/index.d.ts:485
 
 ***
 
@@ -659,7 +659,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:492
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:445
+packages/quickjs-ffi-types/dist/index.d.ts:438
 
 ***
 
@@ -681,7 +681,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:445
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:490
+packages/quickjs-ffi-types/dist/index.d.ts:483
 
 ***
 
@@ -701,7 +701,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:490
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:488
+packages/quickjs-ffi-types/dist/index.d.ts:481
 
 ***
 
@@ -715,7 +715,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:488
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:441
+packages/quickjs-ffi-types/dist/index.d.ts:434
 
 ***
 
@@ -741,7 +741,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:441
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:479
+packages/quickjs-ffi-types/dist/index.d.ts:472
 
 ***
 
@@ -767,7 +767,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:479
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:480
+packages/quickjs-ffi-types/dist/index.d.ts:473
 
 ***
 
@@ -789,7 +789,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:480
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:472
+packages/quickjs-ffi-types/dist/index.d.ts:465
 
 ***
 
@@ -811,7 +811,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:472
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:474
+packages/quickjs-ffi-types/dist/index.d.ts:467
 
 ***
 
@@ -833,7 +833,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:474
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:475
+packages/quickjs-ffi-types/dist/index.d.ts:468
 
 ***
 
@@ -855,7 +855,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:475
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:473
+packages/quickjs-ffi-types/dist/index.d.ts:466
 
 ***
 
@@ -875,7 +875,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:473
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:462
+packages/quickjs-ffi-types/dist/index.d.ts:455
 
 ***
 
@@ -895,7 +895,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:462
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:466
+packages/quickjs-ffi-types/dist/index.d.ts:459
 
 ***
 
@@ -915,7 +915,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:466
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:467
+packages/quickjs-ffi-types/dist/index.d.ts:460
 
 ***
 
@@ -929,7 +929,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:467
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:443
+packages/quickjs-ffi-types/dist/index.d.ts:436
 
 ***
 
@@ -943,7 +943,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:443
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:440
+packages/quickjs-ffi-types/dist/index.d.ts:433
 
 ***
 
@@ -967,7 +967,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:440
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:491
+packages/quickjs-ffi-types/dist/index.d.ts:484
 
 ***
 
@@ -987,7 +987,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:491
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:468
+packages/quickjs-ffi-types/dist/index.d.ts:461
 
 ***
 
@@ -1005,7 +1005,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:468
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:469
+packages/quickjs-ffi-types/dist/index.d.ts:462
 
 ***
 
@@ -1023,7 +1023,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:469
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:457
+packages/quickjs-ffi-types/dist/index.d.ts:450
 
 ***
 
@@ -1045,7 +1045,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:457
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:458
+packages/quickjs-ffi-types/dist/index.d.ts:451
 
 ***
 
@@ -1065,7 +1065,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:458
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:448
+packages/quickjs-ffi-types/dist/index.d.ts:441
 
 ***
 
@@ -1083,7 +1083,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:448
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:433
+packages/quickjs-ffi-types/dist/index.d.ts:426
 
 ***
 
@@ -1103,7 +1103,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:433
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:459
+packages/quickjs-ffi-types/dist/index.d.ts:452
 
 ***
 
@@ -1129,7 +1129,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:459
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:501
+packages/quickjs-ffi-types/dist/index.d.ts:494
 
 ***
 
@@ -1149,7 +1149,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:501
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:444
+packages/quickjs-ffi-types/dist/index.d.ts:437
 
 ***
 
@@ -1167,7 +1167,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:444
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:455
+packages/quickjs-ffi-types/dist/index.d.ts:448
 
 ***
 
@@ -1187,7 +1187,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:455
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:456
+packages/quickjs-ffi-types/dist/index.d.ts:449
 
 ***
 
@@ -1207,7 +1207,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:456
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:493
+packages/quickjs-ffi-types/dist/index.d.ts:486
 
 ***
 
@@ -1221,7 +1221,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:493
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:446
+packages/quickjs-ffi-types/dist/index.d.ts:439
 
 ***
 
@@ -1241,7 +1241,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:446
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:461
+packages/quickjs-ffi-types/dist/index.d.ts:454
 
 ***
 
@@ -1263,7 +1263,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:461
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:465
+packages/quickjs-ffi-types/dist/index.d.ts:458
 
 ***
 
@@ -1283,7 +1283,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:465
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:495
+packages/quickjs-ffi-types/dist/index.d.ts:488
 
 ***
 
@@ -1303,7 +1303,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:495
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:494
+packages/quickjs-ffi-types/dist/index.d.ts:487
 
 ***
 
@@ -1317,7 +1317,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:494
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:437
+packages/quickjs-ffi-types/dist/index.d.ts:430
 
 ***
 
@@ -1337,7 +1337,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:437
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:483
+packages/quickjs-ffi-types/dist/index.d.ts:476
 
 ***
 
@@ -1357,7 +1357,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:483
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:435
+packages/quickjs-ffi-types/dist/index.d.ts:428
 
 ***
 
@@ -1375,7 +1375,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:435
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:504
+packages/quickjs-ffi-types/dist/index.d.ts:497
 
 ***
 
@@ -1393,7 +1393,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:504
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:506
+packages/quickjs-ffi-types/dist/index.d.ts:499
 
 ***
 
@@ -1411,7 +1411,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:506
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:436
+packages/quickjs-ffi-types/dist/index.d.ts:429
 
 ***
 
@@ -1429,7 +1429,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:436
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:503
+packages/quickjs-ffi-types/dist/index.d.ts:496
 
 ***
 
@@ -1449,7 +1449,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:503
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:505
+packages/quickjs-ffi-types/dist/index.d.ts:498
 
 ***
 
@@ -1469,7 +1469,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:505
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:439
+packages/quickjs-ffi-types/dist/index.d.ts:432
 
 ***
 
@@ -1489,7 +1489,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:439
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:434
+packages/quickjs-ffi-types/dist/index.d.ts:427
 
 ***
 
@@ -1509,7 +1509,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:434
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:498
+packages/quickjs-ffi-types/dist/index.d.ts:491
 
 ***
 
@@ -1533,7 +1533,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:498
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:476
+packages/quickjs-ffi-types/dist/index.d.ts:469
 
 ***
 
@@ -1557,7 +1557,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:476
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:477
+packages/quickjs-ffi-types/dist/index.d.ts:470
 
 ***
 
@@ -1575,7 +1575,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:477
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:496
+packages/quickjs-ffi-types/dist/index.d.ts:489
 
 ***
 
@@ -1595,7 +1595,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:496
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:432
+packages/quickjs-ffi-types/dist/index.d.ts:425
 
 ***
 
@@ -1615,7 +1615,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:432
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:489
+packages/quickjs-ffi-types/dist/index.d.ts:482
 
 ***
 
@@ -1635,7 +1635,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:489
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:508
+packages/quickjs-ffi-types/dist/index.d.ts:501
 
 ***
 
@@ -1655,7 +1655,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:508
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:507
+packages/quickjs-ffi-types/dist/index.d.ts:500
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSAsyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:543
+packages/quickjs-ffi-types/dist/index.d.ts:536
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:543
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:544
+packages/quickjs-ffi-types/dist/index.d.ts:537
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:544
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:542
+packages/quickjs-ffi-types/dist/index.d.ts:535
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSEmscriptenModule.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSEmscriptenModule.md
@@ -14,13 +14,6 @@ QuickJS.
 - [Extends](QuickJSEmscriptenModule.md#extends)
 - [Properties](QuickJSEmscriptenModule.md#properties)
   - [FAST\_MEMORY](QuickJSEmscriptenModule.md#fast-memory)
-  - [HEAP16](QuickJSEmscriptenModule.md#heap16)
-  - [HEAP32](QuickJSEmscriptenModule.md#heap32)
-  - [HEAP8](QuickJSEmscriptenModule.md#heap8)
-  - [HEAPF32](QuickJSEmscriptenModule.md#heapf32)
-  - [HEAPF64](QuickJSEmscriptenModule.md#heapf64)
-  - [HEAPU16](QuickJSEmscriptenModule.md#heapu16)
-  - [HEAPU32](QuickJSEmscriptenModule.md#heapu32)
   - [HEAPU8](QuickJSEmscriptenModule.md#heapu8)
   - [TOTAL\_MEMORY](QuickJSEmscriptenModule.md#total-memory)
   - [TOTAL\_STACK](QuickJSEmscriptenModule.md#total-stack)
@@ -55,105 +48,7 @@ QuickJS.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:293
-
-***
-
-### HEAP16
-
-> **HEAP16**: `Int16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAP16`](EmscriptenModule.md#heap16)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:284
-
-***
-
-### HEAP32
-
-> **HEAP32**: `Int32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAP32`](EmscriptenModule.md#heap32)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:285
-
-***
-
-### HEAP8
-
-> **HEAP8**: `Int8Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAP8`](EmscriptenModule.md#heap8)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:283
-
-***
-
-### HEAPF32
-
-> **HEAPF32**: `Float32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPF32`](EmscriptenModule.md#heapf32)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:289
-
-***
-
-### HEAPF64
-
-> **HEAPF64**: `Float64Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPF64`](EmscriptenModule.md#heapf64)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:290
-
-***
-
-### HEAPU16
-
-> **HEAPU16**: `Uint16Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPU16`](EmscriptenModule.md#heapu16)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:287
-
-***
-
-### HEAPU32
-
-> **HEAPU32**: `Uint32Array`
-
-#### Inherited from
-
-[`quickjs-emscripten.EmscriptenModule.HEAPU32`](EmscriptenModule.md#heapu32)
-
-#### Source
-
-packages/quickjs-ffi-types/dist/index.d.ts:288
+packages/quickjs-ffi-types/dist/index.d.ts:286
 
 ***
 
@@ -167,7 +62,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:288
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:286
+packages/quickjs-ffi-types/dist/index.d.ts:283
 
 ***
 
@@ -181,7 +76,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:286
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:292
+packages/quickjs-ffi-types/dist/index.d.ts:285
 
 ***
 
@@ -195,7 +90,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:292
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:291
+packages/quickjs-ffi-types/dist/index.d.ts:284
 
 ***
 
@@ -205,7 +100,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:291
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:330
+packages/quickjs-ffi-types/dist/index.d.ts:323
 
 ***
 
@@ -215,7 +110,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:330
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:329
+packages/quickjs-ffi-types/dist/index.d.ts:322
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSFFI.md
@@ -98,7 +98,7 @@ Set at compile time.
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:351
+packages/quickjs-ffi-types/dist/index.d.ts:344
 
 ***
 
@@ -118,7 +118,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:351
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:413
+packages/quickjs-ffi-types/dist/index.d.ts:406
 
 ***
 
@@ -132,7 +132,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:413
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:411
+packages/quickjs-ffi-types/dist/index.d.ts:404
 
 ***
 
@@ -146,7 +146,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:411
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:410
+packages/quickjs-ffi-types/dist/index.d.ts:403
 
 ***
 
@@ -160,7 +160,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:410
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:358
+packages/quickjs-ffi-types/dist/index.d.ts:351
 
 ***
 
@@ -186,7 +186,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:358
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:395
+packages/quickjs-ffi-types/dist/index.d.ts:388
 
 ***
 
@@ -220,7 +220,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:395
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:393
+packages/quickjs-ffi-types/dist/index.d.ts:386
 
 ***
 
@@ -240,7 +240,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:393
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:397
+packages/quickjs-ffi-types/dist/index.d.ts:390
 
 ***
 
@@ -260,7 +260,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:397
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:374
+packages/quickjs-ffi-types/dist/index.d.ts:367
 
 ***
 
@@ -288,7 +288,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:374
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:398
+packages/quickjs-ffi-types/dist/index.d.ts:391
 
 ***
 
@@ -310,7 +310,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:398
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:389
+packages/quickjs-ffi-types/dist/index.d.ts:382
 
 ***
 
@@ -330,7 +330,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:389
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:373
+packages/quickjs-ffi-types/dist/index.d.ts:366
 
 ***
 
@@ -348,7 +348,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:373
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:369
+packages/quickjs-ffi-types/dist/index.d.ts:362
 
 ***
 
@@ -366,7 +366,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:369
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:367
+packages/quickjs-ffi-types/dist/index.d.ts:360
 
 ***
 
@@ -386,7 +386,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:367
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:370
+packages/quickjs-ffi-types/dist/index.d.ts:363
 
 ***
 
@@ -406,7 +406,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:370
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:371
+packages/quickjs-ffi-types/dist/index.d.ts:364
 
 ***
 
@@ -426,7 +426,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:371
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:372
+packages/quickjs-ffi-types/dist/index.d.ts:365
 
 ***
 
@@ -446,7 +446,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:372
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:383
+packages/quickjs-ffi-types/dist/index.d.ts:376
 
 ***
 
@@ -466,7 +466,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:383
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:384
+packages/quickjs-ffi-types/dist/index.d.ts:377
 
 ***
 
@@ -484,7 +484,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:384
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:408
+packages/quickjs-ffi-types/dist/index.d.ts:401
 
 ***
 
@@ -498,7 +498,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:408
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:362
+packages/quickjs-ffi-types/dist/index.d.ts:355
 
 ***
 
@@ -518,7 +518,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:362
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:380
+packages/quickjs-ffi-types/dist/index.d.ts:373
 
 ***
 
@@ -536,7 +536,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:380
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:403
+packages/quickjs-ffi-types/dist/index.d.ts:396
 
 ***
 
@@ -554,7 +554,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:403
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:365
+packages/quickjs-ffi-types/dist/index.d.ts:358
 
 ***
 
@@ -576,7 +576,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:365
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:401
+packages/quickjs-ffi-types/dist/index.d.ts:394
 
 ***
 
@@ -596,7 +596,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:401
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:399
+packages/quickjs-ffi-types/dist/index.d.ts:392
 
 ***
 
@@ -610,7 +610,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:399
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:361
+packages/quickjs-ffi-types/dist/index.d.ts:354
 
 ***
 
@@ -636,7 +636,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:361
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:394
+packages/quickjs-ffi-types/dist/index.d.ts:387
 
 ***
 
@@ -658,7 +658,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:394
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:390
+packages/quickjs-ffi-types/dist/index.d.ts:383
 
 ***
 
@@ -680,7 +680,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:390
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:391
+packages/quickjs-ffi-types/dist/index.d.ts:384
 
 ***
 
@@ -700,7 +700,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:391
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:382
+packages/quickjs-ffi-types/dist/index.d.ts:375
 
 ***
 
@@ -720,7 +720,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:382
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:386
+packages/quickjs-ffi-types/dist/index.d.ts:379
 
 ***
 
@@ -734,7 +734,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:386
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:363
+packages/quickjs-ffi-types/dist/index.d.ts:356
 
 ***
 
@@ -748,7 +748,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:363
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:360
+packages/quickjs-ffi-types/dist/index.d.ts:353
 
 ***
 
@@ -772,7 +772,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:360
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:402
+packages/quickjs-ffi-types/dist/index.d.ts:395
 
 ***
 
@@ -792,7 +792,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:402
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:387
+packages/quickjs-ffi-types/dist/index.d.ts:380
 
 ***
 
@@ -810,7 +810,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:387
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:388
+packages/quickjs-ffi-types/dist/index.d.ts:381
 
 ***
 
@@ -828,7 +828,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:388
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:377
+packages/quickjs-ffi-types/dist/index.d.ts:370
 
 ***
 
@@ -850,7 +850,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:377
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:378
+packages/quickjs-ffi-types/dist/index.d.ts:371
 
 ***
 
@@ -870,7 +870,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:378
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:368
+packages/quickjs-ffi-types/dist/index.d.ts:361
 
 ***
 
@@ -888,7 +888,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:368
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:353
+packages/quickjs-ffi-types/dist/index.d.ts:346
 
 ***
 
@@ -908,7 +908,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:353
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:379
+packages/quickjs-ffi-types/dist/index.d.ts:372
 
 ***
 
@@ -934,7 +934,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:379
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:412
+packages/quickjs-ffi-types/dist/index.d.ts:405
 
 ***
 
@@ -954,7 +954,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:412
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:364
+packages/quickjs-ffi-types/dist/index.d.ts:357
 
 ***
 
@@ -972,7 +972,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:364
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:375
+packages/quickjs-ffi-types/dist/index.d.ts:368
 
 ***
 
@@ -992,7 +992,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:375
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:376
+packages/quickjs-ffi-types/dist/index.d.ts:369
 
 ***
 
@@ -1012,7 +1012,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:376
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:404
+packages/quickjs-ffi-types/dist/index.d.ts:397
 
 ***
 
@@ -1026,7 +1026,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:404
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:366
+packages/quickjs-ffi-types/dist/index.d.ts:359
 
 ***
 
@@ -1046,7 +1046,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:366
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:381
+packages/quickjs-ffi-types/dist/index.d.ts:374
 
 ***
 
@@ -1068,7 +1068,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:381
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:385
+packages/quickjs-ffi-types/dist/index.d.ts:378
 
 ***
 
@@ -1088,7 +1088,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:385
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:406
+packages/quickjs-ffi-types/dist/index.d.ts:399
 
 ***
 
@@ -1108,7 +1108,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:406
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:405
+packages/quickjs-ffi-types/dist/index.d.ts:398
 
 ***
 
@@ -1122,7 +1122,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:405
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:357
+packages/quickjs-ffi-types/dist/index.d.ts:350
 
 ***
 
@@ -1142,7 +1142,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:357
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:396
+packages/quickjs-ffi-types/dist/index.d.ts:389
 
 ***
 
@@ -1162,7 +1162,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:396
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:355
+packages/quickjs-ffi-types/dist/index.d.ts:348
 
 ***
 
@@ -1180,7 +1180,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:355
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:415
+packages/quickjs-ffi-types/dist/index.d.ts:408
 
 ***
 
@@ -1198,7 +1198,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:415
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:417
+packages/quickjs-ffi-types/dist/index.d.ts:410
 
 ***
 
@@ -1216,7 +1216,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:417
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:356
+packages/quickjs-ffi-types/dist/index.d.ts:349
 
 ***
 
@@ -1234,7 +1234,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:356
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:414
+packages/quickjs-ffi-types/dist/index.d.ts:407
 
 ***
 
@@ -1254,7 +1254,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:414
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:416
+packages/quickjs-ffi-types/dist/index.d.ts:409
 
 ***
 
@@ -1274,7 +1274,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:416
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:359
+packages/quickjs-ffi-types/dist/index.d.ts:352
 
 ***
 
@@ -1294,7 +1294,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:359
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:354
+packages/quickjs-ffi-types/dist/index.d.ts:347
 
 ***
 
@@ -1314,7 +1314,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:354
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:409
+packages/quickjs-ffi-types/dist/index.d.ts:402
 
 ***
 
@@ -1338,7 +1338,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:409
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:392
+packages/quickjs-ffi-types/dist/index.d.ts:385
 
 ***
 
@@ -1356,7 +1356,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:392
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:407
+packages/quickjs-ffi-types/dist/index.d.ts:400
 
 ***
 
@@ -1376,7 +1376,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:407
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:352
+packages/quickjs-ffi-types/dist/index.d.ts:345
 
 ***
 
@@ -1396,7 +1396,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:352
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:400
+packages/quickjs-ffi-types/dist/index.d.ts:393
 
 ***
 
@@ -1416,7 +1416,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:400
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:419
+packages/quickjs-ffi-types/dist/index.d.ts:412
 
 ***
 
@@ -1436,7 +1436,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:419
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:418
+packages/quickjs-ffi-types/dist/index.d.ts:411
 
 ***
 

--- a/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
+++ b/doc/quickjs-emscripten/interfaces/QuickJSSyncVariant.md
@@ -36,7 +36,7 @@ build variant to [newQuickJSWASMModule](../exports.md#newquickjswasmmodule) or [
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:529
+packages/quickjs-ffi-types/dist/index.d.ts:522
 
 ***
 
@@ -50,7 +50,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:529
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:530
+packages/quickjs-ffi-types/dist/index.d.ts:523
 
 ***
 
@@ -60,7 +60,7 @@ packages/quickjs-ffi-types/dist/index.d.ts:530
 
 #### Source
 
-packages/quickjs-ffi-types/dist/index.d.ts:528
+packages/quickjs-ffi-types/dist/index.d.ts:521
 
 ***
 

--- a/exportedRuntimeMethods.asyncify.json
+++ b/exportedRuntimeMethods.asyncify.json
@@ -1,1 +1,1 @@
-["cwrap", "stringToUTF8", "lengthBytesUTF8", "UTF8ToString", "HEAPU8", "HEAP8", "Asyncify"]
+["cwrap", "stringToUTF8", "lengthBytesUTF8", "UTF8ToString", "HEAPU8", "Asyncify"]

--- a/exportedRuntimeMethods.json
+++ b/exportedRuntimeMethods.json
@@ -1,1 +1,1 @@
-["cwrap", "stringToUTF8", "lengthBytesUTF8", "UTF8ToString", "HEAPU8", "HEAP8"]
+["cwrap", "stringToUTF8", "lengthBytesUTF8", "UTF8ToString", "HEAPU8"]

--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -1054,7 +1054,7 @@ export class QuickJSContext
       }
       const len = this.uint32Out.value.typedArray[0]
       const ptr = outPtr.value.typedArray[0]
-      const pointerArray = new Uint32Array(this.module.HEAP8.buffer, ptr, len)
+      const pointerArray = new Uint32Array(this.module.HEAPU8.buffer, ptr, len)
       const handles = Array.from(pointerArray).map((ptr) =>
         this.memory.heapValueHandle(ptr as JSValuePointer),
       )

--- a/packages/quickjs-ffi-types/src/emscripten-types.ts
+++ b/packages/quickjs-ffi-types/src/emscripten-types.ts
@@ -154,15 +154,7 @@ export interface EmscriptenModule extends EmscriptenModuleLoaderOptions {
     opts?: Emscripten.CCallOpts,
   ): (...args: any[]) => any
 
-  // USE_TYPED_ARRAYS == 2
-  HEAP8: Int8Array
-  HEAP16: Int16Array
-  HEAP32: Int32Array
   HEAPU8: Uint8Array
-  HEAPU16: Uint16Array
-  HEAPU32: Uint32Array
-  HEAPF32: Float32Array
-  HEAPF64: Float64Array
 
   TOTAL_STACK: number
   TOTAL_MEMORY: number

--- a/packages/variant-quickjs-asmjs-mjs-release-sync/Makefile
+++ b/packages/variant-quickjs-asmjs-mjs-release-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-asmjs-mjs-release-sync/Makefile
+++ b/packages/variant-quickjs-asmjs-mjs-release-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-asmjs-mjs-release-sync/Makefile
+++ b/packages/variant-quickjs-asmjs-mjs-release-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,60 +41,65 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s WASM=0
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-s WASM_ASYNC_COMPILATION=0
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s WASM=0
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+LDFLAGS_WASM+=-s WASM_ASYNC_COMPILATION=0
 
-CFLAGS_MJS+=-s ENVIRONMENT=web,worker,node
+# Emscripten options - target specific linker flags
+
+LDFLAGS_MJS+=-s ENVIRONMENT=web,worker,node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -106,7 +111,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -124,15 +128,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -155,22 +159,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,70 +41,77 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-O3
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-O3
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV+=ASYNCIFY=true
@@ -115,7 +122,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -133,15 +139,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -164,22 +170,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-ng-wasmfile-debug-asyncify/README.md
+++ b/packages/variant-quickjs-ng-wasmfile-debug-asyncify/README.md
@@ -72,22 +72,22 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-O3"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,65 +41,72 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
+CFLAGS_COMPILE+=-fsanitize=leak
+CFLAGS_COMPILE+=-g2
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-DQTS_SANITIZE_LEAK
-CFLAGS_WASM+=-fsanitize=leak
-CFLAGS_WASM+=-g2
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV+=DEBUG=true
@@ -109,7 +116,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -127,15 +133,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -158,22 +164,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-ng-wasmfile-debug-sync/README.md
+++ b/packages/variant-quickjs-ng-wasmfile-debug-sync/README.md
@@ -76,13 +76,13 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,66 +41,73 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV+=ASYNCIFY=true
@@ -110,7 +117,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -128,15 +134,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -159,22 +165,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-ng-wasmfile-release-asyncify/README.md
+++ b/packages/variant-quickjs-ng-wasmfile-release-asyncify/README.md
@@ -72,15 +72,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/packages/variant-quickjs-ng-wasmfile-release-sync/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-release-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-ng-wasmfile-release-sync/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-release-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-ng-wasmfile-release-sync/Makefile
+++ b/packages/variant-quickjs-ng-wasmfile-release-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,59 +41,66 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 
@@ -103,7 +110,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -121,15 +127,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -152,22 +158,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,70 +41,73 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-O3
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-O3
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
 
 
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
 
 
 # GENERATE_TS options - variant specific
@@ -116,7 +119,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -134,15 +136,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -165,22 +167,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
@@ -90,7 +90,6 @@ CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
 CFLAGS_COMPILE+=-O0
 CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
 CFLAGS_COMPILE+=-DDUMP_LEAKS=1
-CFLAGS_COMPILE+=-gsource-map
 CFLAGS_COMPILE+=-O3
 
 # Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/README.md
@@ -65,7 +65,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-O3",
   "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",

--- a/packages/variant-quickjs-singlefile-browser-debug-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-browser-debug-asyncify/README.md
@@ -60,23 +60,23 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-O3"
+  "-s SINGLE_FILE=1"
 ]
 ```

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,65 +41,68 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
+CFLAGS_COMPILE+=-fsanitize=leak
+CFLAGS_COMPILE+=-g2
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-DQTS_SANITIZE_LEAK
-CFLAGS_WASM+=-fsanitize=leak
-CFLAGS_WASM+=-g2
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
 
 
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
 
 
 # GENERATE_TS options - variant specific
@@ -110,7 +113,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -128,15 +130,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -159,22 +161,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
@@ -88,7 +88,6 @@ endif
 CFLAGS_COMPILE+=-O0
 CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
 CFLAGS_COMPILE+=-DDUMP_LEAKS=1
-CFLAGS_COMPILE+=-gsource-map
 CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
 CFLAGS_COMPILE+=-fsanitize=leak
 CFLAGS_COMPILE+=-g2

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/README.md
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/README.md
@@ -63,7 +63,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-DQTS_SANITIZE_LEAK",
   "-fsanitize=leak",
   "-g2",

--- a/packages/variant-quickjs-singlefile-browser-debug-sync/README.md
+++ b/packages/variant-quickjs-singlefile-browser-debug-sync/README.md
@@ -64,14 +64,14 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "-s SINGLE_FILE=1"
 ]
 ```

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,66 +41,69 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
 
 
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
 
 
 # GENERATE_TS options - variant specific
@@ -111,7 +114,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -129,15 +131,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -160,22 +162,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-browser-release-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-browser-release-asyncify/README.md
@@ -60,15 +60,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/packages/variant-quickjs-singlefile-browser-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-release-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-singlefile-browser-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-release-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,59 +41,62 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
 
 
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
 
 
 # GENERATE_TS options - variant specific
@@ -104,7 +107,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -122,15 +124,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -153,22 +155,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-browser-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-browser-release-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
@@ -90,7 +90,6 @@ CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
 CFLAGS_COMPILE+=-O0
 CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
 CFLAGS_COMPILE+=-DDUMP_LEAKS=1
-CFLAGS_COMPILE+=-gsource-map
 CFLAGS_COMPILE+=-O3
 
 # Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,68 +41,73 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-O3
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-O3
-CFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -116,7 +121,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -134,15 +138,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -165,22 +169,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/README.md
@@ -65,7 +65,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-O3",
   "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",

--- a/packages/variant-quickjs-singlefile-cjs-debug-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-cjs-debug-asyncify/README.md
@@ -60,23 +60,23 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-O3"
+  "-s SINGLE_FILE=1"
 ]
 ```

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,63 +41,68 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
+CFLAGS_COMPILE+=-fsanitize=leak
+CFLAGS_COMPILE+=-g2
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-DQTS_SANITIZE_LEAK
-CFLAGS_WASM+=-fsanitize=leak
-CFLAGS_WASM+=-g2
-CFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -110,7 +115,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -128,15 +132,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -159,22 +163,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
@@ -88,7 +88,6 @@ endif
 CFLAGS_COMPILE+=-O0
 CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
 CFLAGS_COMPILE+=-DDUMP_LEAKS=1
-CFLAGS_COMPILE+=-gsource-map
 CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
 CFLAGS_COMPILE+=-fsanitize=leak
 CFLAGS_COMPILE+=-g2

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/README.md
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/README.md
@@ -63,7 +63,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-DQTS_SANITIZE_LEAK",
   "-fsanitize=leak",
   "-g2",

--- a/packages/variant-quickjs-singlefile-cjs-debug-sync/README.md
+++ b/packages/variant-quickjs-singlefile-cjs-debug-sync/README.md
@@ -64,14 +64,14 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "-s SINGLE_FILE=1"
 ]
 ```

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,64 +41,69 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -111,7 +116,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -129,15 +133,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -160,22 +164,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-cjs-release-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-cjs-release-asyncify/README.md
@@ -60,15 +60,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/packages/variant-quickjs-singlefile-cjs-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-release-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,57 +41,62 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=web,worker,node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -104,7 +109,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -122,15 +126,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -153,22 +157,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-cjs-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-release-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-singlefile-cjs-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-cjs-release-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,69 +41,74 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-O3
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-O3
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
 
-CFLAGS_MJS+=-s ENVIRONMENT=node
+# Emscripten options - target specific linker flags
+
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -116,7 +121,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -134,15 +138,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -165,22 +169,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
@@ -90,7 +90,6 @@ CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
 CFLAGS_COMPILE+=-O0
 CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
 CFLAGS_COMPILE+=-DDUMP_LEAKS=1
-CFLAGS_COMPILE+=-gsource-map
 CFLAGS_COMPILE+=-O3
 
 # Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/README.md
@@ -65,7 +65,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-O3",
   "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",

--- a/packages/variant-quickjs-singlefile-mjs-debug-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-mjs-debug-asyncify/README.md
@@ -60,23 +60,23 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-O3"
+  "-s SINGLE_FILE=1"
 ]
 ```

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,64 +41,69 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
+CFLAGS_COMPILE+=-fsanitize=leak
+CFLAGS_COMPILE+=-g2
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
-CFLAGS_WASM+=-DQTS_SANITIZE_LEAK
-CFLAGS_WASM+=-fsanitize=leak
-CFLAGS_WASM+=-g2
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
 
-CFLAGS_MJS+=-s ENVIRONMENT=node
+# Emscripten options - target specific linker flags
+
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -110,7 +115,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -128,15 +132,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -159,22 +163,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
@@ -88,7 +88,6 @@ endif
 CFLAGS_COMPILE+=-O0
 CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
 CFLAGS_COMPILE+=-DDUMP_LEAKS=1
-CFLAGS_COMPILE+=-gsource-map
 CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
 CFLAGS_COMPILE+=-fsanitize=leak
 CFLAGS_COMPILE+=-g2

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/README.md
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/README.md
@@ -63,7 +63,6 @@ Variant-specific Emscripten build flags:
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
-  "-gsource-map",
   "-DQTS_SANITIZE_LEAK",
   "-fsanitize=leak",
   "-g2",

--- a/packages/variant-quickjs-singlefile-mjs-debug-sync/README.md
+++ b/packages/variant-quickjs-singlefile-mjs-debug-sync/README.md
@@ -64,14 +64,14 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
   "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-s SINGLE_FILE=1",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "-s SINGLE_FILE=1"
 ]
 ```

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,65 +41,70 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
 
-CFLAGS_MJS+=-s ENVIRONMENT=node
+# Emscripten options - target specific linker flags
+
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -111,7 +116,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -129,15 +133,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -160,22 +164,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-singlefile-mjs-release-asyncify/README.md
+++ b/packages/variant-quickjs-singlefile-mjs-release-asyncify/README.md
@@ -60,15 +60,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/packages/variant-quickjs-singlefile-mjs-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-release-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-singlefile-mjs-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-release-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,58 +41,63 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-s SINGLE_FILE=1
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+LDFLAGS_WASM+=-s SINGLE_FILE=1
 
-CFLAGS_MJS+=-s ENVIRONMENT=node
+# Emscripten options - target specific linker flags
+
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
 
 
 
@@ -104,7 +109,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -122,15 +126,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -153,22 +157,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-singlefile-mjs-release-sync/Makefile
+++ b/packages/variant-quickjs-singlefile-mjs-release-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/Makefile
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,70 +41,77 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-O3
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-O3
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV+=ASYNCIFY=true
@@ -115,7 +122,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -133,15 +139,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -164,22 +170,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-wasmfile-debug-asyncify/README.md
+++ b/packages/variant-quickjs-wasmfile-debug-asyncify/README.md
@@ -72,22 +72,22 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
-  "-s ASYNCIFY_STACK_SIZE=81920",
-  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
-  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
-  "-lasync.js",
   "-O0",
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-O3",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
+  "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
+  "-lasync.js",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-O3"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```

--- a/packages/variant-quickjs-wasmfile-debug-sync/Makefile
+++ b/packages/variant-quickjs-wasmfile-debug-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-wasmfile-debug-sync/Makefile
+++ b/packages/variant-quickjs-wasmfile-debug-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,65 +41,72 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-O0
+CFLAGS_COMPILE+=-DQTS_DEBUG_MODE
+CFLAGS_COMPILE+=-DDUMP_LEAKS=1
+CFLAGS_COMPILE+=-gsource-map
+CFLAGS_COMPILE+=-DQTS_SANITIZE_LEAK
+CFLAGS_COMPILE+=-fsanitize=leak
+CFLAGS_COMPILE+=-g2
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-O0
-CFLAGS_WASM+=-DQTS_DEBUG_MODE
-CFLAGS_WASM+=-DDUMP_LEAKS=1
-CFLAGS_WASM+=-gsource-map
-CFLAGS_WASM+=-s ASSERTIONS=1
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_WASM+=-DQTS_SANITIZE_LEAK
-CFLAGS_WASM+=-fsanitize=leak
-CFLAGS_WASM+=-g2
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASSERTIONS=1
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-sourceMapJson.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV+=DEBUG=true
@@ -109,7 +116,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -127,15 +133,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -158,22 +164,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-wasmfile-debug-sync/Makefile
+++ b/packages/variant-quickjs-wasmfile-debug-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-wasmfile-debug-sync/README.md
+++ b/packages/variant-quickjs-wasmfile-debug-sync/README.md
@@ -76,13 +76,13 @@ Variant-specific Emscripten build flags:
   "-DQTS_DEBUG_MODE",
   "-DDUMP_LEAKS=1",
   "-gsource-map",
+  "-DQTS_SANITIZE_LEAK",
+  "-fsanitize=leak",
+  "-g2",
   "-s ASSERTIONS=1",
   "--pre-js $(TEMPLATES)/pre-extension.js",
   "--pre-js $(TEMPLATES)/pre-sourceMapJson.js",
   "--pre-js $(TEMPLATES)/pre-wasmOffsetConverter.js",
-  "--pre-js $(TEMPLATES)/pre-wasmMemory.js",
-  "-DQTS_SANITIZE_LEAK",
-  "-fsanitize=leak",
-  "-g2"
+  "--pre-js $(TEMPLATES)/pre-wasmMemory.js"
 ]
 ```

--- a/packages/variant-quickjs-wasmfile-release-asyncify/Makefile
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,66 +41,73 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=ASYNCIFY
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY=1
+CFLAGS_COMPILE+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-s ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY=1
-CFLAGS_WASM+=-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
-CFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
-CFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
-CFLAGS_WASM+=-lasync.js
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=-s ASYNCIFY=1
+LDFLAGS_WASM+=-s ASYNCIFY_STACK_SIZE=81920
+LDFLAGS_WASM+=-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json
+LDFLAGS_WASM+=-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json
+LDFLAGS_WASM+=-lasync.js
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV+=ASYNCIFY=true
@@ -110,7 +117,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -128,15 +134,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -159,22 +165,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/packages/variant-quickjs-wasmfile-release-asyncify/Makefile
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-wasmfile-release-asyncify/Makefile
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-wasmfile-release-asyncify/README.md
+++ b/packages/variant-quickjs-wasmfile-release-asyncify/README.md
@@ -72,15 +72,15 @@ Variant-specific Emscripten build flags:
 
 ```json
 [
-  "-s ASYNCIFY=1",
   "-DQTS_ASYNCIFY=1",
   "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-Oz",
+  "-flto",
+  "-s ASYNCIFY=1",
   "-s ASYNCIFY_STACK_SIZE=81920",
   "-s ASYNCIFY_REMOVE=@$(BUILD_WRAPPER)/asyncify-remove.json",
   "-s ASYNCIFY_IMPORTS=@$(BUILD_WRAPPER)/asyncify-imports.json",
   "-lasync.js",
-  "-Oz",
-  "-flto",
   "--closure 1",
   "-s FILESYSTEM=0",
   "--pre-js $(TEMPLATES)/pre-extension.js",

--- a/packages/variant-quickjs-wasmfile-release-sync/Makefile
+++ b/packages/variant-quickjs-wasmfile-release-sync/Makefile
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/packages/variant-quickjs-wasmfile-release-sync/Makefile
+++ b/packages/variant-quickjs-wasmfile-release-sync/Makefile
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0

--- a/packages/variant-quickjs-wasmfile-release-sync/Makefile
+++ b/packages/variant-quickjs-wasmfile-release-sync/Makefile
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,59 +41,66 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=SYNC
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE+=-Oz
+CFLAGS_COMPILE+=-flto
 
-# Emscripten options - variant & target specific
-CFLAGS_WASM+=-Oz
-CFLAGS_WASM+=-flto
-CFLAGS_WASM+=--closure 1
-CFLAGS_WASM+=-s FILESYSTEM=0
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
-CFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
-CFLAGS_CJS+=-s ENVIRONMENT=node
-CFLAGS_MJS+=-s ENVIRONMENT=node
-CFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
-CFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_WASM+=--closure 1
+LDFLAGS_WASM+=-s FILESYSTEM=0
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-extension.js
+LDFLAGS_WASM+=--pre-js $(TEMPLATES)/pre-wasmMemory.js
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS+=-s ENVIRONMENT=node
+LDFLAGS_CJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_CJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_MJS+=-s ENVIRONMENT=node
+LDFLAGS_MJS+=-s MIN_NODE_VERSION=160000
+LDFLAGS_MJS+=-s NODEJS_CATCH_EXIT=0
+LDFLAGS_BROWSER+=-s ENVIRONMENT=web,worker
+LDFLAGS_CLOUDFLARE+=-s ENVIRONMENT=web
 
 # GENERATE_TS options - variant specific
 
@@ -103,7 +110,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -121,15 +127,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -152,22 +158,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -286,6 +286,8 @@ const TRIVIAL_FUNCTIONS_EXCLUDED_FROM_ASYNCIFY_REMOVE = new Set([
   "QTS_BuildIsSanitizeLeak",
   "QTS_BuildIsDebug",
   "QTS_TestStringArg",
+  "QTS_RecoverableLeakCheck",
+  "QTS_GetDebugLogEnabled",
 ])
 
 function buildSyncSymbols(context: Context, matches: RegExpMatchArray[]) {

--- a/scripts/prepareVariants.ts
+++ b/scripts/prepareVariants.ts
@@ -725,10 +725,7 @@ function renderMakefile(targetName: string, variant: BuildVariant): string {
   // Get split flags for variant
   const { compile, link } = getFlags(targetName, variant)
 
-  template.replace(
-    "CFLAGS_COMPILE_VARIANT=REPLACE_THIS",
-    appendEnvVars("CFLAGS_COMPILE", compile),
-  )
+  template.replace("CFLAGS_COMPILE_VARIANT=REPLACE_THIS", appendEnvVars("CFLAGS_COMPILE", compile))
 
   template.replace("LDFLAGS_VARIANT=REPLACE_THIS", appendEnvVars("LDFLAGS_WASM", link))
 

--- a/scripts/prepareVariants.ts
+++ b/scripts/prepareVariants.ts
@@ -215,9 +215,10 @@ const SyncModeLinkFlags = {
 }
 
 // Compiler flags for release mode
+// Note: -gsource-map is added conditionally in getFlags() since it's incompatible with SINGLE_FILE
 const ReleaseModeCompileFlags = {
   [ReleaseMode.Release]: [`-Oz`, `-flto`],
-  [ReleaseMode.Debug]: [`-O0`, "-DQTS_DEBUG_MODE", `-DDUMP_LEAKS=1`, `-gsource-map`],
+  [ReleaseMode.Debug]: [`-O0`, "-DQTS_DEBUG_MODE", `-DDUMP_LEAKS=1`],
 }
 
 // Linker flags for release mode
@@ -260,6 +261,14 @@ function getFlags(targetName: string, variant: BuildVariant): SplitFlags {
   link.push(...ReleaseModeLinkFlags[variant.releaseMode])
 
   link.push(...EmscriptenInclusionLinkFlags[variant.emscriptenInclusion])
+
+  // Add source maps for debug builds, but not for SINGLE_FILE (they're incompatible)
+  if (
+    variant.releaseMode === ReleaseMode.Debug &&
+    variant.emscriptenInclusion === EmscriptenInclusion.Separate
+  ) {
+    compile.push("-gsource-map")
+  }
 
   if (variant.releaseMode === ReleaseMode.Debug) {
     switch (variant.syncMode) {

--- a/scripts/validate-emcc-flags.ts
+++ b/scripts/validate-emcc-flags.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Validates emcc flag classification by testing each flag against emcc.
+ *
+ * Flags that emit "linker setting ignored during compilation" or
+ * "linker flag ignored during compilation" warnings are linker-only flags.
+ * Flags that compile without warnings are compiler flags (or work for both).
+ *
+ * Usage:
+ *   corepack yarn tsx scripts/validate-emcc-flags.ts
+ */
+
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
+
+const execFileAsync = promisify(execFile)
+
+// Flags expected to be compiler-only (or work for both compilation and linking)
+const EXPECTED_COMPILER_FLAGS = [
+  "-Oz",
+  "-O0",
+  "-O3",
+  "-flto",
+  "-DQTS_DEBUG_MODE",
+  "-DDUMP_LEAKS=1",
+  "-D_GNU_SOURCE",
+  '-DCONFIG_VERSION="test"',
+  "-DCONFIG_STACK_CHECK",
+  "-DQTS_ASYNCIFY=1",
+  "-DQTS_ASYNCIFY_DEFAULT_STACK_SIZE=81920",
+  "-DQTS_SANITIZE_LEAK",
+  "-DQTS_USE_QUICKJS_NG",
+  "-DQJS_BUILD_LIBC",
+  "-fsanitize=leak",
+  "-gsource-map",
+  "-g2",
+  "-Wcast-function-type",
+]
+
+// Flags expected to be linker-only (should produce warnings during -c compilation)
+const EXPECTED_LINKER_FLAGS = [
+  "-s MODULARIZE=1",
+  "-s IMPORTED_MEMORY=1",
+  "-s EXPORT_NAME=Test",
+  "-s INVOKE_RUN=0",
+  "-s ALLOW_MEMORY_GROWTH=1",
+  "-s ALLOW_TABLE_GROWTH=1",
+  "-s STACK_SIZE=5MB",
+  "-s SUPPORT_ERRNO=0",
+  "-s IGNORE_MISSING_MAIN=0",
+  "--no-entry",
+  "-s AUTO_JS_LIBRARIES=0",
+  "-s AUTO_NATIVE_LIBRARIES=0",
+  "-s AUTO_ARCHIVE_INDEXES=0",
+  "-s DEFAULT_TO_CXX=0",
+  "-s ALLOW_UNIMPLEMENTED_SYSCALLS=0",
+  "-s MIN_NODE_VERSION=160000",
+  "-s NODEJS_CATCH_EXIT=0",
+  "-s FILESYSTEM=0",
+  "-s EXPORT_ES6=1",
+  "-s ENVIRONMENT=node",
+  "-s ASSERTIONS=1",
+  "--closure 1",
+  "-s ASYNCIFY=1",
+  "-s ASYNCIFY_STACK_SIZE=81920",
+  "-s SINGLE_FILE=1",
+  "-s WASM=0",
+  "-s WASM_ASYNC_COMPILATION=0",
+]
+
+type FlagType = "compiler" | "linker" | "error"
+
+interface TestResult {
+  flag: string
+  expected: FlagType
+  actual: FlagType
+  passed: boolean
+  stderr?: string
+}
+
+async function testFlag(
+  flag: string,
+  testCFile: string,
+  testOFile: string,
+): Promise<FlagType> {
+  // Split flag into parts (e.g., "-s MODULARIZE=1" -> ["-s", "MODULARIZE=1"])
+  const flagParts = flag.split(" ")
+
+  try {
+    const { stderr } = await execFileAsync(
+      "emcc",
+      [...flagParts, "-c", "-o", testOFile, testCFile],
+      {
+        encoding: "utf-8",
+        timeout: 30000,
+      },
+    )
+
+    // Check for linker warning patterns
+    if (
+      stderr.includes("linker setting ignored during compilation") ||
+      stderr.includes("linker flag ignored during compilation") ||
+      stderr.includes("linker input unused")
+    ) {
+      return "linker"
+    }
+
+    return "compiler"
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; message?: string }
+    // Some flags may cause compilation to fail entirely
+    if (
+      err.stderr?.includes("linker setting ignored during compilation") ||
+      err.stderr?.includes("linker flag ignored during compilation")
+    ) {
+      return "linker"
+    }
+    console.error(`Error testing flag "${flag}": ${err.message || err}`)
+    return "error"
+  }
+}
+
+async function main() {
+  // Check if emcc is available
+  try {
+    await execFileAsync("emcc", ["--version"], { encoding: "utf-8" })
+  } catch (error) {
+    console.error("Error: emcc not found. Please ensure Emscripten is installed and in PATH.")
+    console.error("You can install it via: brew install emscripten (macOS) or see https://emscripten.org/docs/getting_started/downloads.html")
+    process.exit(1)
+  }
+
+  // Create temporary test files
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "emcc-flag-test-"))
+  const testCFile = path.join(tmpDir, "test.c")
+  const testOFile = path.join(tmpDir, "test.o")
+
+  fs.writeFileSync(testCFile, 'int main() { return 0; }\n')
+
+  const results: TestResult[] = []
+  let passCount = 0
+  let failCount = 0
+
+  console.log("Testing compiler flags (should NOT produce linker warnings)...")
+  console.log("=" .repeat(60))
+
+  for (const flag of EXPECTED_COMPILER_FLAGS) {
+    const actual = await testFlag(flag, testCFile, testOFile)
+    const passed = actual === "compiler"
+    results.push({ flag, expected: "compiler", actual, passed })
+
+    if (passed) {
+      passCount++
+      console.log(`  [PASS] ${flag}`)
+    } else {
+      failCount++
+      console.log(`  [FAIL] ${flag} - expected compiler, got ${actual}`)
+    }
+
+    // Clean up .o file
+    try {
+      fs.unlinkSync(testOFile)
+    } catch {
+      // Ignore
+    }
+  }
+
+  console.log("")
+  console.log("Testing linker flags (should produce linker warnings)...")
+  console.log("=".repeat(60))
+
+  for (const flag of EXPECTED_LINKER_FLAGS) {
+    const actual = await testFlag(flag, testCFile, testOFile)
+    const passed = actual === "linker"
+    results.push({ flag, expected: "linker", actual, passed })
+
+    if (passed) {
+      passCount++
+      console.log(`  [PASS] ${flag}`)
+    } else {
+      failCount++
+      console.log(`  [FAIL] ${flag} - expected linker, got ${actual}`)
+    }
+
+    // Clean up .o file
+    try {
+      fs.unlinkSync(testOFile)
+    } catch {
+      // Ignore
+    }
+  }
+
+  // Clean up
+  fs.rmSync(tmpDir, { recursive: true })
+
+  console.log("")
+  console.log("=".repeat(60))
+  console.log(`Results: ${passCount} passed, ${failCount} failed`)
+
+  if (failCount > 0) {
+    console.log("")
+    console.log("Failed flags:")
+    for (const result of results) {
+      if (!result.passed) {
+        console.log(`  - ${result.flag}: expected ${result.expected}, got ${result.actual}`)
+      }
+    }
+    process.exit(1)
+  }
+
+  console.log("")
+  console.log("All flags correctly classified!")
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error("Unexpected error:", error)
+  process.exit(2)
+})

--- a/scripts/validate-emcc-flags.ts
+++ b/scripts/validate-emcc-flags.ts
@@ -82,11 +82,7 @@ interface TestResult {
   stderr?: string
 }
 
-async function testFlag(
-  flag: string,
-  testCFile: string,
-  testOFile: string,
-): Promise<FlagType> {
+async function testFlag(flag: string, testCFile: string, testOFile: string): Promise<FlagType> {
   // Split flag into parts (e.g., "-s MODULARIZE=1" -> ["-s", "MODULARIZE=1"])
   const flagParts = flag.split(" ")
 
@@ -130,7 +126,9 @@ async function main() {
     await execFileAsync("emcc", ["--version"], { encoding: "utf-8" })
   } catch (error) {
     console.error("Error: emcc not found. Please ensure Emscripten is installed and in PATH.")
-    console.error("You can install it via: brew install emscripten (macOS) or see https://emscripten.org/docs/getting_started/downloads.html")
+    console.error(
+      "You can install it via: brew install emscripten (macOS) or see https://emscripten.org/docs/getting_started/downloads.html",
+    )
     process.exit(1)
   }
 
@@ -139,14 +137,14 @@ async function main() {
   const testCFile = path.join(tmpDir, "test.c")
   const testOFile = path.join(tmpDir, "test.o")
 
-  fs.writeFileSync(testCFile, 'int main() { return 0; }\n')
+  fs.writeFileSync(testCFile, "int main() { return 0; }\n")
 
   const results: TestResult[] = []
   let passCount = 0
   let failCount = 0
 
   console.log("Testing compiler flags (should NOT produce linker warnings)...")
-  console.log("=" .repeat(60))
+  console.log("=".repeat(60))
 
   for (const flag of EXPECTED_COMPILER_FLAGS) {
     const actual = await testFlag(flag, testCFile, testOFile)

--- a/templates/Variant.mk
+++ b/templates/Variant.mk
@@ -61,7 +61,7 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+# Suppress warnings about HEAPU8 in EXPORTED_RUNTIME_METHODS (it's needed but marked "invalid")
 LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js

--- a/templates/Variant.mk
+++ b/templates/Variant.mk
@@ -27,7 +27,7 @@ ifeq ($(QUICKJS_LIB),quickjs-ng)
 	QUICKJS_OBJS=quickjs-amalgam.o
 	QUICKJS_CONFIG_VERSION=$(shell cat $(QUICKJS_ROOT)/VERSION)
 	QUICKJS_DEFINES:=-D_GNU_SOURCE -DQJS_BUILD_LIBC -DCONFIG_VERSION=\"$(QUICKJS_CONFIG_VERSION)\"
-	CFLAGS_WASM+=-DQTS_USE_QUICKJS_NG
+	CFLAGS_COMPILE+=-DQTS_USE_QUICKJS_NG
 else
 	# bellard/quickjs uses separate source files
 	QUICKJS_OBJS=quickjs.o dtoa.o libregexp.o libunicode.o cutils.o quickjs-libc.o
@@ -41,54 +41,58 @@ WRAPPER_DEFINES+=-Wcast-function-type   # Likewise, warns about some quickjs cas
 EMCC_EXPORTED_FUNCS+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.json
 EMCC_EXPORTED_FUNCS_ASYNCIFY+=-s EXPORTED_FUNCTIONS=@$(BUILD_WRAPPER)/symbols.asyncify.json
 
-# Emscripten options
-# EXPORTED_RUNTIME_METHODS set below after SYNC is defined
-CFLAGS_WASM+=-s MODULARIZE=1
-CFLAGS_WASM+=-s IMPORTED_MEMORY=1 # Allow passing WASM memory to Emscripten
-CFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
-CFLAGS_WASM+=-s INVOKE_RUN=0
-CFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
-CFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
-CFLAGS_WASM+=-s STACK_SIZE=5MB
-# CFLAGS_WASM+=-s MINIMAL_RUNTIME=1 # Appears to break MODULARIZE
-CFLAGS_WASM+=-s SUPPORT_ERRNO=0
+###############################################################################
+# Emscripten flag separation:
+# - CFLAGS_COMPILE: Used during .c -> .o compilation (optimization, defines, debug info)
+# - LDFLAGS_WASM: Used only during .o -> .js linking (emscripten settings, exports, pre-js)
+# - Combined for link step via $(CFLAGS_COMPILE) $(LDFLAGS_WASM)
+###############################################################################
 
-# Emscripten options - like STRICT
+# Emscripten linker-only options
+LDFLAGS_WASM+=-s MODULARIZE=1
+LDFLAGS_WASM+=-s IMPORTED_MEMORY=1
+LDFLAGS_WASM+=-s EXPORT_NAME=QuickJSRaw
+LDFLAGS_WASM+=-s INVOKE_RUN=0
+LDFLAGS_WASM+=-s ALLOW_MEMORY_GROWTH=1
+LDFLAGS_WASM+=-s ALLOW_TABLE_GROWTH=1
+LDFLAGS_WASM+=-s STACK_SIZE=5MB
+LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
+
+# Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
-# CFLAGS_WASM+=-s STRICT_JS=1 # Doesn't work with MODULARIZE
-CFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
-CFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
-CFLAGS_WASM+=-s -lccall.js
-CFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
-CFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
-CFLAGS_WASM+=-s DEFAULT_TO_CXX=0
-CFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
+LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
+LDFLAGS_WASM+=-lccall.js
+LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0
+LDFLAGS_WASM+=-s AUTO_ARCHIVE_INDEXES=0
+LDFLAGS_WASM+=-s DEFAULT_TO_CXX=0
+LDFLAGS_WASM+=-s ALLOW_UNIMPLEMENTED_SYSCALLS=0
 
-# Emscripten options - NodeJS
-CFLAGS_WASM+=-s MIN_NODE_VERSION=160000
-CFLAGS_WASM+=-s NODEJS_CATCH_EXIT=0
-
-CFLAGS_MJS+=-s EXPORT_ES6=1
-CFLAGS_BROWSER+=-s EXPORT_ES6=1
+# Emscripten linker options - ESM exports
+LDFLAGS_MJS+=-s EXPORT_ES6=1
+LDFLAGS_BROWSER+=-s EXPORT_ES6=1
 
 # VARIANT
 SYNC=REPLACE_THIS
 
 # Set EXPORTED_RUNTIME_METHODS based on sync mode (Asyncify only available in asyncify builds)
 ifeq ($(SYNC),ASYNCIFY)
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.asyncify.json
 else
-CFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
+LDFLAGS_WASM+=-s EXPORTED_RUNTIME_METHODS=@../../exportedRuntimeMethods.json
 endif
 
-CFLAGS_WASM_BROWSER=$(CFLAGS_WASM)
+# Variant-specific compiler flags (appended to CFLAGS_COMPILE by prepareVariants.ts)
+CFLAGS_COMPILE_VARIANT=REPLACE_THIS
 
-# Emscripten options - variant & target specific
-CFLAGS_ALL=REPLACE_THIS
-CFLAGS_CJS=REPLACE_THIS
-CFLAGS_MJS=REPLACE_THIS
-CFLAGS_BROWSER=REPLACE_THIS
-CFLAGS_CLOUDFLARE=REPLACE_THIS
+# Variant-specific linker flags (appended to LDFLAGS_WASM by prepareVariants.ts)
+LDFLAGS_VARIANT=REPLACE_THIS
+
+# Emscripten options - target specific linker flags
+LDFLAGS_CJS=REPLACE_THIS
+LDFLAGS_MJS=REPLACE_THIS
+LDFLAGS_BROWSER=REPLACE_THIS
+LDFLAGS_CLOUDFLARE=REPLACE_THIS
 
 # GENERATE_TS options - variant specific
 GENERATE_TS_ENV_VARIANT=REPLACE_THIS
@@ -98,7 +102,6 @@ ifdef DEBUG_MAKE
 	MKDIRP=@echo "\n=====[["" target: $@, deps: $<, variant: $(VARIANT) ""]]=====" ; mkdir -p $(dir $@)
 else
 	MKDIRP=@mkdir -p $(dir $@)
-	CFLAGS+=-Wunused-command-line-argument=0
 endif
 
 ###############################################################################
@@ -116,15 +119,15 @@ MJS: $(DIST)/emscripten-module.mjs $(DIST)/emscripten-module.d.ts
 BROWSER: $(DIST)/emscripten-module.browser.mjs $(DIST)/emscripten-module.browser.d.ts
 CLOUDFLARE: $(DIST)/emscripten-module.cloudflare.cjs $(DIST)/emscripten-module.cloudflare.d.ts
 
-$(DIST)/emscripten-module.mjs: CFLAGS_WASM+=$(CFLAGS_ESM)
+$(DIST)/emscripten-module.mjs: LDFLAGS_TARGET=$(LDFLAGS_MJS)
 $(DIST)/emscripten-module.mjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
-$(DIST)/emscripten-module.cjs: CFLAGS_WASM+=$(CFLAGS_CJS)
+$(DIST)/emscripten-module.cjs: LDFLAGS_TARGET=$(LDFLAGS_CJS)
 $(DIST)/emscripten-module.cjs: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 $(DIST)/emscripten-module.d.ts: $(TEMPLATES)/emscripten-module.$(SYNC).d.ts
 	$(MKDIRP)
@@ -147,22 +150,22 @@ $(DIST)/emscripten-module.%.cjs: $(BUILD_WRAPPER)/%/emscripten-module.js
 	if [ -e $(basename $<).wasm ] ; then cp -v $(basename $<).wasm* $(dir $@); fi
 	cp $< $@
 
-$(BUILD_WRAPPER)/browser/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_BROWSER)
-$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: CFLAGS_WASM+=$(CFLAGS_CLOUDFLARE)
+$(BUILD_WRAPPER)/browser/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_BROWSER)
+$(BUILD_WRAPPER)/cloudflare/emscripten-module.js: LDFLAGS_TARGET=$(LDFLAGS_CLOUDFLARE)
 $(BUILD_WRAPPER)/%/emscripten-module.js: $(BUILD_WRAPPER)/interface.o $(VARIANT_QUICKJS_OBJS) $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
+	$(EMCC) $(CFLAGS_COMPILE) $(LDFLAGS_WASM) $(LDFLAGS_TARGET) $(WRAPPER_DEFINES) $(EMCC_EXPORTED_FUNCS) -o $@ $< $(VARIANT_QUICKJS_OBJS)
 
 ###############################################################################
-# Emscripten intermediate files
+# Emscripten intermediate files (.c -> .o compilation uses only compiler flags)
 WASM_SYMBOLS=$(BUILD_WRAPPER)/symbols.json $(BUILD_WRAPPER)/asyncify-remove.json $(BUILD_WRAPPER)/asyncify-imports.json
 $(BUILD_WRAPPER)/%.o: $(WRAPPER_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(WRAPPER_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(WRAPPER_DEFINES) -c -o $@ $<
 
 $(BUILD_QUICKJS)/%.o: $(QUICKJS_ROOT)/%.c $(WASM_SYMBOLS) | $(EMCC_SRC)
 	$(MKDIRP)
-	$(EMCC) $(CFLAGS_WASM) $(QUICKJS_DEFINES) -c -o $@ $<
+	$(EMCC) $(CFLAGS_COMPILE) $(QUICKJS_DEFINES) -c -o $@ $<
 
 $(BUILD_WRAPPER)/symbols.json:
 	$(MKDIRP)

--- a/templates/Variant.mk
+++ b/templates/Variant.mk
@@ -61,6 +61,8 @@ LDFLAGS_WASM+=-s SUPPORT_ERRNO=0
 # Emscripten linker options - like STRICT
 # https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1095-L1109
 LDFLAGS_WASM+=-s IGNORE_MISSING_MAIN=0 --no-entry
+# Suppress warnings about HEAPU8/HEAP8 in EXPORTED_RUNTIME_METHODS (they're needed but marked "invalid")
+LDFLAGS_WASM+=-Wno-js-compiler
 LDFLAGS_WASM+=-s AUTO_JS_LIBRARIES=0
 LDFLAGS_WASM+=-lccall.js
 LDFLAGS_WASM+=-s AUTO_NATIVE_LIBRARIES=0


### PR DESCRIPTION
## Summary

- Separate compiler flags (`CFLAGS_COMPILE`) from linker flags (`LDFLAGS_WASM`) to eliminate ~160+ warnings about linker settings being ignored during compilation
- Fix malformed `-s -lccall.js` flag (changed to `-lccall.js`)
- Move `MIN_NODE_VERSION` to node-specific targets only
- Add `-Wno-js-compiler` to suppress HEAPU8 export warnings
- Only add `-gsource-map` for debug builds with separate wasm files (incompatible with SINGLE_FILE)
- Exclude trivial functions from asyncify-remove list that get optimized away by LTO
- Remove unused HEAP types, keep only HEAPU8 which is actually used

## Test plan

- [x] Full clean build completes without warnings
- [x] All 69 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)