### PR TITLE
Allocators for command execution

### DIFF
--- a/packages/quickjs-emscripten-core/src/internal/ByteRegionAllocator.test.ts
+++ b/packages/quickjs-emscripten-core/src/internal/ByteRegionAllocator.test.ts
@@ -1,0 +1,48 @@
+import assert from "assert"
+import { describe, it } from "vitest"
+import { ByteRegionAllocator } from "./ByteRegionAllocator"
+
+describe("ByteRegionAllocator", () => {
+  it("allocates monotonic pointers within a region", () => {
+    const allocator = new ByteRegionAllocator<number>(12, 16)
+
+    const a = allocator.reserve(5)
+    const b = allocator.reserve(3)
+    const c = allocator.reserve(7)
+
+    assert.strictEqual(a, 12)
+    assert.strictEqual(b, 17)
+    assert.strictEqual(c, 20)
+    assert.strictEqual(allocator.used, 15)
+  })
+
+  it("reset resets bump offset", () => {
+    const allocator = new ByteRegionAllocator<number>(16, 16)
+
+    allocator.reserve(10)
+    allocator.reserve(6)
+    allocator.reset()
+
+    const ptr = allocator.reserve(4)
+    assert.strictEqual(ptr, 16)
+    assert.strictEqual(allocator.used, 4)
+  })
+
+  it("throws when reservation exceeds capacity", () => {
+    const allocator = new ByteRegionAllocator<number>(8, 16)
+    assert.throws(() => allocator.reserve(17), /overflow/)
+  })
+
+  it("setRegion replaces pointer and capacity", () => {
+    const allocator = new ByteRegionAllocator<number>(8, 8)
+    allocator.reserve(4)
+
+    allocator.setRegion(32, 24)
+    const ptr = allocator.reserve(8)
+
+    assert.strictEqual(ptr, 32)
+    assert.strictEqual(allocator.capacity, 24)
+    assert.strictEqual(allocator.used, 8)
+  })
+})
+

