### PR TITLE
Fix WASM memory view invalidation when memory grows

### DIFF
--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -487,7 +487,7 @@ export class QuickJSContext
         mutablePointerArray.value.ptr,
       )
       const promiseHandle = this.memory.heapValueHandle(promisePtr)
-      const [resolveHandle, rejectHandle] = Array.from(mutablePointerArray.value.typedArray).map(
+      const [resolveHandle, rejectHandle] = Array.from(mutablePointerArray.value.typedArray.value).map(
         (jsvaluePtr) => this.memory.heapValueHandle(jsvaluePtr as any),
       )
       return new QuickJSDeferredPromise({
@@ -994,7 +994,7 @@ export class QuickJSContext
     if (status < 0) {
       return undefined
     }
-    return this.uint32Out.value.typedArray[0]
+    return this.uint32Out.value.typedArray.value[0]
   }
 
   /**
@@ -1052,9 +1052,9 @@ export class QuickJSContext
       if (errorPtr) {
         return this.fail(this.memory.heapValueHandle(errorPtr))
       }
-      const len = this.uint32Out.value.typedArray[0]
-      const ptr = outPtr.value.typedArray[0]
-      const pointerArray = new Uint32Array(this.module.HEAP8.buffer, ptr, len)
+      const len = this.uint32Out.value.typedArray.value[0]
+      const ptr = outPtr.value.typedArray.value[0]
+      const pointerArray = new Uint32Array(this.module.HEAPU8.buffer, ptr, len)
       const handles = Array.from(pointerArray).map((ptr) =>
         this.memory.heapValueHandle(ptr as JSValuePointer),
       )

--- a/packages/quickjs-emscripten-core/src/context.ts
+++ b/packages/quickjs-emscripten-core/src/context.ts
@@ -487,9 +487,9 @@ export class QuickJSContext
         mutablePointerArray.value.ptr,
       )
       const promiseHandle = this.memory.heapValueHandle(promisePtr)
-      const [resolveHandle, rejectHandle] = Array.from(mutablePointerArray.value.typedArray.value).map(
-        (jsvaluePtr) => this.memory.heapValueHandle(jsvaluePtr as any),
-      )
+      const [resolveHandle, rejectHandle] = Array.from(
+        mutablePointerArray.value.typedArray.value,
+      ).map((jsvaluePtr) => this.memory.heapValueHandle(jsvaluePtr as any))
       return new QuickJSDeferredPromise({
         context: this,
         promiseHandle,

--- a/packages/quickjs-emscripten-core/src/runtime.ts
+++ b/packages/quickjs-emscripten-core/src/runtime.ts
@@ -251,7 +251,7 @@ export class QuickJSRuntime extends UsingDisposable implements Disposable {
       ctxPtrOut.value.ptr,
     )
 
-    const ctxPtr = ctxPtrOut.value.typedArray[0] as JSContextPointer
+    const ctxPtr = ctxPtrOut.value.typedArray.value[0] as JSContextPointer
     ctxPtrOut.dispose()
     if (ctxPtr === 0) {
       // No jobs executed.


### PR DESCRIPTION
## Summary

When Emscripten's WASM memory grows (due to `-sALLOW_MEMORY_GROWTH`), all existing TypedArray views become detached because the underlying ArrayBuffer is replaced. This caused bugs where reading from views after FFI calls returned undefined (in the C correctness sense) values if memory had grown during the call.

The fix introduces `RefreshableTypedArray`, a wrapper that lazily recreates the TypedArray view when `HEAPU8.buffer` changes. This uses a simple reference comparison that only triggers view recreation when actually needed.

**Affected call sites:**
- `runtime.ts`: `executePendingJobs` - reads `ctxPtrOut` after `QTS_ExecutePendingJob`
- `context.ts`: `newPromise` - reads resolve/reject handles after `QTS_NewPromiseCapability`
- `context.ts`: `getLength` - reads `uint32Out` after `QTS_GetLength`
- `context.ts`: `getOwnPropertyNames` - reads `outPtr` and `uint32Out` after `QTS_GetOwnPropertyNames`

Also fixed: `getOwnPropertyNames` was using `HEAP8.buffer` instead of `HEAPU8.buffer`

Fixes #240

## Test plan

- [x] All 69 existing tests pass
- [ ] Manual testing with memory-intensive workloads that trigger growth

🤖 Generated with [Claude Code](https://claude.ai/code)