### PR TITLE
Improve QTS_Dump: handle inherited props, better fallback (#241)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,51 @@ If you see assertions like:
 - `Assertion failed: p->gc_obj_type == JS_GC_OBJ_TYPE_JS_OBJECT` - memory corruption
 
 These usually indicate memory management bugs: double-frees, use-after-free, or missing frees.
+
+## C Code Style in interface.c
+
+### Naming Conventions
+
+- `QTS_` prefix for exported FFI functions (defined in interface.h, called from JavaScript)
+- `qts_` prefix for internal C helper functions
+- `static` keyword for file-local functions and variables
+- Use `bool` from `<stdbool.h>` for boolean values (already included)
+
+### Code Organization
+
+- Section comments with `// ----` separators for logical grouping
+- Forward declarations at the top of sections when needed
+- Constants defined near related functions
+
+### Error Handling Patterns
+
+- Check `JS_IsException(value)` for error conditions
+- Use `JS_GetException(ctx)` to retrieve the exception value
+- Clean up resources in reverse order of allocation
+- Return `JS_EXCEPTION` or `NULL` to signal errors to callers
+
+### Example
+
+```c
+// ----------------------------------------------------------------------------
+// Section Name
+
+// Forward declaration
+static JSValue qts_helper_function(JSContext *ctx, JSValueConst obj);
+
+// Internal helper - not exported
+static bool qts_check_something(JSContext *ctx, JSValueConst obj) {
+  if (!JS_IsObject(obj)) return false;
+  // ... implementation
+  return true;
+}
+
+// Exported FFI function
+JSValue *QTS_DoSomething(JSContext *ctx, JSValueConst *obj) {
+  JSValue result = qts_helper_function(ctx, *obj);
+  if (JS_IsException(result)) {
+    return jsvalue_to_heap(JS_EXCEPTION);
+  }
+  return jsvalue_to_heap(result);
+}
+```


### PR DESCRIPTION
## Summary

- Fix inherited property handling for Error objects (name was not included because it's inherited from Error.prototype)
- Add informative fallback when JSON serialization fails due to memory limits
- Add comprehensive tests for dump functionality

## Changes

### C code (`c/interface.c`)
- Renamed `qts_prop_is_non_enumerable` to `qts_should_copy_special_prop`
- Updated function to use `JS_GetProperty` (checks prototype chain) instead of only `JS_GetOwnProperty`
- Added JS_PrintValue-based fallback for bellard/quickjs, toString() fallback for quickjs-ng

### Tests (`packages/quickjs-emscripten/src/quickjs.test.ts`)
- "includes Error name, message, and stack" - verifies Error objects dump correctly
- "includes non-enumerable special properties" - tests custom non-enumerable props
- "returns informative fallback when serialization fails due to memory limit" - tests OOM scenario

### Documentation (`CLAUDE.md`)
- Added C code style documentation section

## Test plan
- [x] All existing dump tests pass
- [x] New tests for Error objects pass
- [x] New tests for non-enumerable properties pass
- [x] New tests for memory-constrained scenarios pass
- [x] Tests pass on all variants (bellard + quickjs-ng, sync + async, release + debug)

Closes #241

🤖 Generated with [Claude Code](https://claude.ai/code)