--- a/packages/quickjs-emscripten-core/src/internal/ByteRegionAllocator.ts
+++ b/packages/quickjs-emscripten-core/src/internal/ByteRegionAllocator.ts
@@ -1,0 +1,75 @@
+export interface ByteRegionAllocatorOptions {
+  disableAssertions?: boolean
+}
+
+function assertPositiveInt(value: number, label: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer: ${value}`)
+  }
+}
+
+export class ByteRegionAllocator<Ptr extends number = number> {
+  private readonly assertions: boolean
+  private basePtr: Ptr
+  private capacityBytes: number
+  private usedBytes = 0
+
+  constructor(ptr: Ptr, capacityBytes: number, options: ByteRegionAllocatorOptions = {}) {
+    if (!Number.isInteger(ptr) || ptr < 0) {
+      throw new Error(`Invalid ptr: ${ptr}`)
+    }
+    assertPositiveInt(capacityBytes, "capacityBytes")
+
+    this.basePtr = ptr
+    this.capacityBytes = capacityBytes
+    this.assertions = !options.disableAssertions
+  }
+
+  get ptr(): Ptr {
+    return this.basePtr
+  }
+
+  get capacity(): number {
+    return this.capacityBytes
+  }
+
+  get used(): number {
+    return this.usedBytes
+  }
+
+  reset(): void {
+    this.usedBytes = 0
+  }
+
+  setRegion(ptr: Ptr, capacityBytes: number): void {
+    if (!Number.isInteger(ptr) || ptr < 0) {
+      throw new Error(`Invalid ptr: ${ptr}`)
+    }
+    assertPositiveInt(capacityBytes, "capacityBytes")
+
+    this.basePtr = ptr
+    this.capacityBytes = capacityBytes
+    this.usedBytes = 0
+  }
+
+  reserve(byteLength: number): Ptr {
+    assertPositiveInt(byteLength, "byteLength")
+
+    const required = this.usedBytes + byteLength
+    if (required > this.capacityBytes) {
+      throw new Error(
+        `ByteRegionAllocator overflow: required=${required}, capacity=${this.capacityBytes}`,
+      )
+    }
+
+    const ptr = ((this.basePtr as number) + this.usedBytes) as Ptr
+    this.usedBytes = required
+
+    if (this.assertions && (!Number.isInteger(ptr) || ptr < 0)) {
+      throw new Error(`Invalid reserved ptr: ${ptr}`)
+    }
+
+    return ptr
+  }
+}
+

--- a/packages/quickjs-emscripten-core/src/internal/SlotArena.test.ts
+++ b/packages/quickjs-emscripten-core/src/internal/SlotArena.test.ts
@@ -1,0 +1,156 @@
+import assert from "assert"
+import { describe, it } from "vitest"
+import { SlotArena, FreeList, type Memory } from "./SlotArena"
+
+describe("FreeList", () => {
+  it("allocates bump-first then recycled LIFO", () => {
+    const freeList = new FreeList<number>(3)
+
+    const a = freeList.alloc()
+    const b = freeList.alloc()
+    const c = freeList.alloc()
+
+    assert.strictEqual(a, 0)
+    assert.strictEqual(b, 1)
+    assert.strictEqual(c, 2)
+
+    freeList.free(1)
+    freeList.free(2)
+
+    assert.strictEqual(freeList.alloc(), 2)
+    assert.strictEqual(freeList.alloc(), 1)
+  })
+
+  it("throws on double free in strict mode", () => {
+    const freeList = new FreeList<number>(2)
+    const slot = freeList.alloc()
+    freeList.free(slot)
+
+    assert.throws(() => freeList.free(slot), /Double free/)
+  })
+
+  it("supports grow", () => {
+    const freeList = new FreeList<number>(1)
+    assert.strictEqual(freeList.alloc(), 0)
+    assert.throws(() => freeList.alloc(), /full/)
+
+    freeList.grow(3)
+    assert.strictEqual(freeList.alloc(), 1)
+    assert.strictEqual(freeList.alloc(), 2)
+  })
+})
+
+describe("SlotArena", () => {
+  it("enforces strict exact size when memory is provided without ptr", () => {
+    assert.throws(() => new SlotArena(16, 2, new Uint8Array(31)), /must equal 32/)
+    assert.doesNotThrow(() => new SlotArena(16, 2, new Uint8Array(32)))
+  })
+
+  it("copies bytes in and out of internal arena", () => {
+    const arena = new SlotArena<number>(16, 2)
+    const src = new Uint8Array(16)
+    for (let i = 0; i < src.length; i++) {
+      src[i] = i + 1
+    }
+
+    arena.copyFromBytes(src, 0, 0)
+    arena.copySlot(0, 1)
+
+    const out = new Uint8Array(16)
+    arena.copyToBytes(1, out, 0)
+    assert.deepStrictEqual([...out], [...src])
+  })
+
+  it("uses provider memory on each operation", () => {
+    const memA = new Uint8Array(16)
+    const memB = new Uint8Array(16)
+    for (let i = 0; i < 16; i++) {
+      memA[i] = i + 1
+      memB[i] = i + 101
+    }
+
+    let useA = true
+    let calls = 0
+    const arena = new SlotArena<number>(16, 1, () => {
+      calls++
+      return useA ? memA : memB
+    })
+
+    const src = new Uint8Array(16)
+    src.fill(9)
+    arena.copyFromBytes(src, 0, 0)
+
+    useA = false
+    const out = new Uint8Array(16)
+    arena.copyToBytes(0, out, 0)
+
+    assert.deepStrictEqual([...out], [...memB])
+    assert.ok(calls >= 2)
+  })
+
+  it("supports Memory malloc/realloc in grow", () => {
+    let backing = new Uint8Array(24)
+    let allocated = 0
+    let resizedTo = -1
+
+    const memoryObject: Memory<number> = {
+      uint8: () => backing,
+      uint32: () => new Uint32Array(backing.buffer, backing.byteOffset, backing.byteLength >>> 2),
+      malloc: (bytes) => {
+        allocated = bytes
+        return 8
+      },
+      realloc: (ptr, bytes) => {
+        assert.strictEqual(ptr, 8)
+        resizedTo = bytes
+        const next = new Uint8Array(ptr + bytes)
+        next.set(backing.subarray(0, Math.min(backing.length, next.length)), 0)
+        backing = next
+        return 8
+      },
+    }
+
+    const arena = new SlotArena<number>(8, 2, memoryObject)
+    assert.strictEqual(allocated, 16)
+
+    const src = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    arena.copyFromBytes(src, 0, 0)
+    assert.deepStrictEqual([...backing.subarray(8, 16)], [...src])
+
+    arena.grow(3)
+    assert.strictEqual(resizedTo, 24)
+    assert.strictEqual(arena.capacity, 3)
+  })
+
+  it("throws when Memory ptr is not 4-byte aligned", () => {
+    const backing = new Uint8Array(32)
+    const memoryObject: Memory<number> = {
+      uint8: () => backing,
+      uint32: () => new Uint32Array(backing.buffer, backing.byteOffset, backing.byteLength >>> 2),
+      malloc: () => 2,
+      realloc: () => 2,
+    }
+
+    assert.throws(() => new SlotArena<number>(8, 2, memoryObject), /4-byte aligned/)
+  })
+
+  it("disallows grow for raw memory without resize", () => {
+    const arena = new SlotArena<number>(8, 2, new Uint8Array(16))
+    assert.throws(() => arena.grow(3), /only supported/)
+  })
+
+  it("allocator methods are composed from FreeList", () => {
+    const arena = new SlotArena<number>(8, 2)
+    const a = arena.alloc()
+    const b = arena.alloc()
+
+    assert.strictEqual(a, 0)
+    assert.strictEqual(b, 1)
+
+    arena.free(a)
+    assert.strictEqual(arena.alloc(), 0)
+
+    arena.resetAllocator()
+    assert.strictEqual(arena.alloc(), 0)
+  })
+})

--- a/packages/quickjs-emscripten-core/src/internal/SlotArena.ts
+++ b/packages/quickjs-emscripten-core/src/internal/SlotArena.ts
@@ -1,0 +1,479 @@
+import {
+  assertByteRange,
+  assertStorageWindow as assertStorageWindowRaw,
+  copyBytes,
+  createMemoryViewState,
+  createMemoryViewStateFromViews,
+  getDirectMemoryViews,
+  isMemoryObject,
+  memoryLength,
+  type ArenaRawMemory,
+  type Memory,
+  type MemoryViewState,
+} from "./memory-region"
+
+export type SlotArenaMemory<Ptr extends number = number> =
+  | ArenaRawMemory
+  | (() => ArenaRawMemory)
+  | Memory<Ptr>
+
+export interface SlotArenaOptions {
+  disableAssertions?: boolean
+}
+
+export type { ArenaRawMemory, Memory } from "./memory-region"
+
+type Writable<T> = { -readonly [K in keyof T]: T[K] }
+
+/** @private */
+export class FreeList<SlotT extends number = number> {
+  readonly capacity: number
+  private nextFresh = 0
+  private recycledTop = 0
+  private recycled: Int32Array
+  private inUse?: Uint8Array
+  private usedValue = 0
+  private readonly assertions: boolean
+
+  constructor(capacity: number, disableAssertions?: boolean) {
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new Error(`Invalid capacity: ${capacity}`)
+    }
+
+    this.capacity = capacity
+    this.recycled = new Int32Array(capacity)
+    this.assertions = !disableAssertions
+
+    if (this.assertions) {
+      this.inUse = new Uint8Array(capacity)
+    }
+  }
+
+  get used(): number {
+    return this.usedValue
+  }
+
+  get available(): number {
+    return this.capacity - this.usedValue
+  }
+
+  alloc(): SlotT {
+    let slot = -1
+
+    if (this.recycledTop > 0) {
+      slot = this.recycled[--this.recycledTop]
+    } else if (this.nextFresh < this.capacity) {
+      slot = this.nextFresh
+      this.nextFresh++
+    } else {
+      throw new Error("FreeList is full")
+    }
+
+    if (this.assertions) {
+      const inUse = this.inUse as Uint8Array
+      if (slot < 0 || slot >= this.capacity) {
+        throw new Error(`FreeList produced invalid slot: ${slot}`)
+      }
+      if (inUse[slot] !== 0) {
+        throw new Error(`FreeList produced in-use slot: ${slot}`)
+      }
+      inUse[slot] = 1
+    }
+
+    this.usedValue++
+    return slot as SlotT
+  }
+
+  free(slotValue: SlotT): void {
+    const slot = slotValue as number
+
+    if (this.assertions) {
+      if (!Number.isInteger(slot) || slot < 0 || slot >= this.capacity) {
+        throw new Error(`Slot out of range: ${slot}`)
+      }
+      const inUse = this.inUse as Uint8Array
+      if (inUse[slot] === 0) {
+        throw new Error(`Double free or never-allocated slot: ${slot}`)
+      }
+      inUse[slot] = 0
+    }
+
+    this.recycled[this.recycledTop++] = slot
+    this.usedValue--
+  }
+
+  reset(): void {
+    this.nextFresh = 0
+    this.recycledTop = 0
+    this.usedValue = 0
+
+    if (this.assertions) {
+      ;(this.inUse as Uint8Array).fill(0)
+    }
+  }
+
+  grow(newCap: number): void {
+    if (!Number.isInteger(newCap) || newCap <= 0) {
+      throw new Error(`Invalid new capacity: ${newCap}`)
+    }
+    if (newCap < this.capacity) {
+      throw new Error(`Cannot shrink FreeList capacity from ${this.capacity} to ${newCap}`)
+    }
+    if (newCap === this.capacity) {
+      return
+    }
+
+    const nextRecycled = new Int32Array(newCap)
+    nextRecycled.set(this.recycled.subarray(0, this.recycledTop), 0)
+    this.recycled = nextRecycled
+
+    if (this.assertions) {
+      const nextInUse = new Uint8Array(newCap)
+      nextInUse.set(this.inUse as Uint8Array, 0)
+      this.inUse = nextInUse
+    }
+
+    ;(this as Writable<this>).capacity = newCap
+  }
+}
+
+function assertPowerOfTwoAtLeastFour(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 4 || (value & (value - 1)) !== 0) {
+    throw new Error(`${label} must be a power-of-two integer >= 4: ${value}`)
+  }
+}
+
+function assertPositiveInt(value: number, label: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer: ${value}`)
+  }
+}
+
+export class SlotArena<SlotT extends number = number, Ptr extends number = number> {
+  readonly slotSize: number
+  readonly capacity: number
+  readonly byteLength: number
+  readonly ptr: Ptr
+
+  private readonly assertions: boolean
+  private readonly allocator: FreeList<SlotT>
+
+  private readonly staticStorage: boolean
+  private readonly internalStorage: boolean
+  private readonly directMemory?: Memory<Ptr>
+  private readonly storageProvider?: () => ArenaRawMemory
+  private staticRaw?: ArenaRawMemory
+
+  private arenaView?: MemoryViewState
+  private externalViewCache?: MemoryViewState
+
+  constructor(
+    slotSize: number,
+    capacity: number,
+    memory?: SlotArenaMemory<Ptr>,
+    ptr?: Ptr,
+    options: SlotArenaOptions = {},
+  ) {
+    assertPowerOfTwoAtLeastFour(slotSize, "slotSize")
+    assertPositiveInt(capacity, "capacity")
+
+    this.slotSize = slotSize
+    this.capacity = capacity
+    this.byteLength = slotSize * capacity
+    this.assertions = !options.disableAssertions
+    this.allocator = new FreeList<SlotT>(capacity, options.disableAssertions)
+
+    if (memory === undefined) {
+      if (ptr !== undefined) {
+        throw new Error("ptr is only valid when memory is provided")
+      }
+
+      this.ptr = 0 as Ptr
+      this.staticStorage = true
+      this.internalStorage = true
+      this.staticRaw = new ArrayBuffer(this.byteLength)
+      this.arenaView = createMemoryViewState(this.staticRaw)
+      return
+    }
+
+    if (isMemoryObject<Ptr>(memory)) {
+      const basePtr = ptr ?? memory.malloc(this.byteLength)
+      if (!Number.isInteger(basePtr) || basePtr < 0) {
+        throw new Error(`Invalid ptr: ${basePtr}`)
+      }
+
+      this.ptr = basePtr
+      this.staticStorage = false
+      this.internalStorage = false
+      this.directMemory = memory
+      this.assertDirectMemoryWindow(memory, this.ptr as number)
+      return
+    }
+
+    const basePtr = (ptr ?? 0) as Ptr
+    if (!Number.isInteger(basePtr) || basePtr < 0) {
+      throw new Error(`Invalid ptr: ${basePtr}`)
+    }
+    this.ptr = basePtr
+
+    if (typeof memory === "function") {
+      this.staticStorage = false
+      this.internalStorage = false
+      this.storageProvider = memory
+
+      const initial = this.storageProvider()
+      this.assertStorageWindow(initial, this.ptr as number, ptr === undefined)
+      return
+    }
+
+    this.staticStorage = true
+    this.internalStorage = false
+    this.staticRaw = memory
+    this.assertStorageWindow(memory, this.ptr as number, ptr === undefined)
+    this.arenaView = createMemoryViewState(memory)
+  }
+
+  alloc(): SlotT {
+    return this.allocator.alloc()
+  }
+
+  free(slot: SlotT): void {
+    this.allocator.free(slot)
+  }
+
+  resetAllocator(): void {
+    this.allocator.reset()
+  }
+
+  copyFromBytes(src: ArenaRawMemory, srcByteOffset: number, dstSlot: SlotT): void {
+    const srcView = this.resolveExternalView(src)
+    const srcOffset = this.assertions
+      ? this.assertRange(srcView.byteLength, srcByteOffset, this.slotSize, "source")
+      : srcByteOffset
+
+    const dstOffset = this.slotOffset(dstSlot)
+    const arena = this.resolveArenaView()
+
+    if (this.assertions) {
+      this.assertRange(arena.byteLength, dstOffset, this.slotSize, "arena")
+    }
+
+    copyBytes(srcView, srcOffset, arena, dstOffset, this.slotSize)
+  }
+
+  copyToBytes(srcSlot: SlotT, dst: ArenaRawMemory, dstByteOffset: number): void {
+    const srcOffset = this.slotOffset(srcSlot)
+    const arena = this.resolveArenaView()
+
+    if (this.assertions) {
+      this.assertRange(arena.byteLength, srcOffset, this.slotSize, "arena")
+    }
+
+    const dstView = this.resolveExternalView(dst)
+    const dstOffset = this.assertions
+      ? this.assertRange(dstView.byteLength, dstByteOffset, this.slotSize, "destination")
+      : dstByteOffset
+
+    copyBytes(arena, srcOffset, dstView, dstOffset, this.slotSize)
+  }
+
+  copySlot(srcSlot: SlotT, dstSlot: SlotT): void {
+    const srcOffset = this.slotOffset(srcSlot)
+    const dstOffset = this.slotOffset(dstSlot)
+
+    if (srcOffset === dstOffset) {
+      return
+    }
+
+    const arena = this.resolveArenaView()
+    if (this.assertions) {
+      this.assertRange(arena.byteLength, srcOffset, this.slotSize, "arena src")
+      this.assertRange(arena.byteLength, dstOffset, this.slotSize, "arena dst")
+    }
+
+    copyBytes(arena, srcOffset, arena, dstOffset, this.slotSize)
+  }
+
+  grow(newCap: number): void {
+    assertPositiveInt(newCap, "newCap")
+    if (newCap < this.capacity) {
+      throw new Error(`Cannot shrink capacity from ${this.capacity} to ${newCap}`)
+    }
+    if (newCap === this.capacity) {
+      return
+    }
+
+    const nextByteLength = this.slotSize * newCap
+
+    if (this.internalStorage) {
+      const current = this.resolveArenaView()
+      const nextRaw = new ArrayBuffer(nextByteLength)
+      const nextView = createMemoryViewState(nextRaw)
+      nextView.bytes.set(current.bytes.subarray(0, this.byteLength), 0)
+
+      this.arenaView = nextView
+      this.staticRaw = nextRaw
+      ;(this as Writable<this>).capacity = newCap
+      ;(this as Writable<this>).byteLength = nextByteLength
+      this.allocator.grow(newCap)
+      return
+    }
+
+    if (this.directMemory) {
+      const nextPtr = this.directMemory.realloc(this.ptr, nextByteLength)
+      if (!Number.isInteger(nextPtr) || nextPtr < 0) {
+        throw new Error(`realloc() returned invalid ptr: ${nextPtr}`)
+      }
+
+      this.assertDirectMemoryWindow(this.directMemory, nextPtr as number, nextByteLength)
+      ;(this as Writable<this>).ptr = nextPtr
+      this.arenaView = undefined
+      ;(this as Writable<this>).capacity = newCap
+      ;(this as Writable<this>).byteLength = nextByteLength
+      this.allocator.grow(newCap)
+      return
+    }
+
+    throw new Error("grow() is only supported for internal memory or Memory object")
+  }
+
+  private slotOffset(slotValue: SlotT): number {
+    const slot = slotValue as number
+
+    if (this.assertions) {
+      if (!Number.isInteger(slot) || slot < 0 || slot >= this.capacity) {
+        throw new Error(`Slot out of range: ${slot}`)
+      }
+    }
+
+    const basePtr = this.directMemory ? 0 : (this.ptr as number)
+    return basePtr + slot * this.slotSize
+  }
+
+  private assertRange(total: number, offset: number, len: number, label: string): number {
+    return assertByteRange(total, offset, len, label)
+  }
+
+  private assertStorageWindow(
+    raw: ArenaRawMemory,
+    basePtr: number,
+    strictExact: boolean,
+    requiredByteLength = this.byteLength,
+  ): void {
+    assertStorageWindowRaw(raw, basePtr, requiredByteLength, strictExact)
+  }
+
+  private computeWordStartIndex(words: Uint32Array, bytes: Uint8Array, basePtr: number): number {
+    if ((basePtr & 3) !== 0) {
+      throw new Error(`ptr must be 4-byte aligned for uint32 view access: ${basePtr}`)
+    }
+
+    const arenaByteStart = bytes.byteOffset + basePtr
+    const delta = arenaByteStart - words.byteOffset
+    if (delta < 0 || (delta & 3) !== 0) {
+      throw new Error(
+        `Cannot map byte ptr to uint32 index (bytes.byteOffset=${bytes.byteOffset}, words.byteOffset=${words.byteOffset}, ptr=${basePtr})`,
+      )
+    }
+
+    return delta >>> 2
+  }
+
+  private assertDirectMemoryWindow(
+    memory: Memory<Ptr>,
+    basePtr: number,
+    requiredByteLength = this.byteLength,
+  ): void {
+    const { bytes, words } = getDirectMemoryViews(memory)
+    if ((requiredByteLength & 3) !== 0) {
+      throw new Error(`SlotArena byte length must be 4-byte aligned, got ${requiredByteLength}`)
+    }
+
+    this.assertStorageWindow(bytes, basePtr, false, requiredByteLength)
+    const wordStart = this.computeWordStartIndex(words, bytes, basePtr)
+    const wordLen = requiredByteLength >>> 2
+    if (wordStart + wordLen > words.length) {
+      throw new Error(
+        `Memory uint32 window out of bounds: wordStart=${wordStart}, wordLen=${wordLen}, wordsLen=${words.length}`,
+      )
+    }
+  }
+
+  private resolveArenaRaw(): ArenaRawMemory {
+    if (this.staticStorage) {
+      return this.staticRaw as ArenaRawMemory
+    }
+
+    const provider = this.storageProvider
+    if (!provider) {
+      throw new Error("SlotArena has no memory provider")
+    }
+
+    const raw = provider()
+    if (!(raw instanceof Uint8Array) && !(raw instanceof ArrayBuffer)) {
+      throw new Error("memory() must return ArrayBuffer or Uint8Array")
+    }
+
+    if (this.assertions) {
+      this.assertStorageWindow(raw, this.ptr as number, false)
+    }
+
+    return raw
+  }
+
+  private resolveArenaView(): MemoryViewState {
+    if (this.directMemory) {
+      const { bytes, words } = getDirectMemoryViews(this.directMemory)
+
+      const byteStart = this.ptr as number
+      const byteEnd = byteStart + this.byteLength
+      const wordStart = this.computeWordStartIndex(words, bytes, byteStart)
+      const wordLen = this.byteLength >>> 2
+      if (this.assertions) {
+        this.assertDirectMemoryWindow(this.directMemory, byteStart)
+      }
+
+      const bytesWindow = bytes.subarray(byteStart, byteEnd)
+      const wordsWindow = words.subarray(wordStart, wordStart + wordLen)
+
+      const token = bytes.buffer
+      if (
+        this.arenaView &&
+        this.arenaView.token === token &&
+        this.arenaView.byteLength === this.byteLength &&
+        this.arenaView.bytes.byteOffset === bytesWindow.byteOffset
+      ) {
+        return this.arenaView
+      }
+
+      this.arenaView = createMemoryViewStateFromViews(token, bytesWindow, wordsWindow)
+      return this.arenaView
+    }
+
+    const raw = this.resolveArenaRaw()
+
+    if (
+      this.arenaView &&
+      this.arenaView.token === raw &&
+      this.arenaView.byteLength === memoryLength(raw)
+    ) {
+      return this.arenaView
+    }
+
+    this.arenaView = createMemoryViewState(raw)
+    return this.arenaView
+  }
+
+  private resolveExternalView(raw: ArenaRawMemory): MemoryViewState {
+    if (
+      this.externalViewCache &&
+      this.externalViewCache.token === raw &&
+      this.externalViewCache.byteLength === memoryLength(raw)
+    ) {
+      return this.externalViewCache
+    }
+
+    this.externalViewCache = createMemoryViewState(raw)
+    return this.externalViewCache
+  }
+}

--- a/packages/quickjs-emscripten-core/src/internal/StringAllocator.test.ts
+++ b/packages/quickjs-emscripten-core/src/internal/StringAllocator.test.ts
@@ -1,0 +1,140 @@
+import assert from "assert"
+import { describe, it } from "vitest"
+import { ArrayBufferMemory } from "./memory-region"
+import { StringAllocator, utf8ByteLength } from "./StringAllocator"
+
+function readCString(bytes: Uint8Array, ptr: number): Uint8Array {
+  let end = ptr
+  while (end < bytes.length && bytes[end] !== 0) {
+    end++
+  }
+  return bytes.subarray(ptr, end)
+}
+
+describe("StringAllocator", () => {
+  it("encodes ASCII strings with null terminators", () => {
+    const memory = new ArrayBufferMemory(64, 20)
+    const manager = new StringAllocator(memory)
+
+    manager.reset()
+    manager.addString("ab")
+    manager.addString("xyz")
+    const { ptrs, byteLengths } = manager.finish()
+
+    assert.ok(ptrs instanceof Uint32Array)
+    assert.deepStrictEqual([...byteLengths], [2, 3])
+
+    const bytes = memory.uint8()
+    assert.deepStrictEqual([...bytes.subarray(ptrs[0], ptrs[0] + 3)], [97, 98, 0])
+    assert.deepStrictEqual([...bytes.subarray(ptrs[1], ptrs[1] + 4)], [120, 121, 122, 0])
+  })
+
+  it("encodes multibyte UTF-8 correctly", () => {
+    const memory = new ArrayBufferMemory(128, 8)
+    const manager = new StringAllocator(memory)
+    const encoder = new TextEncoder()
+    const input = ["é", "😀", "漢字"]
+
+    manager.reset()
+    for (const value of input) {
+      manager.addString(value)
+    }
+    const { ptrs, byteLengths } = manager.finish()
+    const bytes = memory.uint8()
+
+    for (let i = 0; i < input.length; i++) {
+      const expected = encoder.encode(input[i])
+      assert.strictEqual(byteLengths[i], expected.byteLength)
+      assert.deepStrictEqual([...bytes.subarray(ptrs[i], ptrs[i] + expected.byteLength)], [...expected])
+      assert.strictEqual(bytes[ptrs[i] + expected.byteLength], 0)
+    }
+  })
+
+  it("handles empty strings", () => {
+    const memory = new ArrayBufferMemory(64, 8)
+    const manager = new StringAllocator(memory)
+
+    manager.reset()
+    manager.addString("")
+    const { ptrs, byteLengths } = manager.finish()
+
+    assert.strictEqual(byteLengths[0], 0)
+    assert.strictEqual(memory.uint8()[ptrs[0]], 0)
+  })
+
+  it("preserves embedded NUL bytes in payload", () => {
+    const memory = new ArrayBufferMemory(64, 8)
+    const manager = new StringAllocator(memory)
+
+    manager.reset()
+    manager.addString("a\u0000b")
+    const { ptrs, byteLengths } = manager.finish()
+    const bytes = memory.uint8()
+
+    assert.strictEqual(byteLengths[0], 3)
+    assert.deepStrictEqual([...bytes.subarray(ptrs[0], ptrs[0] + 4)], [97, 0, 98, 0])
+  })
+
+  it("supports large batches without per-result object allocation", () => {
+    const memory = new ArrayBufferMemory(256, 8)
+    const manager = new StringAllocator(memory, { initialStringCapacity: 4 })
+    const count = 500
+
+    manager.reset()
+    for (let i = 0; i < count; i++) {
+      manager.addString(`k${i}`)
+    }
+    const { ptrs, byteLengths } = manager.finish()
+
+    assert.strictEqual(ptrs.length, count)
+    assert.strictEqual(byteLengths.length, count)
+    assert.ok(ptrs instanceof Uint32Array)
+  })
+
+  it("reuses allocator after reset", () => {
+    const memory = new ArrayBufferMemory(64, 24)
+    const manager = new StringAllocator(memory)
+
+    manager.reset()
+    manager.addString("first")
+    const first = manager.finish()
+
+    manager.reset()
+    manager.addString("second")
+    const second = manager.finish()
+
+    assert.strictEqual(first.ptrs[0], 24)
+    assert.strictEqual(second.ptrs[0], 24)
+  })
+
+  it("returned ptr+len and ptr-only reads both work", () => {
+    const memory = new ArrayBufferMemory(64, 12)
+    const manager = new StringAllocator(memory)
+    const encoder = new TextEncoder()
+    const value = "hello"
+
+    manager.reset()
+    manager.addString(value)
+    const { ptrs, byteLengths } = manager.finish()
+    const ptr = ptrs[0]
+    const bytes = memory.uint8()
+
+    const explicit = bytes.subarray(ptr, ptr + byteLengths[0])
+    const cString = readCString(bytes, ptr)
+    const expected = encoder.encode(value)
+
+    assert.deepStrictEqual([...explicit], [...expected])
+    assert.deepStrictEqual([...cString], [...expected])
+  })
+})
+
+describe("utf8ByteLength", () => {
+  it("matches TextEncoder byteLength for representative inputs", () => {
+    const encoder = new TextEncoder()
+    const inputs = ["", "abc", "é", "😀", "a\u0000b", "\ud800", "\udc00", "漢字"]
+
+    for (const value of inputs) {
+      assert.strictEqual(utf8ByteLength(value), encoder.encode(value).byteLength)
+    }
+  })
+})

--- a/packages/quickjs-emscripten-core/src/internal/StringAllocator.ts
+++ b/packages/quickjs-emscripten-core/src/internal/StringAllocator.ts
@@ -1,0 +1,260 @@
+import {
+  ByteRegionAllocator,
+  type ByteRegionAllocatorOptions,
+} from "./ByteRegionAllocator"
+import {
+  assertStorageWindow,
+  getDirectMemoryViews,
+  getWritableRegion,
+  type Memory,
+} from "./memory-region"
+
+export type StringAllocation = {
+  ptrs: Uint32Array | number[]
+  byteLengths: Uint32Array
+}
+
+export interface StringAllocatorOptions extends ByteRegionAllocatorOptions {
+  initialCapacityBytes?: number
+  initialStringCapacity?: number
+}
+
+const EMPTY_PTRS = new Uint32Array(0)
+const EMPTY_BYTE_LENGTHS = new Uint32Array(0)
+
+function assertPositiveInt(value: number, label: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer: ${value}`)
+  }
+}
+
+/**
+ * Returns the UTF-8 payload length for `value` without allocating temporary buffers.
+ */
+export function utf8ByteLength(value: string): number {
+  let total = 0
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+
+    if (code <= 0x7f) {
+      total += 1
+      continue
+    }
+    if (code <= 0x7ff) {
+      total += 2
+      continue
+    }
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : 0
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        total += 4
+        i++
+      } else {
+        total += 3
+      }
+      continue
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      total += 3
+      continue
+    }
+
+    total += 3
+  }
+
+  return total
+}
+
+export class StringAllocator<Ptr extends number = number> {
+  private readonly encoder = new TextEncoder()
+  private readonly assertions: boolean
+  private readonly initialCapacityBytes: number
+  private readonly disableAssertions: boolean
+
+  private allocator?: ByteRegionAllocator<Ptr>
+  private regionPtr?: Ptr
+  private regionCapacityBytes = 0
+
+  private strings: string[]
+  private utf8Lengths: number[]
+  private count = 0
+
+  private resultPtrs: Uint32Array
+  private resultByteLengths: Uint32Array
+
+  constructor(
+    private readonly memory: Memory<Ptr>,
+    options: StringAllocatorOptions = {},
+  ) {
+    const initialStringCapacity = options.initialStringCapacity ?? 16
+    assertPositiveInt(initialStringCapacity, "initialStringCapacity")
+
+    this.initialCapacityBytes = options.initialCapacityBytes ?? 256
+    assertPositiveInt(this.initialCapacityBytes, "initialCapacityBytes")
+    this.disableAssertions = Boolean(options.disableAssertions)
+    this.assertions = !this.disableAssertions
+
+    this.strings = new Array<string>(initialStringCapacity)
+    this.utf8Lengths = new Array<number>(initialStringCapacity)
+    this.resultPtrs = new Uint32Array(initialStringCapacity)
+    this.resultByteLengths = new Uint32Array(initialStringCapacity)
+  }
+
+  reset(): void {
+    this.count = 0
+    this.allocator?.reset()
+  }
+
+  addString(value: string): number {
+    const index = this.count
+    this.count++
+
+    this.ensureStringCapacity(this.count)
+    this.strings[index] = value
+    this.utf8Lengths[index] = utf8ByteLength(value)
+    return index
+  }
+
+  finish(): StringAllocation {
+    if (this.count === 0) {
+      return {
+        ptrs: EMPTY_PTRS,
+        byteLengths: EMPTY_BYTE_LENGTHS,
+      }
+    }
+
+    this.ensureResultCapacity(this.count)
+
+    let totalBytes = 0
+    for (let i = 0; i < this.count; i++) {
+      totalBytes += this.utf8Lengths[i] + 1
+    }
+
+    this.ensureRegionCapacity(totalBytes)
+
+    const allocator = this.allocator as ByteRegionAllocator<Ptr>
+    allocator.reset()
+    const basePtr = allocator.reserve(totalBytes)
+    const region = getWritableRegion(this.memory, basePtr, totalBytes)
+
+    let cursor = 0
+    for (let i = 0; i < this.count; i++) {
+      const value = this.strings[i]
+      const expectedBytes = this.utf8Lengths[i]
+
+      const target = region.subarray(cursor, cursor + expectedBytes)
+      const encoded = this.encoder.encodeInto(value, target)
+
+      if (this.assertions) {
+        if (encoded.read !== value.length || encoded.written !== expectedBytes) {
+          throw new Error(
+            `encodeInto wrote unexpected size for string ${i}: read=${encoded.read}, written=${encoded.written}, expected=${expectedBytes}`,
+          )
+        }
+      } else if (encoded.written !== expectedBytes) {
+        const fallback = this.encoder.encode(value)
+        if (fallback.byteLength !== expectedBytes) {
+          throw new Error(
+            `UTF-8 length mismatch for string ${i}: fallback=${fallback.byteLength}, expected=${expectedBytes}`,
+          )
+        }
+        region.set(fallback, cursor)
+      }
+
+      region[cursor + expectedBytes] = 0
+
+      const ptr = (basePtr as number) + cursor
+      if (ptr < 0 || ptr > 0xffffffff) {
+        throw new Error(`Ptr out of uint32 range at string ${i}: ${ptr}`)
+      }
+      this.resultPtrs[i] = ptr
+      this.resultByteLengths[i] = expectedBytes
+
+      cursor += expectedBytes + 1
+    }
+
+    return {
+      ptrs: this.resultPtrs.subarray(0, this.count),
+      byteLengths: this.resultByteLengths.subarray(0, this.count),
+    }
+  }
+
+  private ensureRegionCapacity(requiredBytes: number): void {
+    if (requiredBytes <= this.regionCapacityBytes && this.allocator) {
+      return
+    }
+
+    let nextCapacity =
+      this.regionCapacityBytes === 0 ? this.initialCapacityBytes : this.regionCapacityBytes
+    while (nextCapacity < requiredBytes) {
+      nextCapacity <<= 1
+    }
+
+    const nextPtr =
+      this.regionPtr === undefined
+        ? this.memory.malloc(nextCapacity)
+        : this.memory.realloc(this.regionPtr, nextCapacity)
+
+    if (!Number.isInteger(nextPtr) || nextPtr < 0) {
+      throw new Error(`Memory allocator returned invalid ptr: ${nextPtr}`)
+    }
+
+    if (this.assertions) {
+      const { bytes } = getDirectMemoryViews(this.memory)
+      assertStorageWindow(bytes, nextPtr as number, nextCapacity, false)
+    }
+
+    this.regionPtr = nextPtr
+    this.regionCapacityBytes = nextCapacity
+
+    if (this.allocator) {
+      this.allocator.setRegion(nextPtr, nextCapacity)
+    } else {
+      this.allocator = new ByteRegionAllocator(nextPtr, nextCapacity, {
+        disableAssertions: this.disableAssertions,
+      })
+    }
+  }
+
+  private ensureStringCapacity(required: number): void {
+    if (required <= this.strings.length) {
+      return
+    }
+
+    let next = this.strings.length
+    while (next < required) {
+      next <<= 1
+    }
+
+    const nextStrings = new Array<string>(next)
+    const nextLengths = new Array<number>(next)
+
+    for (let i = 0; i < this.count; i++) {
+      nextStrings[i] = this.strings[i]
+      nextLengths[i] = this.utf8Lengths[i]
+    }
+
+    this.strings = nextStrings
+    this.utf8Lengths = nextLengths
+  }
+
+  private ensureResultCapacity(required: number): void {
+    if (required <= this.resultPtrs.length) {
+      return
+    }
+
+    let next = this.resultPtrs.length
+    while (next < required) {
+      next <<= 1
+    }
+
+    const nextPtrs = new Uint32Array(next)
+    const nextByteLengths = new Uint32Array(next)
+    nextPtrs.set(this.resultPtrs, 0)
+    nextByteLengths.set(this.resultByteLengths, 0)
+
+    this.resultPtrs = nextPtrs
+    this.resultByteLengths = nextByteLengths
+  }
+}

--- a/packages/quickjs-emscripten-core/src/internal/memory-region.ts
+++ b/packages/quickjs-emscripten-core/src/internal/memory-region.ts
@@ -1,0 +1,235 @@
+export type ArenaRawMemory = ArrayBuffer | Uint8Array
+
+export type Memory<Ptr extends number = number> = {
+  uint32: () => Uint32Array
+  uint8: () => Uint8Array
+  malloc: (size: number) => Ptr
+  realloc: (ptr: Ptr, size: number) => Ptr
+}
+
+export type MemoryViewState = {
+  token: unknown
+  bytes: Uint8Array
+  words?: Uint32Array
+  byteLength: number
+}
+
+export class ArrayBufferMemory implements Memory<number> {
+  private bytes: Uint8Array
+
+  constructor(
+    memory: ArrayBuffer | Uint8Array | number,
+    private readonly basePtr = 0,
+  ) {
+    if (!Number.isInteger(basePtr) || basePtr < 0) {
+      throw new Error(`Invalid basePtr: ${basePtr}`)
+    }
+    if (typeof memory === "number") {
+      if (!Number.isInteger(memory) || memory <= 0) {
+        throw new Error(`Invalid memory size: ${memory}`)
+      }
+      this.bytes = new Uint8Array(memory)
+      return
+    }
+    this.bytes = memory instanceof Uint8Array ? memory : new Uint8Array(memory)
+  }
+
+  uint8(): Uint8Array {
+    return this.bytes
+  }
+
+  uint32(): Uint32Array {
+    return new Uint32Array(this.bytes.buffer, this.bytes.byteOffset, this.bytes.byteLength >>> 2)
+  }
+
+  malloc(size: number): number {
+    this.ensureWindow(this.basePtr, size)
+    return this.basePtr
+  }
+
+  realloc(ptr: number, size: number): number {
+    if (ptr !== this.basePtr) {
+      throw new Error(`realloc ptr mismatch: got ${ptr}, expected ${this.basePtr}`)
+    }
+    this.ensureWindow(ptr, size)
+    return this.basePtr
+  }
+
+  private ensureWindow(ptr: number, size: number): void {
+    if (!Number.isInteger(size) || size < 0) {
+      throw new Error(`Invalid size: ${size}`)
+    }
+    const needed = ptr + size
+    if (needed <= this.bytes.byteLength) {
+      return
+    }
+
+    const next = new Uint8Array(needed)
+    next.set(this.bytes.subarray(0, Math.min(this.bytes.byteLength, next.byteLength)), 0)
+    this.bytes = next
+  }
+}
+
+export function isMemoryObject<Ptr extends number = number>(value: unknown): value is Memory<Ptr> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "uint32" in value &&
+    "uint8" in value &&
+    "malloc" in value &&
+    "realloc" in value
+  )
+}
+
+export function memoryLength(raw: ArenaRawMemory): number {
+  return raw.byteLength
+}
+
+export function createMemoryViewState(raw: ArenaRawMemory): MemoryViewState {
+  const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw)
+
+  let words: Uint32Array | undefined
+  if ((bytes.byteOffset & 3) === 0 && (bytes.byteLength & 3) === 0) {
+    words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength >>> 2)
+  }
+
+  return {
+    token: raw,
+    bytes,
+    words,
+    byteLength: bytes.byteLength,
+  }
+}
+
+export function createMemoryViewStateFromViews(
+  token: unknown,
+  bytes: Uint8Array,
+  wordsMaybe: Uint32Array,
+): MemoryViewState {
+  let words: Uint32Array | undefined
+
+  if (
+    wordsMaybe.buffer === bytes.buffer &&
+    wordsMaybe.byteOffset === bytes.byteOffset &&
+    wordsMaybe.byteLength === bytes.byteLength
+  ) {
+    words = wordsMaybe
+  } else if ((bytes.byteOffset & 3) === 0 && (bytes.byteLength & 3) === 0) {
+    words = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength >>> 2)
+  }
+
+  return {
+    token,
+    bytes,
+    words,
+    byteLength: bytes.byteLength,
+  }
+}
+
+export function copyBytes(
+  src: MemoryViewState,
+  srcByteOffset: number,
+  dst: MemoryViewState,
+  dstByteOffset: number,
+  byteLength: number,
+): void {
+  const canUseWords =
+    src.words !== undefined &&
+    dst.words !== undefined &&
+    (srcByteOffset & 3) === 0 &&
+    (dstByteOffset & 3) === 0 &&
+    (byteLength & 3) === 0
+
+  if (canUseWords) {
+    const srcWords = src.words as Uint32Array
+    const dstWords = dst.words as Uint32Array
+    const srcWord = srcByteOffset >>> 2
+    const dstWord = dstByteOffset >>> 2
+    const words = byteLength >>> 2
+
+    for (let i = 0; i < words; i++) {
+      dstWords[dstWord + i] = srcWords[srcWord + i]
+    }
+    return
+  }
+
+  const srcBytes = src.bytes
+  const dstBytes = dst.bytes
+  for (let i = 0; i < byteLength; i++) {
+    dstBytes[dstByteOffset + i] = srcBytes[srcByteOffset + i]
+  }
+}
+
+export function assertByteRange(total: number, offset: number, len: number, label: string): number {
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`Invalid ${label} byte offset: ${offset}`)
+  }
+
+  const end = offset + len
+  if (end > total) {
+    throw new Error(`${label} range out of bounds: offset=${offset}, len=${len}, total=${total}`)
+  }
+
+  return offset
+}
+
+export function assertStorageWindow(
+  raw: ArenaRawMemory,
+  basePtr: number,
+  requiredByteLength: number,
+  strictExact = false,
+): void {
+  const total = memoryLength(raw)
+
+  if (!Number.isInteger(basePtr) || basePtr < 0) {
+    throw new Error(`Invalid ptr: ${basePtr}`)
+  }
+  if (!Number.isInteger(requiredByteLength) || requiredByteLength < 0) {
+    throw new Error(`Invalid byte length: ${requiredByteLength}`)
+  }
+
+  if (strictExact) {
+    if (total !== requiredByteLength) {
+      throw new Error(
+        `When ptr is omitted, memory length must equal ${requiredByteLength}, got ${total}`,
+      )
+    }
+    return
+  }
+
+  if (basePtr + requiredByteLength > total) {
+    throw new Error(
+      `Memory window out of bounds: ptr=${basePtr}, bytes=${requiredByteLength}, total=${total}`,
+    )
+  }
+}
+
+export function getDirectMemoryViews<Ptr extends number>(
+  memory: Memory<Ptr>,
+): { bytes: Uint8Array; words: Uint32Array } {
+  const bytes = memory.uint8()
+  const words = memory.uint32()
+
+  if (!(bytes instanceof Uint8Array)) {
+    throw new Error("Memory.uint8() must return Uint8Array")
+  }
+  if (!(words instanceof Uint32Array)) {
+    throw new Error("Memory.uint32() must return Uint32Array")
+  }
+  if (words.buffer !== bytes.buffer) {
+    throw new Error("Memory.uint8() and Memory.uint32() must share the same ArrayBuffer")
+  }
+
+  return { bytes, words }
+}
+
+export function getWritableRegion<Ptr extends number>(
+  memory: Memory<Ptr>,
+  ptr: Ptr,
+  byteLength: number,
+): Uint8Array {
+  const { bytes } = getDirectMemoryViews(memory)
+  assertStorageWindow(bytes, ptr as number, byteLength, false)
+  return bytes.subarray(ptr as number, (ptr as number) + byteLength)
+}
+


### PR DESCRIPTION
## Summary
- add internal memory/string allocation modules under `src/internal`
- rename `Arena` to `SlotArena` and keep it private
- rename `Utf8StringAllocator` to `StringAllocator`
- split shared memory helpers into `internal/memory-region.ts`
- make readonly updates typed via `Writable<typeof this>`
- remove public export of slot arena from `index.ts`

## Validation
- `pnpm -C packages/quickjs-emscripten-core test`
- `pnpm -C packages/quickjs-emscripten-core tsc`
- eslint on changed internal/core files
